### PR TITLE
(docs) document config file format and profile system

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,71 @@ Revoke the access token server-side and clear local credentials for a profile.
 
 ## Configuration
 
-### OAuth 2.0 (Recommended)
+### Config File Format
+
+LinkedCtl stores configuration in YAML files. Each file represents a single profile:
+
+```yaml
+api-version: "202501"
+oauth:
+    client-id: "YOUR_CLIENT_ID"
+    client-secret: "YOUR_CLIENT_SECRET"
+    access-token: "YOUR_ACCESS_TOKEN"
+    refresh-token: "YOUR_REFRESH_TOKEN"
+    token-expires-at: "2026-05-03T12:00:00.000Z"
+```
+
+**Available keys:**
+
+| Key                      | Description                           |
+| ------------------------ | ------------------------------------- |
+| `api-version`            | LinkedIn API version (e.g. `202501`)  |
+| `oauth.client-id`        | OAuth 2.0 client ID                   |
+| `oauth.client-secret`    | OAuth 2.0 client secret               |
+| `oauth.access-token`     | OAuth 2.0 access token                |
+| `oauth.refresh-token`    | OAuth 2.0 refresh token               |
+| `oauth.token-expires-at` | Token expiration timestamp (ISO 8601) |
+
+Config files are written with `0600` permissions (owner read/write only).
+
+### File Location and Precedence
+
+Without a profile, LinkedCtl searches for config files in this order:
+
+1. `.linkedctl.yaml` in the current working directory
+2. `~/.linkedctl.yaml` in the home directory
+
+The first file found is used. When writing (e.g. after `auth login`), LinkedCtl writes to the CWD file if it exists, otherwise to the home directory file.
+
+### Profiles
+
+Profiles let you manage multiple LinkedIn accounts or configurations. Each profile is stored as a separate YAML file under `~/.linkedctl/`:
+
+| Profile    | Config file path             |
+| ---------- | ---------------------------- |
+| (default)  | `~/.linkedctl.yaml`          |
+| `work`     | `~/.linkedctl/work.yaml`     |
+| `personal` | `~/.linkedctl/personal.yaml` |
+
+Use the `--profile` flag with any command:
+
+```sh
+linkedctl --profile work auth login --client-id ID --client-secret SECRET
+linkedctl --profile work post "Hello from my work account!"
+```
+
+Manage profiles with the `profile` command:
+
+```sh
+linkedctl profile create work --access-token YOUR_TOKEN --api-version 202501
+linkedctl profile list
+linkedctl profile show work
+linkedctl profile delete work
+```
+
+### Authentication Methods
+
+#### OAuth 2.0 (Recommended)
 
 LinkedCtl supports OAuth 2.0 with your own LinkedIn Developer App:
 
