### PR TITLE
(docs) add per-package READMEs for core, cli, mcp

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,21 @@
+# @linkedctl/cli
+
+CLI commands for LinkedIn API integration -- the command-line interface used by [`linkedctl`](https://github.com/alexey-pelykh/linkedctl).
+
+## Installation
+
+```sh
+npm install @linkedctl/cli
+```
+
+Requires Node.js >= 24.
+
+## Overview
+
+This package provides the CLI command definitions and program setup for LinkedCtl. It includes commands for authentication (`auth`), posting (`post`), profile management (`profile`), and user info (`whoami`).
+
+For full CLI documentation and usage examples, see the [main project](https://github.com/alexey-pelykh/linkedctl).
+
+## License
+
+[AGPL-3.0-only](https://www.gnu.org/licenses/agpl-3.0.txt)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,46 @@
+# @linkedctl/core
+
+Core library for LinkedIn API integration -- OAuth 2.0, HTTP client, and service layer used by [`linkedctl`](https://github.com/alexey-pelykh/linkedctl).
+
+## Installation
+
+```sh
+npm install @linkedctl/core
+```
+
+Requires Node.js >= 24.
+
+## API Surface
+
+### HTTP Client
+
+- **`LinkedInClient`** -- authenticated HTTP client for the LinkedIn REST API
+
+### OAuth 2.0
+
+- **`buildAuthorizationUrl`** -- construct the OAuth 2.0 authorization URL
+- **`exchangeAuthorizationCode`** -- exchange an authorization code for tokens
+- **`refreshAccessToken`** -- refresh an expired access token
+- **`revokeAccessToken`** -- revoke an access token server-side
+- **`generateCodeVerifier`** / **`computeCodeChallenge`** -- PKCE helpers
+
+### Configuration
+
+- **`resolveConfig`** -- resolve a complete configuration from file + environment
+- **`loadConfigFile`** / **`validateConfig`** -- load and validate config files
+- **`saveOAuthTokens`** / **`saveOAuthClientCredentials`** / **`clearOAuthTokens`** -- persist credentials
+- **`applyEnvOverlay`** -- overlay environment variables onto config
+
+### Services
+
+- **`getUserInfo`** / **`getCurrentPersonUrn`** -- fetch authenticated user info
+- **`createTextPost`** -- create a text post on LinkedIn
+- **`getTokenExpiry`** -- introspect JWT token expiry
+
+## License
+
+[AGPL-3.0-only](https://www.gnu.org/licenses/agpl-3.0.txt)
+
+**Using `@linkedctl/core` as a library in your project**: Your combined work must be licensed under AGPL-3.0 (or a compatible license).
+
+See the [main project](https://github.com/alexey-pelykh/linkedctl) for full documentation.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,21 @@
+# @linkedctl/mcp
+
+MCP (Model Context Protocol) server for LinkedIn API integration -- the AI-tool interface used by [`linkedctl`](https://github.com/alexey-pelykh/linkedctl).
+
+## Installation
+
+```sh
+npm install @linkedctl/mcp
+```
+
+Requires Node.js >= 24.
+
+## Overview
+
+This package provides an MCP server that exposes LinkedIn API operations as tools for AI assistants (Claude, Cursor, etc.). It registers tools for creating posts, checking authentication status, and revoking tokens.
+
+For full MCP integration documentation and available tools, see the [main project](https://github.com/alexey-pelykh/linkedctl).
+
+## License
+
+[AGPL-3.0-only](https://www.gnu.org/licenses/agpl-3.0.txt)


### PR DESCRIPTION
## Summary

- Add `packages/core/README.md` with package purpose, installation, API surface summary, and AGPL-3.0 license note
- Add `packages/cli/README.md` with package purpose, link to main project, and license note
- Add `packages/mcp/README.md` with package purpose, link to main project, and license note
- Prepack scripts verified: sub-packages only copy LICENSE (not README), so package-specific READMEs are preserved during `npm pack`

Closes #52

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (245 tests)
- [x] `npm pack --dry-run` for each sub-package confirms README.md is included in tarball
- [x] `npx prettier --write` confirms READMEs are Prettier-compliant
- [x] Prepack scripts do not overwrite sub-package READMEs

Generated with [Claude Code](https://claude.com/claude-code)