### PR TITLE
(feat) HTTP client foundation

### DIFF
--- a/packages/core/src/http/errors.test.ts
+++ b/packages/core/src/http/errors.test.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, expect, it } from "vitest";
+import { LinkedInApiError, LinkedInAuthError, LinkedInRateLimitError, LinkedInServerError } from "./errors.js";
+
+describe("LinkedInApiError", () => {
+  it("stores status and message", () => {
+    const error = new LinkedInApiError("bad request", 400);
+    expect(error.message).toBe("bad request");
+    expect(error.status).toBe(400);
+    expect(error.name).toBe("LinkedInApiError");
+    expect(error.responseBody).toBeUndefined();
+  });
+
+  it("stores response body when provided", () => {
+    const body = { error: "invalid_request" };
+    const error = new LinkedInApiError("bad request", 400, body);
+    expect(error.responseBody).toEqual(body);
+  });
+
+  it("is an instance of Error", () => {
+    const error = new LinkedInApiError("test", 400);
+    expect(error).toBeInstanceOf(Error);
+  });
+});
+
+describe("LinkedInAuthError", () => {
+  it("has status 401 and correct name", () => {
+    const error = new LinkedInAuthError("unauthorized");
+    expect(error.status).toBe(401);
+    expect(error.name).toBe("LinkedInAuthError");
+    expect(error.message).toBe("unauthorized");
+  });
+
+  it("is an instance of LinkedInApiError", () => {
+    const error = new LinkedInAuthError("unauthorized");
+    expect(error).toBeInstanceOf(LinkedInApiError);
+  });
+
+  it("stores response body", () => {
+    const body = { message: "Token expired" };
+    const error = new LinkedInAuthError("unauthorized", body);
+    expect(error.responseBody).toEqual(body);
+  });
+});
+
+describe("LinkedInRateLimitError", () => {
+  it("has status 429, correct name, and retries count", () => {
+    const error = new LinkedInRateLimitError("rate limited", 3);
+    expect(error.status).toBe(429);
+    expect(error.name).toBe("LinkedInRateLimitError");
+    expect(error.retriesExhausted).toBe(3);
+  });
+
+  it("is an instance of LinkedInApiError", () => {
+    const error = new LinkedInRateLimitError("rate limited", 3);
+    expect(error).toBeInstanceOf(LinkedInApiError);
+  });
+
+  it("stores response body", () => {
+    const body = { message: "Too many requests" };
+    const error = new LinkedInRateLimitError("rate limited", 3, body);
+    expect(error.responseBody).toEqual(body);
+  });
+});
+
+describe("LinkedInServerError", () => {
+  it("has the given 5xx status and correct name", () => {
+    const error = new LinkedInServerError("server error", 502);
+    expect(error.status).toBe(502);
+    expect(error.name).toBe("LinkedInServerError");
+    expect(error.message).toBe("server error");
+  });
+
+  it("is an instance of LinkedInApiError", () => {
+    const error = new LinkedInServerError("server error", 500);
+    expect(error).toBeInstanceOf(LinkedInApiError);
+  });
+
+  it("stores response body", () => {
+    const body = { error: "internal" };
+    const error = new LinkedInServerError("server error", 500, body);
+    expect(error.responseBody).toEqual(body);
+  });
+});

--- a/packages/core/src/http/errors.ts
+++ b/packages/core/src/http/errors.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * Base error for all LinkedIn API HTTP errors.
+ */
+export class LinkedInApiError extends Error {
+  public readonly status: number;
+  public readonly responseBody: unknown;
+
+  constructor(message: string, status: number, responseBody?: unknown) {
+    super(message);
+    this.name = "LinkedInApiError";
+    this.status = status;
+    this.responseBody = responseBody;
+  }
+}
+
+/**
+ * Thrown on HTTP 401 — the access token is invalid or expired.
+ */
+export class LinkedInAuthError extends LinkedInApiError {
+  constructor(message: string, responseBody?: unknown) {
+    super(message, 401, responseBody);
+    this.name = "LinkedInAuthError";
+  }
+}
+
+/**
+ * Thrown on HTTP 429 when all retry attempts have been exhausted.
+ */
+export class LinkedInRateLimitError extends LinkedInApiError {
+  public readonly retriesExhausted: number;
+
+  constructor(message: string, retriesExhausted: number, responseBody?: unknown) {
+    super(message, 429, responseBody);
+    this.name = "LinkedInRateLimitError";
+    this.retriesExhausted = retriesExhausted;
+  }
+}
+
+/**
+ * Thrown on HTTP 5xx — server-side failure.
+ */
+export class LinkedInServerError extends LinkedInApiError {
+  constructor(message: string, status: number, responseBody?: unknown) {
+    super(message, status, responseBody);
+    this.name = "LinkedInServerError";
+  }
+}

