### PR TITLE
(feat) add auth status and logout commands

### DIFF
--- a/packages/cli/src/commands/auth/index.ts
+++ b/packages/cli/src/commands/auth/index.ts
@@ -3,12 +3,16 @@
 
 import { Command } from "commander";
 import { tokenCommand } from "./token.js";
+import { statusCommand } from "./status.js";
+import { logoutCommand } from "./logout.js";
 
 export function authCommand(): Command {
   const cmd = new Command("auth");
   cmd.description("Manage authentication");
 
   cmd.addCommand(tokenCommand());
+  cmd.addCommand(statusCommand());
+  cmd.addCommand(logoutCommand());
 
   return cmd;
 }

--- a/packages/cli/src/commands/auth/logout.test.ts
+++ b/packages/cli/src/commands/auth/logout.test.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { rm } from "node:fs/promises";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { readConfigFile, writeConfigFile } from "@linkedctl/core";
+import * as configFile from "@linkedctl/core";
+import { logoutCommand } from "./logout.js";
+
+vi.mock("@linkedctl/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof configFile>();
+  return { ...actual };
+});
+
+function tempConfigPath(): string {
+  return join(tmpdir(), `linkedctl-test-${randomUUID()}`, "config.yaml");
+}
+
+describe("auth logout", () => {
+  let configPath: string;
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    configPath = tempConfigPath();
+    vi.spyOn(configFile, "getDefaultConfigPath").mockReturnValue(configPath);
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(join(configPath, ".."), { recursive: true, force: true });
+  });
+
+  it("clears access token from the default profile", async () => {
+    await writeConfigFile(configPath, {
+      "default-profile": "personal",
+      profiles: { personal: { "access-token": "secret-token", "api-version": "202501" } },
+    });
+
+    const cmd = logoutCommand();
+    await cmd.parseAsync([], { from: "user" });
+
+    const config = await readConfigFile(configPath);
+    expect(config.profiles?.["personal"]?.["access-token"]).toBe("");
+    expect(config.profiles?.["personal"]?.["api-version"]).toBe("202501");
+    expect(consoleSpy).toHaveBeenCalledWith('Credentials cleared for profile "personal".');
+  });
+
+  it("clears refresh token when present", async () => {
+    await writeConfigFile(configPath, {
+      "default-profile": "personal",
+      profiles: {
+        personal: { "access-token": "tok", "refresh-token": "refresh-tok", "api-version": "202501" },
+      },
+    });
+
+    const cmd = logoutCommand();
+    await cmd.parseAsync([], { from: "user" });
+
+    const config = await readConfigFile(configPath);
+    expect(config.profiles?.["personal"]?.["access-token"]).toBe("");
+    expect(config.profiles?.["personal"]?.["refresh-token"]).toBeUndefined();
+    expect(config.profiles?.["personal"]?.["api-version"]).toBe("202501");
+  });
+
+  it("throws when profile does not exist", async () => {
+    const cmd = logoutCommand();
+    await expect(cmd.parseAsync([], { from: "user" })).rejects.toThrow(/not found/);
+  });
+
+  it("preserves other profiles", async () => {
+    await writeConfigFile(configPath, {
+      "default-profile": "a",
+      profiles: {
+        a: { "access-token": "tok-a", "api-version": "202501" },
+        b: { "access-token": "tok-b", "api-version": "202501" },
+      },
+    });
+
+    const cmd = logoutCommand();
+    await cmd.parseAsync([], { from: "user" });
+
+    const config = await readConfigFile(configPath);
+    expect(config.profiles?.["a"]?.["access-token"]).toBe("");
+    expect(config.profiles?.["b"]?.["access-token"]).toBe("tok-b");
+  });
+});

