### PR TITLE
(docs) fix CLAUDE.md package exports description

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,13 +100,34 @@ ESLint enforces this via `eslint-plugin-header`.
 
 ### Package Exports
 
-Each package uses conditional exports with `types` + `import`:
+All packages use conditional exports with `types` + `import`. `@linkedctl/core` and `@linkedctl/cli` follow the standard single-entry pattern:
 
 ```json
 "exports": {
   ".": {
     "types": "./dist/index.d.ts",
     "import": "./dist/index.js"
+  }
+}
+```
+
+`@linkedctl/mcp` exposes three entry points (server and stdio transports):
+
+```json
+"exports": {
+  ".":        { "types": "./dist/server.d.ts", "import": "./dist/server.js" },
+  "./server": { "types": "./dist/server.d.ts", "import": "./dist/server.js" },
+  "./stdio":  { "types": "./dist/stdio.d.ts",  "import": "./dist/stdio.js"  }
+}
+```
+
+`linkedctl` (umbrella) exports the CLI entry point instead of `index`:
+
+```json
+"exports": {
+  ".": {
+    "types": "./dist/cli.d.ts",
+    "import": "./dist/cli.js"
   }
 }
 ```


### PR DESCRIPTION
## Summary

- Updated the Package Exports section in CLAUDE.md to accurately describe all 4 publishable packages
- `@linkedctl/core` and `@linkedctl/cli` documented as following the standard single-entry `index` pattern
- `@linkedctl/mcp` documented with its 3 export entries (`.`, `./server`, `./stdio`)
- `linkedctl` (umbrella) documented with its `cli.js` entry point instead of `index.js`

Closes #46

## Test plan

- [x] Verified each documented export matches the actual `exports` field in corresponding `package.json`
- [x] Ran `pnpm exec prettier --write CLAUDE.md` (no formatting changes needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)