--- a/packages/core/src/http/linkedin-client.test.ts
+++ b/packages/core/src/http/linkedin-client.test.ts
@@ -1,0 +1,357 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LinkedInClient } from "./linkedin-client.js";
+import { LinkedInApiError, LinkedInAuthError, LinkedInRateLimitError, LinkedInServerError } from "./errors.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function textResponse(body: string, status: number): Response {
+  return new Response(body, {
+    status,
+    headers: { "Content-Type": "text/plain" },
+  });
+}
+
+function emptyResponse(status: number): Response {
+  return new Response(null, { status });
+}
+
+const CLIENT_OPTIONS = {
+  accessToken: "test-token",
+  apiVersion: "202501",
+  userAgent: "test-agent",
+} as const;
+
+/** Stub the private `sleep` method on a client so retries don't wait. */
+function stubSleep(client: LinkedInClient) {
+  return vi.spyOn(client as never, "sleep" as never).mockImplementation((() => Promise.resolve()) as never);
+}
+
+describe("LinkedInClient", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("headers", () => {
+    it("sends Authorization, LinkedIn-Version, X-Restli-Protocol-Version, and User-Agent", async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+      const client = new LinkedInClient(CLIENT_OPTIONS);
+      await client.request("/test");
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [, init] = fetchSpy.mock.calls[0];
+      const headers = init.headers;
+
+      expect(headers.get("Authorization")).toBe("Bearer test-token");
+      expect(headers.get("LinkedIn-Version")).toBe("202501");
+      expect(headers.get("X-Restli-Protocol-Version")).toBe("2.0.0");
+      expect(headers.get("User-Agent")).toBe("test-agent");
+    });
+
+    it("uses default user agent when not specified", async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({}));
+
+      const client = new LinkedInClient({
+        accessToken: "token",
+        apiVersion: "202501",
+      });
+      await client.request("/test");
+
+      const [, init] = fetchSpy.mock.calls[0];
+      expect(init.headers.get("User-Agent")).toBe("linkedctl");
+    });
+
+    it("constructs URL from base URL and path", async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({}));
+
+      const client = new LinkedInClient(CLIENT_OPTIONS);
+      await client.request("/v2/me");
+
+      const [url] = fetchSpy.mock.calls[0];
+      expect(url).toBe("https://api.linkedin.com/v2/me");
+    });
+
+    it("uses custom base URL when provided", async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({}));
+
+      const client = new LinkedInClient({
+        ...CLIENT_OPTIONS,
+        baseUrl: "https://custom.api.example.com",
+      });
+      await client.request("/v2/me");
+
+      const [url] = fetchSpy.mock.calls[0];
+      expect(url).toBe("https://custom.api.example.com/v2/me");
+    });
+
+    it("preserves caller-supplied headers alongside required ones", async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({}));
+
+      const client = new LinkedInClient(CLIENT_OPTIONS);
+      await client.request("/test", {
+        headers: { "X-Custom": "value" },
+      });
+
+      const [, init] = fetchSpy.mock.calls[0];
+      const headers = init.headers;
+      expect(headers.get("X-Custom")).toBe("value");
+      expect(headers.get("Authorization")).toBe("Bearer test-token");
+    });
+
+    it("forwards request init options (method, body)", async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({}));
+
+      const client = new LinkedInClient(CLIENT_OPTIONS);
+      const body = JSON.stringify({ text: "hello" });
+      await client.request("/v2/posts", { method: "POST", body });
+
+      const [, init] = fetchSpy.mock.calls[0];
+      expect(init.method).toBe("POST");
+      expect(init.body).toBe(body);
+    });
+  });
+
+  describe("successful responses", () => {
+    it("returns parsed JSON body", async () => {
+      const data = { id: "123", name: "Test" };
+      fetchSpy.mockResolvedValueOnce(jsonResponse(data));
+
+      const client = new LinkedInClient(CLIENT_OPTIONS);
+      const result = await client.request("/v2/me");
+
+      expect(result).toEqual(data);
+    });
+
+    it("returns undefined for 204 No Content", async () => {
+      fetchSpy.mockResolvedValueOnce(emptyResponse(204));
+
+      const client = new LinkedInClient(CLIENT_OPTIONS);
+      const result = await client.request("/v2/resource");
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("401 authentication error", () => {
+    it("throws LinkedInAuthError with re-authenticate message", async () => {
+      fetchSpy.mockResolvedValue(jsonResponse({ message: "Invalid token" }, 401));
+
+      const client = new LinkedInClient(CLIENT_OPTIONS);
+
+      await expect(client.request("/v2/me")).rejects.toThrow(LinkedInAuthError);
+      await expect(client.request("/v2/me")).rejects.toThrow(/re-authenticate/);
+    });
+
+    it("includes response body in error", async () => {
+      const errorBody = { message: "Token expired" };
+      fetchSpy.mockResolvedValueOnce(jsonResponse(errorBody, 401));
+
+      const client = new LinkedInClient(CLIENT_OPTIONS);
+
+      try {
+        await client.request("/v2/me");
+        expect.fail("should have thrown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(LinkedInAuthError);
+        expect((error as LinkedInAuthError).responseBody).toEqual(errorBody);
+      }
+    });
+
+    it("does not retry on 401", async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({}, 401));
+
+      const client = new LinkedInClient(CLIENT_OPTIONS);
+
+      await expect(client.request("/v2/me")).rejects.toThrow(LinkedInAuthError);
+      expect(fetchSpy).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("5xx server errors", () => {
+    it("throws LinkedInServerError with status", async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({ error: "internal" }, 500));
+
+      const client = new LinkedInClient(CLIENT_OPTIONS);
+
+      await expect(client.request("/v2/me")).rejects.toThrow(LinkedInServerError);
+    });
+
+    it("includes HTTP status code in message", async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({}, 503));
+
+      const client = new LinkedInClient(CLIENT_OPTIONS);
+
+      await expect(client.request("/v2/me")).rejects.toThrow(/503/);
+    });
+
+    it("handles various 5xx status codes", async () => {
+      for (const status of [500, 502, 503]) {
+        fetchSpy.mockResolvedValueOnce(jsonResponse({}, status));
+
+        const client = new LinkedInClient(CLIENT_OPTIONS);
+
+        try {
+          await client.request("/test");
+          expect.fail("should have thrown");
+        } catch (error) {
+          expect(error).toBeInstanceOf(LinkedInServerError);
+          expect((error as LinkedInServerError).status).toBe(status);
+        }
+      }
+    });
+
+    it("does not retry on 5xx", async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({}, 500));
+
+      const client = new LinkedInClient(CLIENT_OPTIONS);
+
+      await expect(client.request("/v2/me")).rejects.toThrow(LinkedInServerError);
+      expect(fetchSpy).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("other error status codes", () => {
+    it("throws LinkedInApiError for 4xx (non-401, non-429)", async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({}, 403));
+
+      const client = new LinkedInClient(CLIENT_OPTIONS);
+
+      await expect(client.request("/v2/me")).rejects.toThrow(LinkedInApiError);
+    });
+
+    it("includes status code in message", async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({}, 404));
+
+      const client = new LinkedInClient(CLIENT_OPTIONS);
+
+      await expect(client.request("/v2/me")).rejects.toThrow(/404/);
+    });
+  });
+
+  describe("429 rate limiting with exponential backoff", () => {
+    it("retries up to maxRetries times then throws LinkedInRateLimitError", async () => {
+      fetchSpy.mockResolvedValue(jsonResponse({}, 429));
+
+      const client = new LinkedInClient({ ...CLIENT_OPTIONS, maxRetries: 3 });
+      stubSleep(client);
+
+      await expect(client.request("/v2/me")).rejects.toThrow(LinkedInRateLimitError);
+      // 1 initial + 3 retries = 4 total attempts
+      expect(fetchSpy).toHaveBeenCalledTimes(4);
+    });
+
+    it("returns successfully if a retry succeeds", async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({}, 429)).mockResolvedValueOnce(jsonResponse({ id: "success" }));
+
+      const client = new LinkedInClient(CLIENT_OPTIONS);
+      stubSleep(client);
+
+      const result = await client.request("/v2/me");
+
+      expect(result).toEqual({ id: "success" });
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("reports retries exhausted count in error", async () => {
+      fetchSpy.mockResolvedValue(jsonResponse({}, 429));
+
+      const client = new LinkedInClient({ ...CLIENT_OPTIONS, maxRetries: 2 });
+      stubSleep(client);
+
+      try {
+        await client.request("/v2/me");
+        expect.fail("should have thrown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(LinkedInRateLimitError);
+        // 3 total attempts: initial (1) + 2 retries → final attempt index+1 = 3
+        expect((error as LinkedInRateLimitError).retriesExhausted).toBe(3);
+      }
+    });
+
+    it("applies increasing delays between retries", async () => {
+      fetchSpy.mockResolvedValue(jsonResponse({}, 429));
+
+      const sleepCalls: number[] = [];
+      const client = new LinkedInClient({ ...CLIENT_OPTIONS, maxRetries: 3 });
+
+      vi.spyOn(client as never, "sleep" as never).mockImplementation(((ms: number) => {
+        sleepCalls.push(ms);
+        return Promise.resolve();
+      }) as never);
+
+      try {
+        await client.request("/v2/me");
+      } catch {
+        // Expected to throw after exhausting retries.
+      }
+
+      expect(sleepCalls).toHaveLength(3);
+      // Each successive delay should be larger (exponential growth).
+      for (let i = 1; i < sleepCalls.length; i++) {
+        const previous = sleepCalls[i - 1];
+        expect(previous).toBeDefined();
+        expect(sleepCalls[i]).toBeGreaterThan(previous as number);
+      }
+    });
+  });
+
+  describe("error response body handling", () => {
+    it("includes JSON error body in thrown error", async () => {
+      const errorBody = { code: "FORBIDDEN", message: "Access denied" };
+      fetchSpy.mockResolvedValueOnce(jsonResponse(errorBody, 403));
+
+      const client = new LinkedInClient(CLIENT_OPTIONS);
+
+      try {
+        await client.request("/v2/me");
+        expect.fail("should have thrown");
+      } catch (error) {
+        expect((error as LinkedInApiError).responseBody).toEqual(errorBody);
+      }
+    });
+
+    it("falls back to text body when JSON parsing fails", async () => {
+      fetchSpy.mockResolvedValueOnce(textResponse("Bad Gateway", 502));
+
+      const client = new LinkedInClient(CLIENT_OPTIONS);
+
+      try {
+        await client.request("/v2/me");
+        expect.fail("should have thrown");
+      } catch (error) {
+        expect((error as LinkedInServerError).responseBody).toBe("Bad Gateway");
+      }
+    });
+
+    it("sets responseBody to undefined when body is unreadable", async () => {
+      const response = emptyResponse(400);
+      // Simulate text() failing (body unreadable).
+      vi.spyOn(response, "text").mockRejectedValue(new Error("no body"));
+      fetchSpy.mockResolvedValueOnce(response);
+
+      const client = new LinkedInClient(CLIENT_OPTIONS);
+
+      try {
+        await client.request("/test");
+        expect.fail("should have thrown");
+      } catch (error) {
+        expect((error as LinkedInApiError).responseBody).toBeUndefined();
+      }
+    });
+  });
+});