--- a/packages/cli/src/commands/auth/logout.ts
+++ b/packages/cli/src/commands/auth/logout.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { Command } from "commander";
+import {
+  getDefaultConfigPath,
+  readConfigFile,
+  writeConfigFile,
+  getProfile,
+  clearProfileCredentials,
+} from "@linkedctl/core";
+
+export function logoutCommand(): Command {
+  const cmd = new Command("logout");
+  cmd.description("Clear stored credentials from the active profile");
+
+  cmd.action(async (_opts: Record<string, unknown>, actionCmd: Command) => {
+    const rootOpts = actionCmd.optsWithGlobals();
+    const configPath = getDefaultConfigPath();
+    const config = await readConfigFile(configPath);
+
+    const profileFlag = typeof rootOpts["profile"] === "string" ? rootOpts["profile"] : undefined;
+    const profileName = profileFlag ?? config["default-profile"] ?? "default";
+    const profile = getProfile(config, profileName);
+
+    if (profile === undefined) {
+      throw new Error(`Profile "${profileName}" not found.`);
+    }
+
+    const updated = clearProfileCredentials(config, profileName);
+    await writeConfigFile(configPath, updated);
+    console.log(`Credentials cleared for profile "${profileName}".`);
+  });
+
+  return cmd;
+}

--- a/packages/cli/src/commands/auth/status.test.ts
+++ b/packages/cli/src/commands/auth/status.test.ts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { rm } from "node:fs/promises";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { writeConfigFile } from "@linkedctl/core";
+import * as configFile from "@linkedctl/core";
+import { statusCommand } from "./status.js";
+
+vi.mock("@linkedctl/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof configFile>();
+  return { ...actual };
+});
+
+function tempConfigPath(): string {
+  return join(tmpdir(), `linkedctl-test-${randomUUID()}`, "config.yaml");
+}
+
+/**
+ * Build a minimal JWT with the given payload claims.
+ */
+function buildJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const signature = "fake-signature";
+  return `${header}.${body}.${signature}`;
+}
+
+describe("auth status", () => {
+  let configPath: string;
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    configPath = tempConfigPath();
+    vi.spyOn(configFile, "getDefaultConfigPath").mockReturnValue(configPath);
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(join(configPath, ".."), { recursive: true, force: true });
+  });
+
+  it("shows not configured when profile does not exist", async () => {
+    const cmd = statusCommand();
+    await cmd.parseAsync([], { from: "user" });
+
+    expect(consoleSpy).toHaveBeenCalledWith("Profile: default");
+    expect(consoleSpy).toHaveBeenCalledWith("Status: not configured");
+    expect(consoleSpy).toHaveBeenCalledWith('Run "linkedctl profile create" to set up authentication.');
+  });
+
+  it("shows not configured when access token is empty", async () => {
+    await writeConfigFile(configPath, {
+      "default-profile": "personal",
+      profiles: { personal: { "access-token": "", "api-version": "202501" } },
+    });
+
+    const cmd = statusCommand();
+    await cmd.parseAsync([], { from: "user" });
+
+    expect(consoleSpy).toHaveBeenCalledWith("Profile: personal");
+    expect(consoleSpy).toHaveBeenCalledWith("Status: not configured");
+  });
+
+  it("shows authenticated with expiry for valid JWT token", async () => {
+    const futureExp = Math.floor(Date.now() / 1000) + 86400 * 3; // 3 days
+    const token = buildJwt({ exp: futureExp, sub: "user" });
+
+    await writeConfigFile(configPath, {
+      "default-profile": "work",
+      profiles: { work: { "access-token": token, "api-version": "202501" } },
+    });
+
+    const cmd = statusCommand();
+    await cmd.parseAsync([], { from: "user" });
+
+    expect(consoleSpy).toHaveBeenCalledWith("Profile: work");
+    expect(consoleSpy).toHaveBeenCalledWith("Status: authenticated");
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("remaining)"));
+  });
+
+  it("shows expired status with guidance for expired JWT", async () => {
+    const pastExp = Math.floor(Date.now() / 1000) - 3600;
+    const token = buildJwt({ exp: pastExp });
+
+    await writeConfigFile(configPath, {
+      "default-profile": "expired",
+      profiles: { expired: { "access-token": token, "api-version": "202501" } },
+    });
+
+    const cmd = statusCommand();
+    await cmd.parseAsync([], { from: "user" });
+
+    expect(consoleSpy).toHaveBeenCalledWith("Profile: expired");
+    expect(consoleSpy).toHaveBeenCalledWith("Status: expired");
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Run "linkedctl profile create" with a new --access-token to re-authenticate.',
+    );
+  });
+
+  it("shows authenticated with unknown expiry for opaque token", async () => {
+    await writeConfigFile(configPath, {
+      "default-profile": "opaque",
+      profiles: { opaque: { "access-token": "AQVh7cKZopaque", "api-version": "202501" } },
+    });
+
+    const cmd = statusCommand();
+    await cmd.parseAsync([], { from: "user" });
+
+    expect(consoleSpy).toHaveBeenCalledWith("Profile: opaque");
+    expect(consoleSpy).toHaveBeenCalledWith("Status: authenticated");
+    expect(consoleSpy).toHaveBeenCalledWith("Expiry: unknown (token is not a JWT)");
+  });
+});