@@ -106,7 +170,7 @@ LinkedCtl supports OAuth 2.0 with your own LinkedIn Developer App:
 linkedctl auth login --client-id YOUR_CLIENT_ID --client-secret YOUR_CLIENT_SECRET
 ```
 
-### Direct Token
+#### Direct Token
 
 If you already have an access token from another application:
 
@@ -122,6 +186,27 @@ linkedctl auth token --access-token YOUR_TOKEN
 | `LINKEDCTL_CLIENT_SECRET` | LinkedIn OAuth 2.0 client secret                         |
 | `LINKEDCTL_ACCESS_TOKEN`  | Direct access token (bypasses OAuth flow)                |
 | `LINKEDCTL_API_VERSION`   | LinkedIn API version string (e.g. `202501`) **required** |
+
+Environment variables take precedence over config file values.
+
+#### Profile-Prefixed Environment Variables
+
+When using a named profile, LinkedCtl also reads profile-prefixed environment variables. The profile name is uppercased with hyphens converted to underscores:
+
+| Profile    | Variable                          |
+| ---------- | --------------------------------- |
+| (default)  | `LINKEDCTL_ACCESS_TOKEN`          |
+| `work`     | `LINKEDCTL_WORK_ACCESS_TOKEN`     |
+| `my-brand` | `LINKEDCTL_MY_BRAND_ACCESS_TOKEN` |
+
+The same pattern applies to `CLIENT_ID`, `CLIENT_SECRET`, and `API_VERSION`.
+
+### Precedence Order
+
+Configuration values are resolved in this order (highest priority first):
+
+1. **Environment variables** (profile-prefixed if a profile is active)
+2. **Config file** (profile-specific file, or CWD/home fallback)
 
 ## CLI Reference
 

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -67,17 +67,21 @@ LinkedCtl requires a LinkedIn API version to be configured. LinkedIn uses date-b
 
 There are three ways to set the API version:
 
-**Option A: Config file** — add `api-version` to your config file (`~/.linkedctl.yaml` or `.linkedctl.yaml` in the current directory):
+**Option A: Config file** — add `api-version` to your config file:
 
 ```yaml
 api-version: "202501"
 ```
+
+LinkedCtl searches for config files in this order: `.linkedctl.yaml` in the current directory, then `~/.linkedctl.yaml` in the home directory. When using a named profile (e.g. `--profile work`), the config is stored at `~/.linkedctl/work.yaml` instead.
 
 **Option B: Environment variable**:
 
 ```sh
 export LINKEDCTL_API_VERSION=202501
 ```
+
+When using a named profile, prefix the variable with the uppercased profile name (hyphens become underscores). For example, profile `work` reads `LINKEDCTL_WORK_API_VERSION`.
 
 **Option C: Profile creation** — when creating a named profile, pass `--api-version`:
 
@@ -103,6 +107,14 @@ This will:
 4. LinkedCtl exchanges the authorization code for access and refresh tokens
 5. Credentials are saved to `~/.linkedctl.yaml`
 
+To authenticate a **named profile** instead, add the `--profile` flag:
+
+```sh
+linkedctl --profile work auth login --client-id YOUR_CLIENT_ID --client-secret YOUR_CLIENT_SECRET
+```
+
+Credentials for named profiles are saved to `~/.linkedctl/<profile>.yaml` (e.g. `~/.linkedctl/work.yaml`).
+
 If the browser does not open automatically, copy the URL printed in the terminal and open it manually.
 
 ### Subsequent logins
@@ -120,6 +132,8 @@ export LINKEDCTL_API_VERSION=202501
 linkedctl auth login
 ```
 
+For named profiles, use profile-prefixed variables (e.g. `LINKEDCTL_WORK_CLIENT_ID` for profile `work`).
+
 ## 7. Verify Authentication
 
 Check that authentication is working:
@@ -132,6 +146,18 @@ Expected output:
 
 ```text
 Profile: default
+Status: authenticated
+Expires: 2026-05-03T12:00:00.000Z (59d 23h remaining)
+```
+
+For a named profile:
+
+```sh
+linkedctl --profile work auth status
+```
+
+```text
+Profile: work
 Status: authenticated
 Expires: 2026-05-03T12:00:00.000Z (59d 23h remaining)
 ```


### PR DESCRIPTION
## Summary

- Add comprehensive Configuration section to README.md covering YAML config file format, available keys, file location precedence, profile system, profile-prefixed environment variables, and overall precedence order
- Update docs/oauth-setup.md to mention profile-specific config paths when saving credentials and authenticating, and add named profile examples to verification output
- Restructure existing OAuth 2.0 / Direct Token auth methods under a new "Authentication Methods" heading within the Configuration section

Closes #51

## Test plan

- [ ] Verify YAML config example in README matches the actual schema in `packages/core/src/config/validate.ts`
- [ ] Verify file precedence description matches `packages/core/src/config/loader.ts` logic
- [ ] Verify env var naming convention matches `packages/core/src/config/env.ts` `buildPrefix()` logic
- [ ] Verify `docs/oauth-setup.md` profile paths match `packages/core/src/config/writer.ts` `resolveWritePath()` logic
- [ ] Run `pnpm exec prettier --check README.md docs/oauth-setup.md` to confirm formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)