### PR TITLE
(fix) auto-include openid scopes when Share on LinkedIn is selected

### DIFF
--- a/packages/cli/src/commands/auth/setup.test.ts
+++ b/packages/cli/src/commands/auth/setup.test.ts
@@ -133,12 +133,12 @@ describe("auth setup", () => {
     });
   });
 
-  it("saves scope for Share only", () => {
+  it("saves scope for Share only (auto-includes openid scopes)", () => {
     mockReadline(["my-client-id", "my-client-secret", "n", "y", "n"]);
 
     const program = wrapInProgram(setupCommand());
     return program.parseAsync(["auth", "setup"], { from: "user" }).then(() => {
-      expect(saveOAuthScopeSpy).toHaveBeenCalledWith("w_member_social", undefined);
+      expect(saveOAuthScopeSpy).toHaveBeenCalledWith("w_member_social openid profile email", undefined);
     });
   });
 

--- a/packages/cli/src/commands/auth/setup.ts
+++ b/packages/cli/src/commands/auth/setup.ts
@@ -82,6 +82,15 @@ export function setupCommand(): Command {
       const share = await rl.question("Share on LinkedIn? [y/N] ");
       if (share.trim().toLowerCase() === "y" || share.trim().toLowerCase() === "yes") {
         scopes.push("w_member_social");
+        // Posting requires the author's person URN, which is only available via
+        // the /v2/userinfo endpoint. That endpoint needs openid scopes, so we
+        // force-enable them when Share on LinkedIn is selected.
+        if (!scopes.includes("openid")) {
+          scopes.push("openid", "profile", "email");
+          process.stderr.write(
+            '  → Also enabling "Sign In with LinkedIn" scopes (required to resolve author identity for posts)\n',
+          );
+        }
       }
 
       if (scopes.length === 0) {


### PR DESCRIPTION
## Summary
- When "Share on LinkedIn" is selected during `auth setup`, automatically include `openid profile email` scopes
- Posting requires the author's person URN from `/v2/userinfo`, which needs `openid` scopes
- User sees an informational message explaining the auto-inclusion

Closes #68

## Test plan
- [x] "Share only" test updated to expect openid scopes included
- [x] "Both products" test still passes (no duplicate scopes via `Set`)
- [x] All 117 CLI tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)