### PR TITLE
(docs) add CLI command reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,91 @@ linkedctl auth token --access-token YOUR_TOKEN
 | `LINKEDCTL_CLIENT_SECRET` | LinkedIn OAuth 2.0 client secret          |
 | `LINKEDCTL_ACCESS_TOKEN`  | Direct access token (bypasses OAuth flow) |
 
+## CLI Reference
+
+### Global Options
+
+| Option             | Description                          |
+| ------------------ | ------------------------------------ |
+| `--profile <name>` | Use a specific configuration profile |
+
+### `auth` -- Manage Authentication
+
+| Command        | Description                                                |
+| -------------- | ---------------------------------------------------------- |
+| `auth login`   | Authenticate via OAuth 2.0 (opens browser)                 |
+| `auth token`   | Store a direct access token                                |
+| `auth status`  | Show authentication status and token expiry                |
+| `auth logout`  | Clear stored credentials from the active profile           |
+| `auth refresh` | Refresh the access token using a stored refresh token      |
+| `auth revoke`  | Revoke the access token server-side and clear local tokens |
+
+**`auth login` options:**
+
+| Option                     | Description                        | Default                          |
+| -------------------------- | ---------------------------------- | -------------------------------- |
+| `--client-id <id>`         | OAuth 2.0 client ID                | from config                      |
+| `--client-secret <secret>` | OAuth 2.0 client secret            | from config                      |
+| `--scope <scopes>`         | OAuth 2.0 scopes (space-separated) | `openid profile w_member_social` |
+
+**`auth token` options:**
+
+| Option                   | Description                      |
+| ------------------------ | -------------------------------- |
+| `--access-token <token>` | Access token to store (required) |
+
+### `post` -- Manage LinkedIn Posts
+
+```sh
+# Shorthand: pass text as an argument
+linkedctl post "Hello from LinkedCtl!"
+
+# Explicit subcommand
+linkedctl post create --text "Hello from LinkedCtl!"
+
+# Pipe content from stdin
+echo "Hello from LinkedCtl!" | linkedctl post create
+```
+
+**`post create` options:**
+
+| Option                      | Description                     | Default  |
+| --------------------------- | ------------------------------- | -------- |
+| `--text <text>`             | Text content of the post        |          |
+| `--visibility <visibility>` | `PUBLIC` or `CONNECTIONS`       | `PUBLIC` |
+| `--format <format>`         | Output format (`json`, `table`) | auto     |
+
+When no `--text` is provided, text is read from stdin if available.
+
+The `--format` option defaults to `table` in a terminal and `json` when piped.
+
+### `profile` -- Manage Configuration Profiles
+
+| Command                 | Description                     |
+| ----------------------- | ------------------------------- |
+| `profile create <name>` | Create a new profile            |
+| `profile list`          | List all profiles               |
+| `profile show <name>`   | Show profile details (redacted) |
+| `profile delete <name>` | Delete a profile                |
+
+**`profile create` options:**
+
+| Option                    | Description                                    |
+| ------------------------- | ---------------------------------------------- |
+| `--access-token <token>`  | OAuth 2.0 access token (required)              |
+| `--api-version <version>` | LinkedIn API version, e.g. `202501` (required) |
+
+### `whoami` -- Show Current User
+
+```sh
+linkedctl whoami
+linkedctl whoami --format json
+```
+
+| Option              | Description                     | Default |
+| ------------------- | ------------------------------- | ------- |
+| `--format <format>` | Output format (`json`, `table`) | auto    |
+
 ## Disclaimer
 
 This is an independent project and is not affiliated with, endorsed by, or associated with LinkedIn Corporation. LinkedIn is a trademark of LinkedIn Corporation.


### PR DESCRIPTION
## Summary
- Add a comprehensive CLI Reference section to README.md documenting all commands, options, and usage examples
- Documents global `--profile` option, all `auth` subcommands (login/token/status/logout/refresh/revoke), `post` commands with `--text`/`--visibility`/`--format`, `profile` management (create/list/show/delete), and `whoami`
- Includes stdin piping example and auto-format behavior explanation

Closes #48

## Test plan
- [ ] Verify all documented commands match actual CLI behavior
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm prettier formatting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)