--- a/packages/cli/src/commands/auth/status.ts
+++ b/packages/cli/src/commands/auth/status.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { Command } from "commander";
+import { getDefaultConfigPath, readConfigFile, getProfile, getTokenExpiry } from "@linkedctl/core";
+
+/**
+ * Format remaining time until token expiry as a human-readable string.
+ */
+function formatTimeRemaining(expiresAt: Date): string {
+  const diffMs = expiresAt.getTime() - Date.now();
+  const totalMinutes = Math.floor(diffMs / 60_000);
+  const totalHours = Math.floor(totalMinutes / 60);
+  const days = Math.floor(totalHours / 24);
+  const hours = totalHours % 24;
+
+  if (days > 0) {
+    return hours > 0 ? `${String(days)}d ${String(hours)}h` : `${String(days)}d`;
+  }
+  if (totalHours > 0) {
+    const minutes = totalMinutes % 60;
+    return minutes > 0 ? `${String(totalHours)}h ${String(minutes)}m` : `${String(totalHours)}h`;
+  }
+  return `${String(totalMinutes)}m`;
+}
+
+export function statusCommand(): Command {
+  const cmd = new Command("status");
+  cmd.description("Show authentication status for the active profile");
+
+  cmd.action(async (_opts: Record<string, unknown>, actionCmd: Command) => {
+    const rootOpts = actionCmd.optsWithGlobals();
+    const configPath = getDefaultConfigPath();
+    const config = await readConfigFile(configPath);
+
+    const profileFlag = typeof rootOpts["profile"] === "string" ? rootOpts["profile"] : undefined;
+    const profileName = profileFlag ?? config["default-profile"] ?? "default";
+    const profile = getProfile(config, profileName);
+
+    if (profile === undefined || profile["access-token"] === "") {
+      console.log(`Profile: ${profileName}`);
+      console.log("Status: not configured");
+      console.log('Run "linkedctl profile create" to set up authentication.');
+      return;
+    }
+
+    const expiry = getTokenExpiry(profile["access-token"]);
+
+    console.log(`Profile: ${profileName}`);
+
+    if (expiry === undefined) {
+      console.log("Status: authenticated");
+      console.log("Expiry: unknown (token is not a JWT)");
+      return;
+    }
+
+    if (expiry.isExpired) {
+      console.log("Status: expired");
+      console.log(`Expired: ${expiry.expiresAt.toISOString()}`);
+      console.log('Run "linkedctl profile create" with a new --access-token to re-authenticate.');
+      return;
+    }
+
+    const remaining = formatTimeRemaining(expiry.expiresAt);
+    console.log("Status: authenticated");
+    console.log(`Expires: ${expiry.expiresAt.toISOString()} (${remaining} remaining)`);
+  });
+
+  return cmd;
+}

