### PR TITLE
(test) add E2E test suite for CLI and MCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ## Project-specific
 .linkedctl.yaml
+.linkedctl-e2e.yaml
 *.local.*
 build/
 .tmp/

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -22,6 +22,7 @@
     "@linkedctl/cli": "workspace:^",
     "@linkedctl/core": "workspace:^",
     "@linkedctl/mcp": "workspace:^",
+    "yaml": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/e2e/src/cli.e2e.test.ts
+++ b/packages/e2e/src/cli.e2e.test.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { execFile } from "node:child_process";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import { hasCredentials, cliEnv } from "./credentials.js";
+
+const execFileAsync = promisify(execFile);
+
+const CLI_BIN = resolve(dirname(fileURLToPath(import.meta.url)), "../../linkedctl/dist/cli.js");
+
+async function runCli(...args: string[]): Promise<{ stdout: string; stderr: string }> {
+  return execFileAsync("node", [CLI_BIN, ...args], {
+    env: { ...process.env, ...cliEnv() },
+    timeout: 20_000,
+  });
+}
+
+describe.skipIf(!hasCredentials())("CLI E2E", () => {
+  describe("whoami", () => {
+    it("returns user info as JSON", async () => {
+      const { stdout } = await runCli("whoami", "--format", "json");
+      const data = JSON.parse(stdout) as Record<string, unknown>;
+
+      expect(data).toHaveProperty("name");
+      expect(data).toHaveProperty("email");
+      expect(typeof data["name"]).toBe("string");
+      expect(typeof data["email"]).toBe("string");
+    });
+  });
+
+  describe("post create", () => {
+    it("creates a text post and returns the URN", async () => {
+      const text = `[E2E test] linkedctl ${new Date().toISOString()}`;
+      const { stdout } = await runCli(
+        "post",
+        "create",
+        "--text",
+        text,
+        "--visibility",
+        "CONNECTIONS",
+        "--format",
+        "json",
+      );
+      const data = JSON.parse(stdout) as Record<string, unknown>;
+
+      expect(data).toHaveProperty("urn");
+      expect(typeof data["urn"]).toBe("string");
+      expect(data["urn"]).toMatch(/^urn:li:share:\d+$/);
+    });
+  });
+});

--- a/packages/e2e/src/credentials.ts
+++ b/packages/e2e/src/credentials.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { parse } from "yaml";
+
+const CONFIG_FILENAME = ".linkedctl-e2e.yaml";
+
+export interface E2ECredentials {
+  accessToken: string;
+  apiVersion: string;
+}
+
+/**
+ * Search upward from `cwd` for a `.linkedctl-e2e.yaml` configuration file.
+ * Returns the absolute path if found, or `undefined` otherwise.
+ */
+function findConfigFile(from: string = process.cwd()): string | undefined {
+  let dir = resolve(from);
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  while (true) {
+    const candidate = join(dir, CONFIG_FILENAME);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      return undefined;
+    }
+    dir = parent;
+  }
+}
+
+/**
+ * Returns `true` when a `.linkedctl-e2e.yaml` file is reachable from the
+ * current working directory (searching upward).
+ */
+export function hasCredentials(): boolean {
+  return findConfigFile() !== undefined;
+}
+
+/**
+ * Read and parse E2E credentials from the nearest `.linkedctl-e2e.yaml`.
+ *
+ * @throws if the file is missing or does not contain the required fields.
+ */
+export function getCredentials(): E2ECredentials {
+  const configPath = findConfigFile();
+  if (configPath === undefined) {
+    throw new Error(`No ${CONFIG_FILENAME} found. Create one with "access-token" and "api-version" fields.`);
+  }
+
+  const raw = readFileSync(configPath, "utf8");
+  const config = parse(raw) as Record<string, unknown>;
+
+  const accessToken = config["access-token"];
+  const apiVersion = config["api-version"];
+
+  if (typeof accessToken !== "string" || accessToken === "") {
+    throw new Error(`${CONFIG_FILENAME}: "access-token" is required and must be a non-empty string.`);
+  }
+  if (typeof apiVersion !== "string" || apiVersion === "") {
+    throw new Error(`${CONFIG_FILENAME}: "api-version" is required and must be a non-empty string.`);
+  }
+
+  return { accessToken, apiVersion };
+}
+
+/**
+ * Return environment variables suitable for spawning a `linkedctl` CLI
+ * subprocess with E2E credentials.
+ */
+export function cliEnv(): Record<string, string> {
+  const creds = getCredentials();
+  return {
+    LINKEDCTL_ACCESS_TOKEN: creds.accessToken,
+    LINKEDCTL_API_VERSION: creds.apiVersion,
+  };
+}

