### PR TITLE
(docs) add cross-references between documentation files

### DIFF
--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -179,3 +179,10 @@ Access tokens are valid for approximately 60 days. Run `linkedctl auth login` ag
 ### Scope errors when posting
 
 If you get permission errors when creating posts, verify that your LinkedIn app has the **Share on LinkedIn** product enabled and that the `w_member_social` scope is listed under your app's OAuth 2.0 scopes.
+
+## Next Steps
+
+Now that authentication is configured, explore what LinkedCtl can do:
+
+- [CLI Reference](../README.md#cli-reference) — all available commands and options
+- [MCP Integration](../README.md#mcp-integration) — connect LinkedCtl to AI assistants like Claude


### PR DESCRIPTION
## Summary
- Add a "Next Steps" section at the end of `docs/oauth-setup.md` linking to the CLI Reference and MCP Integration sections in the README
- Users completing OAuth setup now have clear guidance on what to do next

Closes #54

## Test plan
- [ ] Verify markdown links resolve correctly on GitHub (`../README.md#cli-reference`, `../README.md#mcp-integration`)
- [ ] Confirm Prettier formatting passes in CI

Generated with [Claude Code](https://claude.com/claude-code)