--- a/packages/core/src/http/linkedin-client.ts
+++ b/packages/core/src/http/linkedin-client.ts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { LinkedInApiError, LinkedInAuthError, LinkedInRateLimitError, LinkedInServerError } from "./errors.js";
+
+const RESTLI_PROTOCOL_VERSION = "2.0.0";
+const DEFAULT_BASE_URL = "https://api.linkedin.com";
+const DEFAULT_MAX_RETRIES = 3;
+const BACKOFF_BASE_MS = 1000;
+const BACKOFF_MAX_MS = 30_000;
+
+export interface LinkedInClientOptions {
+  /** OAuth2 access token. */
+  accessToken: string;
+  /** LinkedIn API version identifier (e.g. "202501"). */
+  apiVersion: string;
+  /** Base URL for the LinkedIn API. */
+  baseUrl?: string | undefined;
+  /** Value sent in the User-Agent header. */
+  userAgent?: string | undefined;
+  /** Maximum number of retry attempts on HTTP 429. Defaults to 3. */
+  maxRetries?: number | undefined;
+}
+
+export class LinkedInClient {
+  private readonly accessToken: string;
+  private readonly apiVersion: string;
+  private readonly baseUrl: string;
+  private readonly userAgent: string;
+  private readonly maxRetries: number;
+
+  constructor(options: LinkedInClientOptions) {
+    this.accessToken = options.accessToken;
+    this.apiVersion = options.apiVersion;
+    this.baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
+    this.userAgent = options.userAgent ?? "linkedctl";
+    this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+  }
+
+  /**
+   * Send an HTTP request to the LinkedIn API.
+   *
+   * Automatically sets required LinkedIn headers, retries on 429 with
+   * exponential backoff, and throws typed errors for known failure modes.
+   */
+  async request<T>(path: string, init?: RequestInit): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const headers = this.buildHeaders(init?.headers);
+
+    let lastError: LinkedInRateLimitError | undefined;
+
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      if (attempt > 0) {
+        const delayMs = this.calculateBackoff(attempt);
+        await this.sleep(delayMs);
+      }
+
+      const response = await fetch(url, { ...init, headers });
+
+      if (response.ok) {
+        if (response.status === 204) {
+          return undefined as T;
+        }
+        return (await response.json()) as T;
+      }
+
+      const body = await this.tryReadBody(response);
+
+      if (response.status === 429) {
+        lastError = new LinkedInRateLimitError("LinkedIn API rate limit exceeded", attempt + 1, body);
+        if (attempt < this.maxRetries) {
+          continue;
+        }
+        throw lastError;
+      }
+
+      if (response.status === 401) {
+        throw new LinkedInAuthError("LinkedIn API authentication failed — please re-authenticate", body);
+      }
+
+      if (response.status >= 500) {
+        throw new LinkedInServerError(`LinkedIn API server error (HTTP ${response.status})`, response.status, body);
+      }
+
+      throw new LinkedInApiError(`LinkedIn API request failed (HTTP ${response.status})`, response.status, body);
+    }
+
+    // This is only reachable if maxRetries < 0, but satisfies the compiler.
+    throw lastError ?? new LinkedInApiError("Request failed", 0);
+  }
+
+  private buildHeaders(existing?: RequestInit["headers"]): Headers {
+    const headers = new Headers(existing);
+    headers.set("Authorization", `Bearer ${this.accessToken}`);
+    headers.set("LinkedIn-Version", this.apiVersion);
+    headers.set("X-Restli-Protocol-Version", RESTLI_PROTOCOL_VERSION);
+    headers.set("User-Agent", this.userAgent);
+    return headers;
+  }
+
+  /** Exponential backoff: base * 2^(attempt-1) capped at BACKOFF_MAX_MS, with jitter. */
+  private calculateBackoff(attempt: number): number {
+    const exponential = BACKOFF_BASE_MS * Math.pow(2, attempt - 1);
+    const capped = Math.min(exponential, BACKOFF_MAX_MS);
+    const jitter = Math.random() * capped * 0.1;
+    return capped + jitter;
+  }
+
+  private async tryReadBody(response: Response): Promise<unknown> {
+    try {
+      const text = await response.text();
+      try {
+        return JSON.parse(text) as unknown;
+      } catch {
+        return text;
+      }
+    } catch {
+      return undefined;
+    }
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-export {};
+export { LinkedInApiError, LinkedInAuthError, LinkedInRateLimitError, LinkedInServerError } from "./http/errors.js";
+export { LinkedInClient } from "./http/linkedin-client.js";
+export type { LinkedInClientOptions } from "./http/linkedin-client.js";


### PR DESCRIPTION
## Summary

- Implement `LinkedInClient` in `@linkedctl/core` with required LinkedIn API headers (`Authorization`, `LinkedIn-Version`, `X-Restli-Protocol-Version`, `User-Agent`)
- Add exponential backoff retry on HTTP 429 (up to 3 retries, capped at 30s with jitter)
- Add typed error classes: `LinkedInAuthError` (401 with re-authenticate message), `LinkedInRateLimitError` (429), `LinkedInServerError` (5xx), `LinkedInApiError` (base)
- Zero new production dependencies — uses Node.js 24 native `fetch`

Closes #1

## Test plan

- [x] 36 unit tests covering all acceptance criteria
- [x] Header tests verify all 4 required headers are sent correctly
- [x] Retry tests verify exponential backoff, retry count, and successful recovery
- [x] Error tests verify 401 re-authenticate message, 5xx status codes, response body parsing
- [x] Build, lint, and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)