### PR TITLE
(feat) add whoami command for user profile retrieval

### DIFF
--- a/packages/cli/src/commands/whoami.test.ts
+++ b/packages/cli/src/commands/whoami.test.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import * as core from "@linkedctl/core";
+import { whoamiCommand } from "./whoami.js";
+
+vi.mock("@linkedctl/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof core>();
+  return { ...actual };
+});
+
+const SAMPLE_USERINFO: core.UserInfo = {
+  sub: "abc123",
+  name: "Jane Doe",
+  given_name: "Jane",
+  family_name: "Doe",
+  picture: "https://media.licdn.com/dms/image/example.jpg",
+  email: "jane@example.com",
+  email_verified: true,
+};
+
+describe("whoami", () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let resolveConfigSpy: ReturnType<typeof vi.spyOn>;
+  let getUserInfoSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    resolveConfigSpy = vi.spyOn(core, "resolveConfig").mockResolvedValue({
+      accessToken: "test-token",
+      apiVersion: "202501",
+      profile: "default",
+    });
+    getUserInfoSpy = vi.spyOn(core, "getUserInfo").mockResolvedValue(SAMPLE_USERINFO);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("displays user info in table format for TTY", async () => {
+    const originalIsTTY = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, "isTTY", { value: true, writable: true });
+
+    try {
+      const cmd = whoamiCommand();
+      await cmd.parseAsync([], { from: "user" });
+
+      expect(resolveConfigSpy).toHaveBeenCalledWith({ profile: undefined });
+      expect(getUserInfoSpy).toHaveBeenCalledOnce();
+      expect(consoleSpy).toHaveBeenCalledOnce();
+
+      const output = consoleSpy.mock.calls[0]?.[0] as string;
+      expect(output).toContain("Jane Doe");
+      expect(output).toContain("jane@example.com");
+      expect(output).toContain("https://media.licdn.com/dms/image/example.jpg");
+    } finally {
+      Object.defineProperty(process.stdout, "isTTY", { value: originalIsTTY, writable: true });
+    }
+  });
+
+  it("outputs JSON when --format json is specified", async () => {
+    const cmd = whoamiCommand();
+    await cmd.parseAsync(["--format", "json"], { from: "user" });
+
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(output) as Record<string, unknown>;
+
+    expect(parsed).toEqual({
+      name: "Jane Doe",
+      email: "jane@example.com",
+      picture: "https://media.licdn.com/dms/image/example.jpg",
+    });
+  });
+
+  it("passes profile flag to resolveConfig", async () => {
+    const cmd = whoamiCommand();
+    cmd.parent = null;
+
+    // Simulate --profile by creating a parent command
+    const { Command } = await import("commander");
+    const parent = new Command("linkedctl");
+    parent.option("--profile <name>", "profile");
+    parent.addCommand(cmd);
+
+    await parent.parseAsync(["whoami", "--profile", "work"], { from: "user" });
+
+    expect(resolveConfigSpy).toHaveBeenCalledWith({ profile: "work" });
+  });
+
+  it("outputs only name, email, and picture in JSON format", async () => {
+    const cmd = whoamiCommand();
+    await cmd.parseAsync(["--format", "json"], { from: "user" });
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(output) as Record<string, unknown>;
+
+    expect(Object.keys(parsed)).toEqual(["name", "email", "picture"]);
+    expect(parsed).not.toHaveProperty("sub");
+    expect(parsed).not.toHaveProperty("given_name");
+    expect(parsed).not.toHaveProperty("email_verified");
+  });
+});

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { Command } from "commander";
+import { resolveConfig, LinkedInClient, getUserInfo } from "@linkedctl/core";
+import type { OutputFormat } from "../output/index.js";
+import { resolveFormat, formatOutput } from "../output/index.js";
+
+export function whoamiCommand(): Command {
+  const cmd = new Command("whoami");
+  cmd.description("Display the current authenticated user's profile");
+  cmd.option("--format <format>", "output format (json, table)");
+
+  cmd.action(async (opts: Record<string, unknown>, actionCmd: Command) => {
+    const rootOpts = actionCmd.optsWithGlobals();
+    const profileFlag = typeof rootOpts["profile"] === "string" ? rootOpts["profile"] : undefined;
+
+    const config = await resolveConfig({ profile: profileFlag });
+    const client = new LinkedInClient({
+      accessToken: config.accessToken,
+      apiVersion: config.apiVersion,
+    });
+
+    const userInfo = await getUserInfo(client);
+
+    const format = resolveFormat(opts["format"] as OutputFormat | undefined, process.stdout);
+
+    const data = {
+      name: userInfo.name,
+      email: userInfo.email,
+      picture: userInfo.picture,
+    };
+
+    console.log(formatOutput(data, format));
+  });
+
+  return cmd;
+}

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -4,6 +4,7 @@
 import { Command } from "commander";
 import { authCommand } from "./commands/auth/index.js";
 import { profileCommand } from "./commands/profile/index.js";
