### PR TITLE
(fix) route informational messages to stderr

### DIFF
--- a/packages/cli/src/commands/auth/login.test.ts
+++ b/packages/cli/src/commands/auth/login.test.ts
@@ -76,7 +76,7 @@ describe("auth login", () => {
     loadConfigFileSpy = vi.spyOn(core, "loadConfigFile").mockResolvedValue({ raw: undefined, path: undefined });
     saveOAuthTokensSpy = vi.spyOn(core, "saveOAuthTokens").mockResolvedValue(undefined);
     saveOAuthClientCredentialsSpy = vi.spyOn(core, "saveOAuthClientCredentials").mockResolvedValue(undefined);
-    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -63,7 +63,7 @@ export function loginCommand(): Command {
     // Check for existing refresh token and attempt refresh first
     const existingRefreshToken = config.oauth?.refreshToken;
     if (existingRefreshToken !== undefined) {
-      console.log("Attempting token refresh...");
+      console.error("Attempting token refresh...");
       const refreshConfig: OAuth2Config = {
         clientId,
         clientSecret,
@@ -83,13 +83,13 @@ export function loginCommand(): Command {
         );
         await saveOAuthClientCredentials({ clientId, clientSecret }, writeOpts);
         if (profileFlag !== undefined) {
-          console.log(`Token refreshed for profile "${profileFlag}".`);
+          console.error(`Token refreshed for profile "${profileFlag}".`);
         } else {
-          console.log("Token refreshed.");
+          console.error("Token refreshed.");
         }
         return;
       } catch {
-        console.log("Token refresh failed, starting full authorization flow...");
+        console.error("Token refresh failed, starting full authorization flow...");
       }
     }
 
@@ -115,8 +115,8 @@ export function loginCommand(): Command {
     };
 
     const authUrl = buildAuthorizationUrl(oauth2Config, state, codeChallenge);
-    console.log("Opening browser for LinkedIn authorization...");
-    console.log(`If the browser does not open, visit:\n${authUrl}`);
+    console.error("Opening browser for LinkedIn authorization...");
+    console.error(`If the browser does not open, visit:\n${authUrl}`);
     openBrowser(authUrl);
 
     try {
@@ -138,9 +138,9 @@ export function loginCommand(): Command {
       );
       await saveOAuthClientCredentials({ clientId, clientSecret }, writeOpts);
       if (profileFlag !== undefined) {
-        console.log(`Authenticated and saved to profile "${profileFlag}".`);
+        console.error(`Authenticated and saved to profile "${profileFlag}".`);
       } else {
-        console.log("Authenticated successfully.");
+        console.error("Authenticated successfully.");
       }
     } finally {
       await stop();

--- a/packages/cli/src/commands/auth/status.test.ts
+++ b/packages/cli/src/commands/auth/status.test.ts
@@ -22,9 +22,11 @@ function buildJwt(payload: Record<string, unknown>): string {
 
 describe("auth status", () => {
   let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -42,6 +44,7 @@ describe("auth status", () => {
 
     expect(consoleSpy).toHaveBeenCalledWith("Profile: default");
     expect(consoleSpy).toHaveBeenCalledWith("Status: not configured");
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Run "linkedctl auth login" to set up authentication.');
   });
 
   it("shows not configured when access token is empty", async () => {
@@ -58,6 +61,7 @@ describe("auth status", () => {
 
     expect(consoleSpy).toHaveBeenCalledWith("Profile: default");
     expect(consoleSpy).toHaveBeenCalledWith("Status: not configured");
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Run "linkedctl auth login" to set up authentication.');
   });
 
   it("shows authenticated with expiry for valid JWT token", async () => {
@@ -97,6 +101,7 @@ describe("auth status", () => {
 
     expect(consoleSpy).toHaveBeenCalledWith("Profile: default");
     expect(consoleSpy).toHaveBeenCalledWith("Status: expired");
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Run "linkedctl auth login" to re-authenticate.');
   });
 
   it("shows authenticated with unknown expiry for opaque token", async () => {

--- a/packages/cli/src/commands/auth/status.ts
+++ b/packages/cli/src/commands/auth/status.ts
@@ -39,7 +39,7 @@ export function statusCommand(): Command {
     if (config.oauth?.accessToken === undefined || config.oauth.accessToken === "") {
       console.log(`Profile: ${label}`);
       console.log("Status: not configured");
-      console.log('Run "linkedctl auth login" to set up authentication.');
+      console.error('Run "linkedctl auth login" to set up authentication.');
       return;
     }
 
@@ -56,7 +56,7 @@ export function statusCommand(): Command {
     if (expiry.isExpired) {
       console.log("Status: expired");
       console.log(`Expired: ${expiry.expiresAt.toISOString()}`);
-      console.log('Run "linkedctl auth login" to re-authenticate.');
+      console.error('Run "linkedctl auth login" to re-authenticate.');
       return;
     }
 


### PR DESCRIPTION
## Summary

- Route all progress/informational messages in `auth login` to stderr (`console.error`)
- Route suggestion messages ("Run linkedctl auth login...") in `auth status` to stderr
- Keep data output (profile name, status, expiry) on stdout in `auth status`
- Update tests to assert correct output streams

Closes #75

## Test plan

- [x] All existing unit tests pass with updated stream assertions
- [x] Build, typecheck, lint, format checks pass
- [ ] CI passes on all 3 OS matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)