### PR TITLE
(feat) validate OAuth scopes before API calls (#69)

### DIFF
--- a/packages/cli/src/commands/post/create.test.ts
+++ b/packages/cli/src/commands/post/create.test.ts
@@ -123,7 +123,12 @@ describe("post create", () => {
     const program = createProgram();
     await program.parseAsync(["node", "linkedctl", "--profile", "work", "post", "create", "--text", "Hello"]);
 
-    expect(coreMock.resolveConfig).toHaveBeenCalledWith(expect.objectContaining({ profile: "work" }));
+    expect(coreMock.resolveConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profile: "work",
+        requiredScopes: ["openid", "profile", "email", "w_member_social"],
+      }),
+    );
   });
 
   it("wraps API errors with actionable message", async () => {

--- a/packages/cli/src/commands/post/create.ts
+++ b/packages/cli/src/commands/post/create.ts
@@ -39,7 +39,10 @@ export async function createPostAction(textOpt: string | undefined, opts: Create
   const text = await resolveText(textOpt);
   const globals = cmd.optsWithGlobals<{ profile?: string | undefined }>();
 
-  const { config } = await resolveConfig({ profile: globals.profile });
+  const { config } = await resolveConfig({
+    profile: globals.profile,
+    requiredScopes: ["openid", "profile", "email", "w_member_social"],
+  });
   // resolveConfig guarantees oauth.accessToken and apiVersion are defined
   const accessToken = config.oauth?.accessToken ?? "";
   const apiVersion = config.apiVersion ?? "";

--- a/packages/cli/src/commands/whoami.test.ts
+++ b/packages/cli/src/commands/whoami.test.ts
@@ -49,7 +49,10 @@ describe("whoami", () => {
       const cmd = whoamiCommand();
       await cmd.parseAsync([], { from: "user" });
 
-      expect(resolveConfigSpy).toHaveBeenCalledWith({ profile: undefined });
+      expect(resolveConfigSpy).toHaveBeenCalledWith({
+        profile: undefined,
+        requiredScopes: ["openid", "profile", "email"],
+      });
       expect(getUserInfoSpy).toHaveBeenCalledOnce();
       expect(consoleSpy).toHaveBeenCalledOnce();
 
@@ -89,7 +92,7 @@ describe("whoami", () => {
 
     await parent.parseAsync(["whoami", "--profile", "work"], { from: "user" });
 
-    expect(resolveConfigSpy).toHaveBeenCalledWith({ profile: "work" });
+    expect(resolveConfigSpy).toHaveBeenCalledWith({ profile: "work", requiredScopes: ["openid", "profile", "email"] });
   });
 
   it("outputs only name, email, and picture in JSON format", async () => {

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -15,7 +15,7 @@ export function whoamiCommand(): Command {
     const rootOpts = actionCmd.optsWithGlobals();
     const profileFlag = typeof rootOpts["profile"] === "string" ? rootOpts["profile"] : undefined;
 
-    const { config } = await resolveConfig({ profile: profileFlag });
+    const { config } = await resolveConfig({ profile: profileFlag, requiredScopes: ["openid", "profile", "email"] });
     // resolveConfig guarantees oauth.accessToken and apiVersion are defined
     const accessToken = config.oauth?.accessToken ?? "";
     const apiVersion = config.apiVersion ?? "";

--- a/packages/core/src/config/resolve.test.ts
+++ b/packages/core/src/config/resolve.test.ts
@@ -147,6 +147,61 @@ api-version: "202501"
     expect(config.apiVersion).toBe("202501");
   });
 
+  it("throws ConfigError when required scopes are missing", async () => {
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, ".linkedctl.yaml"),
+      `oauth:
+  access-token: "tok"
+  scope: "openid profile"
+api-version: "202501"
+`,
+    );
+
+    await expect(
+      resolveConfig({ home: dir, cwd: dir, env: {}, requiredScopes: ["openid", "profile", "email"] }),
+    ).rejects.toThrow(/Missing required OAuth scopes: email/);
+  });
+
+  it("passes when all required scopes are present", async () => {
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, ".linkedctl.yaml"),
+      `oauth:
+  access-token: "tok"
+  scope: "openid profile email"
+api-version: "202501"
+`,
+    );
+
+    const { config } = await resolveConfig({
+      home: dir,
+      cwd: dir,
+      env: {},
+      requiredScopes: ["openid", "profile", "email"],
+    });
+    expect(config.oauth?.accessToken).toBe("tok");
+  });
+
+  it("skips scope validation when scope field is not set", async () => {
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, ".linkedctl.yaml"),
+      `oauth:
+  access-token: "tok"
+api-version: "202501"
+`,
+    );
+
+    const { config } = await resolveConfig({
+      home: dir,
+      cwd: dir,
+      env: {},
+      requiredScopes: ["openid", "profile", "email"],
+    });
+    expect(config.oauth?.accessToken).toBe("tok");
+  });
+
   it("returns warnings for unknown keys", async () => {
     await mkdir(dir, { recursive: true });
     await writeFile(

--- a/packages/core/src/config/resolve.ts
+++ b/packages/core/src/config/resolve.ts
@@ -64,6 +64,24 @@ export async function resolveConfig(options?: ResolveOptions): Promise<ConfigRes
     );
   }
 
+  // 5. Validate required scopes
+  const requiredScopes = options?.requiredScopes;
+  const configuredScope = config.oauth?.scope;
+  if (
+    requiredScopes !== undefined &&
+    requiredScopes.length > 0 &&
+    configuredScope !== undefined &&
+    configuredScope !== ""
+  ) {
+    const grantedScopes = configuredScope.split(" ");
+    const missingScopes = requiredScopes.filter((s) => !grantedScopes.includes(s));
+    if (missingScopes.length > 0) {
+      throw new ConfigError(
+        `Missing required OAuth scopes: ${missingScopes.join(", ")}. Re-run "linkedctl auth setup" to configure the required scopes, then "linkedctl auth login" to re-authenticate.`,
+      );
+    }
+  }
+
   return { config, warnings };
 }
 

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -39,4 +39,5 @@ export interface ResolveOptions {
   cwd?: string | undefined;
   home?: string | undefined;
   env?: Record<string, string | undefined> | undefined;
+  requiredScopes?: string[] | undefined;
 }

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -84,7 +84,10 @@ describe("createMcpServer", () => {
         arguments: { text: "Hello LinkedIn" },
       });
 
