### PR TITLE
(feat) add NO_COLOR and --no-color support

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,5 +2,5 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 export type { OutputFormat } from "./output/index.js";
-export { detectFormat, resolveFormat, formatJson, formatTable, formatOutput } from "./output/index.js";
+export { detectFormat, resolveFormat, formatJson, formatTable, formatOutput, isColorEnabled } from "./output/index.js";
 export { createProgram } from "./program.js";

--- a/packages/cli/src/output/color.test.ts
+++ b/packages/cli/src/output/color.test.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, expect, it } from "vitest";
+import { isColorEnabled } from "./color.js";
+
+describe("isColorEnabled", () => {
+  it("returns true when no constraints are present", () => {
+    expect(isColorEnabled({ env: {} })).toBe(true);
+  });
+
+  it("returns false when NO_COLOR env var is set to a non-empty string", () => {
+    expect(isColorEnabled({ env: { NO_COLOR: "1" } })).toBe(false);
+  });
+
+  it("returns false when NO_COLOR env var is set to an empty string", () => {
+    expect(isColorEnabled({ env: { NO_COLOR: "" } })).toBe(false);
+  });
+
+  it("returns false when noColor flag is true", () => {
+    expect(isColorEnabled({ noColor: true, env: {} })).toBe(false);
+  });
+
+  it("returns true when noColor flag is false", () => {
+    expect(isColorEnabled({ noColor: false, env: {} })).toBe(true);
+  });
+
+  it("returns false when both NO_COLOR and noColor flag are set", () => {
+    expect(isColorEnabled({ noColor: true, env: { NO_COLOR: "1" } })).toBe(false);
+  });
+
+  it("returns true when noColor is undefined and NO_COLOR is absent", () => {
+    expect(isColorEnabled({ noColor: undefined, env: {} })).toBe(true);
+  });
+
+  it("defaults to process.env when env is not provided", () => {
+    // Without explicit env, it uses process.env — which may or may not have NO_COLOR
+    const result = isColorEnabled({ noColor: false });
+    expect(typeof result).toBe("boolean");
+  });
+
+  it("returns true when called with no arguments and NO_COLOR is absent from process.env", () => {
+    // Provide explicit empty env to avoid process.env interference
+    expect(isColorEnabled({ env: {} })).toBe(true);
+  });
+});

--- a/packages/cli/src/output/color.ts
+++ b/packages/cli/src/output/color.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * Determine whether color output is enabled.
+ *
+ * Color is disabled when:
+ * - The `NO_COLOR` environment variable is set (any value, per https://no-color.org/)
+ * - The `noColor` flag is `true` (from `--no-color` CLI flag)
+ *
+ * @param options.noColor - Whether the `--no-color` CLI flag was provided
+ * @param options.env - Environment variables to check (defaults to `process.env`)
+ */
+export function isColorEnabled(options?: {
+  noColor?: boolean | undefined;
+  env?: Record<string, string | undefined> | undefined;
+}): boolean {
+  const env = options?.env ?? process.env;
+
+  if ("NO_COLOR" in env) {
+    return false;
+  }
+
+  if (options?.noColor === true) {
+    return false;
+  }
+
+  return true;
+}

--- a/packages/cli/src/output/index.ts
+++ b/packages/cli/src/output/index.ts
@@ -6,3 +6,4 @@ export { detectFormat, resolveFormat } from "./format.js";
 export { formatJson } from "./json-formatter.js";
 export { formatTable } from "./table-formatter.js";
 export { formatOutput } from "./formatter.js";
+export { isColorEnabled } from "./color.js";

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -14,6 +14,7 @@ export function createProgram(): Command {
   const program = new Command("linkedctl");
   program.description("CLI for the LinkedIn API");
   program.option("--profile <name>", "profile to use from config file");
+  program.option("--no-color", "disable color output");
 
   program.addCommand(authCommand());
   program.addCommand(postCommand());


### PR DESCRIPTION
## Summary

- Add `isColorEnabled()` utility in `@linkedctl/cli` that checks `NO_COLOR` env var (per [no-color.org](https://no-color.org/)) and `--no-color` global CLI flag
- Add `--no-color` global option to the root Commander program
- Export `isColorEnabled` from `@linkedctl/cli` for use by all commands

Closes #73

## Test plan

- [x] Unit tests for `isColorEnabled()` covering NO_COLOR env var, --no-color flag, both combined, and defaults
- [x] All 272 existing tests pass
- [x] Typecheck, lint, and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)