--- a/packages/core/src/auth/token-introspection.test.ts
+++ b/packages/core/src/auth/token-introspection.test.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { getTokenExpiry } from "./token-introspection.js";
+
+/**
+ * Build a minimal JWT with the given payload claims.
+ */
+function buildJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const signature = "fake-signature";
+  return `${header}.${body}.${signature}`;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("getTokenExpiry", () => {
+  it("returns expiry for a valid JWT with exp claim", () => {
+    const futureExp = Math.floor(Date.now() / 1000) + 86400; // 1 day from now
+    const token = buildJwt({ exp: futureExp, sub: "user123" });
+
+    const result = getTokenExpiry(token);
+    expect(result).toBeDefined();
+    expect(result?.isExpired).toBe(false);
+    expect(result?.expiresAt.getTime()).toBe(futureExp * 1000);
+  });
+
+  it("marks expired tokens correctly", () => {
+    const pastExp = Math.floor(Date.now() / 1000) - 3600; // 1 hour ago
+    const token = buildJwt({ exp: pastExp });
+
+    const result = getTokenExpiry(token);
+    expect(result).toBeDefined();
+    expect(result?.isExpired).toBe(true);
+  });
+
+  it("returns undefined for opaque (non-JWT) tokens", () => {
+    expect(getTokenExpiry("AQVh7cKZ...opaque-token")).toBeUndefined();
+  });
+
+  it("returns undefined for tokens with wrong number of parts", () => {
+    expect(getTokenExpiry("only-one-part")).toBeUndefined();
+    expect(getTokenExpiry("two.parts")).toBeUndefined();
+    expect(getTokenExpiry("four.parts.here.extra")).toBeUndefined();
+  });
+
+  it("returns undefined when payload is not valid JSON", () => {
+    const header = Buffer.from("{}").toString("base64url");
+    const token = `${header}.not-valid-base64!.sig`;
+    expect(getTokenExpiry(token)).toBeUndefined();
+  });
+
+  it("returns undefined when payload has no exp claim", () => {
+    const token = buildJwt({ sub: "user123", iat: 1000 });
+    expect(getTokenExpiry(token)).toBeUndefined();
+  });
+
+  it("returns undefined when exp is not a number", () => {
+    const token = buildJwt({ exp: "not-a-number" });
+    expect(getTokenExpiry(token)).toBeUndefined();
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(getTokenExpiry("")).toBeUndefined();
+  });
+
+  it("returns undefined when payload is not an object", () => {
+    const header = Buffer.from("{}").toString("base64url");
+    const body = Buffer.from('"just a string"').toString("base64url");
+    const token = `${header}.${body}.sig`;
+    expect(getTokenExpiry(token)).toBeUndefined();
+  });
+
+  it("returns undefined when payload is null", () => {
+    const header = Buffer.from("{}").toString("base64url");
+    const body = Buffer.from("null").toString("base64url");
+    const token = `${header}.${body}.sig`;
+    expect(getTokenExpiry(token)).toBeUndefined();
+  });
+
+  it("handles token expiring at exact boundary", () => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    vi.spyOn(Date, "now").mockReturnValue(nowSeconds * 1000);
+
+    const token = buildJwt({ exp: nowSeconds });
+    const result = getTokenExpiry(token);
+    expect(result).toBeDefined();
+    expect(result?.isExpired).toBe(true);
+  });
+});

