### PR TITLE
(docs) update CLAUDE.md dev commands and CI description

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,11 @@ pnpm install          # Install dependencies
 pnpm build            # Build all packages (via Turbo)
 pnpm test             # Run unit tests
 pnpm test:e2e         # Run E2E tests (sequential)
+pnpm format:check     # Check Prettier formatting
+pnpm typecheck        # Type-check all packages (via Turbo)
 pnpm lint             # Lint all packages
 pnpm license-check    # Verify dependency licenses
+pnpm publish-check    # Validate publish manifests
 pnpm dev              # Watch mode
 ```
 
@@ -118,7 +121,7 @@ Each package uses conditional exports with `types` + `import`:
 
 ## CI/CD
 
-- **CI**: Runs on push/PR to `main`; 3-OS matrix (ubuntu, macos, windows); builds, lints, license-checks, tests
+- **CI**: Runs on push/PR to `main`; 3-OS matrix (ubuntu, macos, windows); format-checks, builds, type-checks, lints, license-checks, publish-checks, tests
 - **Release**: Triggered by GitHub Release publish; validates, stamps version from git tag, publishes to npm with provenance
 - **Setup**: Composite action at `.github/actions/setup/` (pnpm + Node.js 24 + frozen lockfile + Turbo cache)
 - Coverage uploaded to Codecov on ubuntu only


### PR DESCRIPTION
## Summary
- Add `pnpm format:check`, `pnpm typecheck`, and `pnpm publish-check` to the Development Commands section in CLAUDE.md
- Update the CI/CD description to accurately list all pipeline steps: format-checks, builds, type-checks, lints, license-checks, publish-checks, tests

Closes #49

## Test plan
- [x] Verify `CLAUDE.md` Development Commands lists `pnpm format:check` and `pnpm publish-check`
- [x] Verify `CLAUDE.md` CI/CD description includes format-check and publish-check steps
- [x] Prettier formatting confirmed (no changes needed)