### PR TITLE
(feat) add --version flag

### DIFF
--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, expect, it } from "vitest";
+import { createProgram } from "./program.js";
+
+describe("createProgram", () => {
+  it("sets version when provided", () => {
+    const program = createProgram("1.2.3");
+    expect(program.version()).toBe("1.2.3");
+  });
+
+  it("does not set version when omitted", () => {
+    const program = createProgram();
+    expect(program.version()).toBeUndefined();
+  });
+});

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -10,9 +10,12 @@ import { whoamiCommand } from "./commands/whoami.js";
 /**
  * Build and return the top-level Commander program.
  */
-export function createProgram(): Command {
+export function createProgram(version?: string): Command {
   const program = new Command("linkedctl");
   program.description("CLI for the LinkedIn API");
+  if (version !== undefined) {
+    program.version(version);
+  }
   program.option("--profile <name>", "profile to use from config file");
 
   program.addCommand(authCommand());

--- a/packages/linkedctl/src/cli.ts
+++ b/packages/linkedctl/src/cli.ts
@@ -2,11 +2,15 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { createRequire } from "node:module";
 import { Command } from "commander";
 import { createProgram } from "@linkedctl/cli";
 import { startStdioServer } from "@linkedctl/mcp/stdio";
 
-const program = createProgram();
+const require = createRequire(import.meta.url);
+const { version } = require("../package.json") as { version: string };
+
+const program = createProgram(version);
 
 const mcpCommand = new Command("mcp");
 mcpCommand.description("Start the MCP server on stdio transport");


### PR DESCRIPTION
## Summary

- Add `--version` / `-V` flag to the CLI by accepting an optional `version` parameter in `createProgram()`
- The umbrella package reads its version from `package.json` via `createRequire` and passes it to the CLI program
- Add unit tests for version behavior in `program.test.ts`

Closes #72

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (119 tests, including 2 new version tests)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm format:check` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)