-      expect(resolveConfig).toHaveBeenCalledWith({ profile: undefined });
+      expect(resolveConfig).toHaveBeenCalledWith({
+        profile: undefined,
+        requiredScopes: ["openid", "profile", "email", "w_member_social"],
+      });
       expect(createTextPost).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
@@ -119,7 +122,10 @@ describe("createMcpServer", () => {
         },
       });
 
-      expect(resolveConfig).toHaveBeenCalledWith({ profile: "work" });
+      expect(resolveConfig).toHaveBeenCalledWith({
+        profile: "work",
+        requiredScopes: ["openid", "profile", "email", "w_member_social"],
+      });
       expect(createTextPost).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -36,7 +36,10 @@ export function createMcpServer(): McpServer {
       },
     },
     async (args) => {
-      const { config } = await resolveConfig({ profile: args.profile });
+      const { config } = await resolveConfig({
+        profile: args.profile,
+        requiredScopes: ["openid", "profile", "email", "w_member_social"],
+      });
       // resolveConfig guarantees oauth.accessToken and apiVersion are defined
       const accessToken = config.oauth?.accessToken ?? "";
       const apiVersion = config.apiVersion ?? "";


### PR DESCRIPTION
## Summary

- Add `requiredScopes` option to `ResolveOptions` and validate configured scopes inside `resolveConfig()` — the single gate all API-making commands pass through
- Commands (`whoami`, `post create`, MCP `post_create`) now fail early with an actionable error naming missing scopes and suggesting `auth setup` + `auth login`
- Skip validation when scope field is absent (supports direct token flow via `auth token`)

## Test plan

- [x] New unit tests in `resolve.test.ts`: missing scopes throws, all present passes, absent scope skips validation
- [x] Updated existing test assertions in `whoami.test.ts`, `create.test.ts`, `server.test.ts` to verify `requiredScopes` is passed
- [x] `pnpm build` — passes
- [x] `pnpm test` — all 10 task suites pass
- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — passes
- [x] `pnpm format:check` — passes (excluding untracked `docs/scope/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)