--- a/packages/core/src/auth/token-introspection.ts
+++ b/packages/core/src/auth/token-introspection.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * Result of introspecting a token's expiry information.
+ */
+export interface TokenExpiry {
+  expiresAt: Date;
+  isExpired: boolean;
+}
+
+/**
+ * Attempt to extract expiry information from a token by decoding it as a JWT.
+ *
+ * This performs a base64url decode of the payload section only — no signature
+ * verification is performed.  Returns `undefined` when the token is not a
+ * valid JWT or does not contain an `exp` claim.
+ */
+export function getTokenExpiry(token: string): TokenExpiry | undefined {
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    return undefined;
+  }
+
+  const payloadPart = parts[1];
+  if (payloadPart === undefined || payloadPart === "") {
+    return undefined;
+  }
+
+  let payload: unknown;
+  try {
+    const json = Buffer.from(payloadPart, "base64url").toString("utf-8");
+    payload = JSON.parse(json) as unknown;
+  } catch {
+    return undefined;
+  }
+
+  if (typeof payload !== "object" || payload === null) {
+    return undefined;
+  }
+
+  const exp = (payload as Record<string, unknown>)["exp"];
+  if (typeof exp !== "number") {
+    return undefined;
+  }
+
+  const expiresAt = new Date(exp * 1000);
+  const isExpired = expiresAt.getTime() <= Date.now();
+
+  return { expiresAt, isExpired };
+}

--- a/packages/core/src/config/config-file.test.ts
+++ b/packages/core/src/config/config-file.test.ts
@@ -15,6 +15,7 @@ import {
   deleteProfile,
   setDefaultProfile,
   redactProfile,
+  clearProfileCredentials,
   getDefaultConfigPath,
 } from "./config-file.js";
 import type { ConfigFile, Profile } from "./types.js";
@@ -245,5 +246,70 @@ describe("redactProfile", () => {
     const profile: Profile = { "access-token": "12345678", "api-version": "202501" };
     const result = redactProfile(profile);
     expect(result["access-token"]).toBe("****");
+  });
+
+  it("includes redacted refresh token when present", () => {
+    const profile: Profile = {
+      "access-token": "abcd1234efgh5678",
+      "refresh-token": "refr1234wxyz5678",
+      "api-version": "202501",
+    };
+    const result = redactProfile(profile);
+    expect(result["access-token"]).toBe("abcd****5678");
+    expect(result["refresh-token"]).toBe("refr****5678");
+  });
+
+  it("omits refresh token when not present", () => {
+    const profile: Profile = { "access-token": "abcd1234efgh5678", "api-version": "202501" };
+    const result = redactProfile(profile);
+    expect(result["refresh-token"]).toBeUndefined();
+  });
+});
+
+describe("clearProfileCredentials", () => {
+  it("clears access token and removes refresh token", () => {
+    const config: ConfigFile = {
+      profiles: {
+        test: { "access-token": "secret", "refresh-token": "refresh-secret", "api-version": "202501" },
+      },
+    };
+    const result = clearProfileCredentials(config, "test");
+    expect(result.profiles?.["test"]?.["access-token"]).toBe("");
+    expect(result.profiles?.["test"]?.["refresh-token"]).toBeUndefined();
+    expect(result.profiles?.["test"]?.["api-version"]).toBe("202501");
+  });
+
+  it("preserves api-version after clearing", () => {
+    const config: ConfigFile = {
+      profiles: { test: { "access-token": "tok", "api-version": "202502" } },
+    };
+    const result = clearProfileCredentials(config, "test");
+    expect(result.profiles?.["test"]?.["api-version"]).toBe("202502");
+  });
+
+  it("returns unchanged config when profile does not exist", () => {
+    const config: ConfigFile = { profiles: {} };
+    const result = clearProfileCredentials(config, "nonexistent");
+    expect(result).toEqual(config);
+  });
+
+  it("does not mutate the original config", () => {
+    const config: ConfigFile = {
+      profiles: { test: { "access-token": "secret", "api-version": "v" } },
+    };
+    clearProfileCredentials(config, "test");
+    expect(config.profiles?.["test"]?.["access-token"]).toBe("secret");
+  });
+
+  it("preserves other profiles", () => {
+    const config: ConfigFile = {
+      profiles: {
+        a: { "access-token": "tok-a", "api-version": "v" },
+        b: { "access-token": "tok-b", "api-version": "v" },
+      },
+    };
+    const result = clearProfileCredentials(config, "a");
+    expect(result.profiles?.["a"]?.["access-token"]).toBe("");
+    expect(result.profiles?.["b"]?.["access-token"]).toBe("tok-b");
   });
 });

