### PR TITLE
(feat) add MCP server foundation

### DIFF
--- a/packages/linkedctl/package.json
+++ b/packages/linkedctl/package.json
@@ -47,7 +47,8 @@
   },
   "dependencies": {
     "@linkedctl/cli": "workspace:^",
-    "@linkedctl/mcp": "workspace:^"
+    "@linkedctl/mcp": "workspace:^",
+    "commander": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/linkedctl/src/cli.ts
+++ b/packages/linkedctl/src/cli.ts
@@ -2,7 +2,17 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { Command } from "commander";
 import { createProgram } from "@linkedctl/cli";
+import { startStdioServer } from "@linkedctl/mcp/stdio";
 
 const program = createProgram();
+
+const mcpCommand = new Command("mcp");
+mcpCommand.description("Start the MCP server on stdio transport");
+mcpCommand.action(async () => {
+  await startStdioServer();
+});
+program.addCommand(mcpCommand);
+
 await program.parseAsync(process.argv);

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { startStdioServer } from "./stdio.js";
+
+await startStdioServer();

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createMcpServer } from "./server.js";
+
+vi.mock("@linkedctl/core", () => ({
+  resolveConfig: vi.fn(),
+  LinkedInClient: vi.fn(),
+  getCurrentPersonUrn: vi.fn(),
+  createTextPost: vi.fn(),
+  getDefaultConfigPath: vi.fn(),
+  readConfigFile: vi.fn(),
+  getProfile: vi.fn(),
+  getTokenExpiry: vi.fn(),
+}));
+
+import {
+  resolveConfig,
+  LinkedInClient,
+  getCurrentPersonUrn,
+  createTextPost,
+  getDefaultConfigPath,
+  readConfigFile,
+  getProfile,
+  getTokenExpiry,
+} from "@linkedctl/core";
+
+describe("createMcpServer", () => {
+  let client: Client;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const server = createMcpServer();
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    client = new Client({ name: "test-client", version: "1.0.0" });
+
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    cleanup = async () => {
+      await client.close();
+      await server.close();
+    };
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  it("lists post_create and auth_status tools", async () => {
+    const result = await client.listTools();
+    const toolNames = result.tools.map((t) => t.name);
+
+    expect(toolNames).toContain("post_create");
+    expect(toolNames).toContain("auth_status");
+  });
+
+  describe("post_create", () => {
+    it("creates a post and returns the URN", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        accessToken: "test-token",
+        apiVersion: "202401",
+        profile: "default",
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockResolvedValue("urn:li:person:abc123");
+      vi.mocked(createTextPost).mockResolvedValue("urn:li:share:post456");
+
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: { text: "Hello LinkedIn" },
+      });
+
+      expect(resolveConfig).toHaveBeenCalledWith({ profile: undefined });
+      expect(createTextPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          author: "urn:li:person:abc123",
+          text: "Hello LinkedIn",
+          visibility: "PUBLIC",
+        }),
+      );
+      expect(result.content).toEqual([{ type: "text", text: "Post created: urn:li:share:post456" }]);
+    });
+
+    it("passes profile and visibility options", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        accessToken: "test-token",
+        apiVersion: "202401",
+        profile: "work",
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockResolvedValue("urn:li:person:abc123");
+      vi.mocked(createTextPost).mockResolvedValue("urn:li:share:post789");
+
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: {
+          text: "Connections only",
+          visibility: "CONNECTIONS",
+          profile: "work",
+        },
+      });
+
+      expect(resolveConfig).toHaveBeenCalledWith({ profile: "work" });
+      expect(createTextPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          visibility: "CONNECTIONS",
+        }),
+      );
+      expect(result.content).toEqual([{ type: "text", text: "Post created: urn:li:share:post789" }]);
+    });
+  });
+
+  describe("auth_status", () => {
+    it("reports not configured when profile has no token", async () => {
+      vi.mocked(getDefaultConfigPath).mockReturnValue("/home/user/.linkedctl.yaml");
+      vi.mocked(readConfigFile).mockResolvedValue({ "default-profile": "default" });
+      vi.mocked(getProfile).mockReturnValue(undefined);
+
+      const result = await client.callTool({
+        name: "auth_status",
+        arguments: {},
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: expect.stringContaining("Status: not configured"),
+        },
+      ]);
+    });
+
+    it("reports authenticated with expiry for valid JWT", async () => {
+      vi.mocked(getDefaultConfigPath).mockReturnValue("/home/user/.linkedctl.yaml");
+      vi.mocked(readConfigFile).mockResolvedValue({ "default-profile": "default" });
+      vi.mocked(getProfile).mockReturnValue({
+        "access-token": "valid-jwt-token",
+        "api-version": "202401",
+      });
+      vi.mocked(getTokenExpiry).mockReturnValue({
+        expiresAt: new Date("2099-12-31T23:59:59Z"),
+        isExpired: false,
+      });
+
+      const result = await client.callTool({
+        name: "auth_status",
+        arguments: {},
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: expect.stringContaining("Status: authenticated"),
+        },
+      ]);
+    });
+
+    it("reports expired for expired token", async () => {
+      vi.mocked(getDefaultConfigPath).mockReturnValue("/home/user/.linkedctl.yaml");
+      vi.mocked(readConfigFile).mockResolvedValue({ "default-profile": "default" });
+      vi.mocked(getProfile).mockReturnValue({
+        "access-token": "expired-jwt-token",
+        "api-version": "202401",
+      });
+      vi.mocked(getTokenExpiry).mockReturnValue({
+        expiresAt: new Date("2020-01-01T00:00:00Z"),
+        isExpired: true,
+      });
+
+      const result = await client.callTool({
+        name: "auth_status",
+        arguments: {},
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: expect.stringContaining("Status: expired"),
+        },
+      ]);
+    });
+
+    it("reports unknown expiry for non-JWT token", async () => {
+      vi.mocked(getDefaultConfigPath).mockReturnValue("/home/user/.linkedctl.yaml");
+      vi.mocked(readConfigFile).mockResolvedValue({ "default-profile": "default" });
+      vi.mocked(getProfile).mockReturnValue({
+        "access-token": "opaque-token",
+        "api-version": "202401",
+      });
+      vi.mocked(getTokenExpiry).mockReturnValue(undefined);
+
+      const result = await client.callTool({
+        name: "auth_status",
+        arguments: {},
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: expect.stringContaining("unknown (token is not a JWT)"),
+        },
+      ]);
+    });
+
+    it("uses specified profile name", async () => {
+      vi.mocked(getDefaultConfigPath).mockReturnValue("/home/user/.linkedctl.yaml");
+      vi.mocked(readConfigFile).mockResolvedValue({ "default-profile": "default" });
+      vi.mocked(getProfile).mockReturnValue(undefined);
+
+      const result = await client.callTool({
+        name: "auth_status",
+        arguments: { profile: "work" },
+      });
+
+      expect(getProfile).toHaveBeenCalledWith(expect.anything(), "work");
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: expect.stringContaining("Profile: work"),
+        },
+      ]);
+    });
+  });
+});

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,4 +1,122 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-export {};
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import {
+  resolveConfig,
+  LinkedInClient,
+  getCurrentPersonUrn,
+  createTextPost,
+  getDefaultConfigPath,
+  readConfigFile,
+  getProfile,
+  getTokenExpiry,
+} from "@linkedctl/core";
+
+/**
+ * Create and configure the LinkedCtl MCP server with all tools registered.
+ */
+export function createMcpServer(): McpServer {
+  const server = new McpServer({
+    name: "linkedctl",
+    version: "0.0.0",
+  });
+
+  server.registerTool(
+    "post_create",
+    {
+      title: "Create Post",
+      description: "Create a text post on LinkedIn",
+      inputSchema: {
+        text: z.string().describe("The text content of the post"),
+        visibility: z.enum(["PUBLIC", "CONNECTIONS"]).optional().describe("Post visibility (defaults to PUBLIC)"),
+        profile: z.string().optional().describe("Profile name to use from config file"),
+      },
+    },
+    async (args) => {
+      const config = await resolveConfig({ profile: args.profile });
+      const client = new LinkedInClient({
+        accessToken: config.accessToken,
+        apiVersion: config.apiVersion,
+      });
+
+      const authorUrn = await getCurrentPersonUrn(client);
+      const visibility = args.visibility ?? "PUBLIC";
+
+      const postUrn = await createTextPost(client, {
+        author: authorUrn,
+        text: args.text,
+        visibility,
+      });
+
+      return {
+        content: [{ type: "text" as const, text: `Post created: ${postUrn}` }],
+      };
+    },
+  );
+
+  server.registerTool(
+    "auth_status",
+    {
+      title: "Auth Status",
+      description: "Show authentication status for a profile",
+      inputSchema: {
+        profile: z.string().optional().describe("Profile name to check (uses default if not specified)"),
+      },
+    },
+    async (args) => {
+      const configPath = getDefaultConfigPath();
+      const config = await readConfigFile(configPath);
+
+      const profileName = args.profile ?? config["default-profile"] ?? "default";
+      const profile = getProfile(config, profileName);
+
+      if (profile === undefined || profile["access-token"] === "") {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Profile: ${profileName}\nStatus: not configured\nRun "linkedctl profile create" to set up authentication.`,
+            },
+          ],
+        };
+      }
+
+      const expiry = getTokenExpiry(profile["access-token"]);
+
+      if (expiry === undefined) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Profile: ${profileName}\nStatus: authenticated\nExpiry: unknown (token is not a JWT)`,
+            },
+          ],
+        };
+      }
+
+      if (expiry.isExpired) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Profile: ${profileName}\nStatus: expired\nExpired: ${expiry.expiresAt.toISOString()}\nRun "linkedctl profile create" with a new --access-token to re-authenticate.`,
+            },
+          ],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Profile: ${profileName}\nStatus: authenticated\nExpires: ${expiry.expiresAt.toISOString()}`,
+          },
+        ],
+      };
+    },
+  );
+
+  return server;
+}

--- a/packages/mcp/src/stdio.ts
+++ b/packages/mcp/src/stdio.ts
@@ -1,4 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-export {};
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createMcpServer } from "./server.js";
+
+/**
+ * Start the MCP server using stdio transport.
+ */
+export async function startStdioServer(): Promise<void> {
+  const server = createMcpServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       "@linkedctl/mcp":
         specifier: workspace:^
         version: link:../mcp
+      commander:
+        specifier: "catalog:"
+        version: 14.0.3
     devDependencies:
       "@types/node":
         specifier: "catalog:"


### PR DESCRIPTION
## Summary

- Implement MCP server with `post_create` and `auth_status` tools using `@modelcontextprotocol/sdk`
- Add stdio transport entry point (`startStdioServer`) and `linkedctl mcp` CLI command
- Share the same config file and profile resolution system as the CLI

Closes #9

## Test plan

- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [x] All 205 unit tests pass (`pnpm test`)
- [x] Format check passes (`pnpm format:check`)
- [x] License check passes (`pnpm license-check`)
- [x] MCP server tests verify tool listing, post creation, and auth status scenarios (8 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)