+import { whoamiCommand } from "./commands/whoami.js";
 
 /**
  * Build and return the top-level Commander program.
@@ -15,6 +16,7 @@ export function createProgram(): Command {
 
   program.addCommand(authCommand());
   program.addCommand(profileCommand());
+  program.addCommand(whoamiCommand());
 
   return program;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,3 +23,5 @@ export { LinkedInClient } from "./http/linkedin-client.js";
 export type { LinkedInClientOptions } from "./http/linkedin-client.js";
 export { buildAuthorizationUrl, exchangeAuthorizationCode, refreshAccessToken } from "./oauth2/oauth2-client.js";
 export type { OAuth2Config, OAuth2TokenResponse } from "./oauth2/types.js";
+export { getUserInfo } from "./userinfo/userinfo.js";
+export type { UserInfo } from "./userinfo/userinfo.js";

--- a/packages/core/src/userinfo/userinfo.test.ts
+++ b/packages/core/src/userinfo/userinfo.test.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LinkedInClient } from "../http/linkedin-client.js";
+import { getUserInfo } from "./userinfo.js";
+import type { UserInfo } from "./userinfo.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const SAMPLE_USERINFO: UserInfo = {
+  sub: "abc123",
+  name: "Jane Doe",
+  given_name: "Jane",
+  family_name: "Doe",
+  picture: "https://media.licdn.com/dms/image/example.jpg",
+  email: "jane@example.com",
+  email_verified: true,
+};
+
+describe("getUserInfo", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls the /v2/userinfo endpoint and returns the response", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse(SAMPLE_USERINFO));
+
+    const client = new LinkedInClient({ accessToken: "test-token", apiVersion: "202501" });
+    const result = await getUserInfo(client);
+
+    expect(result).toEqual(SAMPLE_USERINFO);
+    const [url] = fetchSpy.mock.calls[0] as [string];
+    expect(url).toBe("https://api.linkedin.com/v2/userinfo");
+  });
+
+  it("returns userinfo with locale when present", async () => {
+    const withLocale = { ...SAMPLE_USERINFO, locale: { country: "US", language: "en" } };
+    fetchSpy.mockResolvedValueOnce(jsonResponse(withLocale));
+
+    const client = new LinkedInClient({ accessToken: "test-token", apiVersion: "202501" });
+    const result = await getUserInfo(client);
+
+    expect(result.locale).toEqual({ country: "US", language: "en" });
+  });
+});

--- a/packages/core/src/userinfo/userinfo.ts
+++ b/packages/core/src/userinfo/userinfo.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { LinkedInClient } from "../http/linkedin-client.js";
+
+/**
+ * OpenID Connect userinfo response from LinkedIn.
+ */
+export interface UserInfo {
+  sub: string;
+  name: string;
+  given_name: string;
+  family_name: string;
+  picture: string;
+  email: string;
+  email_verified: boolean;
+  locale?: { country: string; language: string } | undefined;
+}
+
+/**
+ * Retrieve the authenticated user's profile via the OpenID Connect userinfo endpoint.
+ */
+export async function getUserInfo(client: LinkedInClient): Promise<UserInfo> {
+  return client.request<UserInfo>("/v2/userinfo");
+}


### PR DESCRIPTION
## Summary

- Adds `linkedctl whoami` command that displays the authenticated user's name, email, and profile picture URL via the LinkedIn OpenID Connect `/v2/userinfo` endpoint
- Supports `--format json` for machine-readable output; defaults to table format on TTY
- Adds `UserInfo` type and `getUserInfo()` service in `@linkedctl/core`

Closes #6

## Test plan

- [x] Core: `getUserInfo` calls `/v2/userinfo` and returns parsed response
- [x] CLI: `whoami` displays name, email, picture in table format
- [x] CLI: `--format json` outputs only name, email, picture as JSON
- [x] CLI: `--profile` flag passes through to config resolver
- [x] All 175 existing + new tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)