--- a/packages/e2e/src/index.ts
+++ b/packages/e2e/src/index.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-export {};
+export { hasCredentials, getCredentials, cliEnv } from "./credentials.js";
+export type { E2ECredentials } from "./credentials.js";

--- a/packages/e2e/src/mcp.e2e.test.ts
+++ b/packages/e2e/src/mcp.e2e.test.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { hasCredentials, cliEnv } from "./credentials.js";
+
+const MCP_BIN = resolve(dirname(fileURLToPath(import.meta.url)), "../../mcp/dist/index.js");
+
+describe.skipIf(!hasCredentials())("MCP E2E", () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+
+  beforeAll(async () => {
+    transport = new StdioClientTransport({
+      command: "node",
+      args: [MCP_BIN],
+      env: { ...process.env, ...cliEnv() },
+    });
+    client = new Client({ name: "e2e-test", version: "0.0.0" });
+    await client.connect(transport);
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  it("lists available tools", async () => {
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name);
+
+    expect(names).toContain("post_create");
+    expect(names).toContain("auth_status");
+  });
+
+  describe("post_create", () => {
+    it("creates a text post and returns the URN", async () => {
+      const text = `[E2E test] linkedctl MCP ${new Date().toISOString()}`;
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: { text, visibility: "CONNECTIONS" },
+      });
+
+      expect(result.isError).not.toBe(true);
+      expect(result.content).toHaveLength(1);
+
+      const content = result.content[0];
+      expect(content).toHaveProperty("type", "text");
+      expect(content).toHaveProperty("text");
+      expect((content as { text: string }).text).toMatch(/^Post created: urn:li:share:\d+$/);
+    });
+  });
+
+  describe("auth_status", () => {
+    it("returns authentication status", async () => {
+      const result = await client.callTool({
+        name: "auth_status",
+        arguments: {},
+      });
+
+      expect(result.isError).not.toBe(true);
+      expect(result.content).toHaveLength(1);
+
+      const content = result.content[0];
+      expect(content).toHaveProperty("type", "text");
+      expect((content as { text: string }).text).toContain("Profile:");
+      expect((content as { text: string }).text).toContain("Status:");
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       "@modelcontextprotocol/sdk":
         specifier: "catalog:"
         version: 1.27.1(zod@4.3.6)
+      yaml:
+        specifier: "catalog:"
+        version: 2.8.2
       zod:
         specifier: "catalog:"
         version: 4.3.6


### PR DESCRIPTION
## Summary

- Add credential helpers (`hasCredentials()`, `getCredentials()`, `cliEnv()`) that search upward for `.linkedctl-e2e.yaml` and provide environment variables for spawning CLI subprocesses
- Add CLI E2E tests covering `whoami` and `post create` via subprocess execution
- Add MCP E2E tests covering tool listing, `post_create`, and `auth_status` via `StdioClientTransport`
- Tests skip gracefully with clear messaging when no credentials are available (`describe.skipIf(!hasCredentials())`)

Closes #35

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm format:check` passes
- [x] `pnpm test` passes (205 unit tests)
- [x] `pnpm test:e2e` skips gracefully without credentials (5 tests skipped)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)