### PR TITLE
(docs) fix README duplication and broken npm links

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ npx linkedctl --help
     linkedctl post "Hello from LinkedCtl!"
     ```
 
-See the [OAuth Setup Guide](docs/oauth-setup.md) for detailed step-by-step instructions.
+See the [OAuth Setup Guide](https://github.com/alexey-pelykh/linkedctl/blob/main/docs/oauth-setup.md) for detailed step-by-step instructions.
 
 ## MCP Integration
 


### PR DESCRIPTION
## Summary

- Fix the OAuth Setup Guide link in the root README from a relative path (`docs/oauth-setup.md`) to an absolute GitHub URL (`https://github.com/alexey-pelykh/linkedctl/blob/main/docs/oauth-setup.md`) so it resolves correctly when viewed on npm
- The `packages/linkedctl/README.md` duplication is already resolved: the file is not tracked in git, and the `prepack` script copies the root README at publish time

Closes #53

## Test plan

- [ ] Verify the link in the README renders correctly on GitHub
- [ ] Verify `packages/linkedctl/README.md` is not tracked (`git ls-files packages/linkedctl/README.md` returns empty)
- [ ] Verify the prepack script in `packages/linkedctl/package.json` copies `../../README.md`