--- a/packages/core/src/config/config-file.ts
+++ b/packages/core/src/config/config-file.ts
@@ -113,13 +113,47 @@ export function setDefaultProfile(config: ConfigFile, name: string): ConfigFile 
 }
 
 /**
+ * Redact a single secret value for display.
+ */
+function redactSecret(value: string): string {
+  return value.length > 8 ? value.slice(0, 4) + "****" + value.slice(-4) : "****";
+}
+
+/**
  * Redact secrets from a profile for display.
  */
 export function redactProfile(profile: Profile): Record<string, string> {
-  const token = profile["access-token"];
-  const redacted = token.length > 8 ? token.slice(0, 4) + "****" + token.slice(-4) : "****";
-  return {
-    "access-token": redacted,
+  const result: Record<string, string> = {
+    "access-token": redactSecret(profile["access-token"]),
     "api-version": profile["api-version"],
+  };
+  if (profile["refresh-token"] !== undefined) {
+    result["refresh-token"] = redactSecret(profile["refresh-token"]);
+  }
+  return result;
+}
+
+/**
+ * Remove credentials (access token and refresh token) from a profile,
+ * preserving non-secret settings like `api-version`.
+ * Returns a **new** `ConfigFile` — the original is not mutated.
+ */
+export function clearProfileCredentials(config: ConfigFile, name: string): ConfigFile {
+  const profile = config.profiles?.[name];
+  if (profile === undefined) {
+    return config;
+  }
+
+  const cleared: Profile = {
+    "access-token": "",
+    "api-version": profile["api-version"],
+  };
+
+  return {
+    ...config,
+    profiles: {
+      ...config.profiles,
+      [name]: cleared,
+    },
   };
 }

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -6,6 +6,7 @@
  */
 export interface Profile {
   "access-token": string;
+  "refresh-token"?: string | undefined;
   "api-version": string;
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,7 +11,10 @@ export {
   deleteProfile,
   setDefaultProfile,
   redactProfile,
+  clearProfileCredentials,
 } from "./config/config-file.js";
+export { getTokenExpiry } from "./auth/token-introspection.js";
+export type { TokenExpiry } from "./auth/token-introspection.js";
 export { resolveConfig } from "./config/config-resolver.js";
 export type { CliOverrides, EnvOverrides } from "./config/config-resolver.js";
 export type { ConfigFile, Profile, ResolvedConfig } from "./config/types.js";


### PR DESCRIPTION
## Summary

- Add `linkedctl auth status` command to display authentication state for the active profile:
  - JWT tokens: shows validity and human-readable time until expiry (e.g., "3d 2h remaining")
  - Expired JWT tokens: shows expiry date and guidance to re-authenticate
  - Opaque tokens: shows "authenticated" with "expiry unknown"
  - No token/empty token: shows "not configured" with setup guidance
- Add `linkedctl auth logout` command to clear stored credentials (access token and refresh token) from the active profile while preserving non-secret settings like `api-version`
- Add optional `refresh-token` field to `Profile` type for future OAuth2 support
- Add `getTokenExpiry()` utility for JWT payload decoding (base64url decode, no signature verification)
- Add `clearProfileCredentials()` to config-file operations
- Both commands respect the `--profile` flag for targeting specific profiles

Closes #5

## Test plan

- [x] 11 tests for `getTokenExpiry` (valid JWT, expired JWT, opaque tokens, edge cases)
- [x] 5 tests for `clearProfileCredentials` (credential clearing, immutability, profile isolation)
- [x] 2 tests for `redactProfile` refresh-token handling
- [x] 5 tests for `auth status` (not configured, empty token, valid JWT, expired JWT, opaque token)
- [x] 4 tests for `auth logout` (clear credentials, refresh token, missing profile, profile isolation)
- [x] All 143 tests pass, lint clean, build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)