### PR TITLE
(feat) default --api-version in profile create

### DIFF
--- a/packages/cli/src/commands/auth/setup.ts
+++ b/packages/cli/src/commands/auth/setup.ts
@@ -7,7 +7,13 @@ import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { createInterface } from "node:readline/promises";
 import { Command } from "commander";
-import { saveOAuthClientCredentials, saveOAuthScope, saveOAuthPkce, saveApiVersion } from "@linkedctl/core";
+import {
+  saveOAuthClientCredentials,
+  saveOAuthScope,
+  saveOAuthPkce,
+  saveApiVersion,
+  DEFAULT_API_VERSION,
+} from "@linkedctl/core";
 
 import { DEFAULT_REDIRECT_PORT } from "./login.js";
 
@@ -106,7 +112,7 @@ export function setupCommand(): Command {
       const pkceAnswer = await rl.question("Is PKCE enabled for your app? [y/N] ");
       const pkce = pkceAnswer.trim().toLowerCase() === "y" || pkceAnswer.trim().toLowerCase() === "yes";
       await saveOAuthPkce(pkce, writeOpts);
-      await saveApiVersion("202501", writeOpts);
+      await saveApiVersion(DEFAULT_API_VERSION, writeOpts);
 
       if (profileFlag !== undefined) {
         process.stderr.write(`\nOAuth client credentials and scope saved to profile "${profileFlag}".\n`);

--- a/packages/cli/src/commands/profile/create.test.ts
+++ b/packages/cli/src/commands/profile/create.test.ts
@@ -48,15 +48,28 @@ describe("profile create", () => {
     vi.restoreAllMocks();
   });
 
-  it("creates a profile with access token and api version", async () => {
+  it("creates a profile with explicit api version", async () => {
     const cmd = createCommand();
-    await cmd.parseAsync(["personal", "--access-token", "tok123", "--api-version", "202501"], { from: "user" });
+    await cmd.parseAsync(["personal", "--access-token", "tok123", "--api-version", "202502"], { from: "user" });
 
     expect(loadConfigFileSpy).toHaveBeenCalledWith({ profile: "personal" });
     expect(vi.mocked(mkdir)).toHaveBeenCalledWith(join("/mock/home", ".linkedctl"), { recursive: true });
     expect(vi.mocked(writeFile)).toHaveBeenCalledWith(
       join("/mock/home", ".linkedctl", "personal.yaml"),
-      'api-version: "202501"\n',
+      'api-version: "202502"\n',
+      { mode: 0o600 },
+    );
+    expect(saveOAuthTokensSpy).toHaveBeenCalledWith({ accessToken: "tok123" }, { profile: "personal" });
+    expect(consoleSpy).toHaveBeenCalledWith('Profile "personal" created.');
+  });
+
+  it("defaults api version when not specified", async () => {
+    const cmd = createCommand();
+    await cmd.parseAsync(["personal", "--access-token", "tok123"], { from: "user" });
+
+    expect(vi.mocked(writeFile)).toHaveBeenCalledWith(
+      join("/mock/home", ".linkedctl", "personal.yaml"),
+      `api-version: "${core.DEFAULT_API_VERSION}"\n`,
       { mode: 0o600 },
     );
     expect(saveOAuthTokensSpy).toHaveBeenCalledWith({ accessToken: "tok123" }, { profile: "personal" });
@@ -70,16 +83,16 @@ describe("profile create", () => {
     });
 
     const cmd = createCommand();
-    await expect(
-      cmd.parseAsync(["personal", "--access-token", "tok", "--api-version", "v"], { from: "user" }),
-    ).rejects.toThrow(/already exists/);
+    await expect(cmd.parseAsync(["personal", "--access-token", "tok"], { from: "user" })).rejects.toThrow(
+      /already exists/,
+    );
   });
 
   it("throws for invalid profile name", async () => {
     const cmd = createCommand();
-    await expect(
-      cmd.parseAsync(["../evil", "--access-token", "tok", "--api-version", "v"], { from: "user" }),
-    ).rejects.toThrow(/Invalid profile name/);
+    await expect(cmd.parseAsync(["../evil", "--access-token", "tok"], { from: "user" })).rejects.toThrow(
+      /Invalid profile name/,
+    );
   });
 
   it("does not write files when profile already exists", async () => {
@@ -89,9 +102,7 @@ describe("profile create", () => {
     });
 
     const cmd = createCommand();
-    await expect(
-      cmd.parseAsync(["personal", "--access-token", "tok", "--api-version", "v"], { from: "user" }),
-    ).rejects.toThrow();
+    await expect(cmd.parseAsync(["personal", "--access-token", "tok"], { from: "user" })).rejects.toThrow();
 
     expect(vi.mocked(writeFile)).not.toHaveBeenCalled();
     expect(saveOAuthTokensSpy).not.toHaveBeenCalled();

--- a/packages/cli/src/commands/profile/create.ts
+++ b/packages/cli/src/commands/profile/create.ts
@@ -5,14 +5,14 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 import { writeFile, mkdir } from "node:fs/promises";
 import { Command } from "commander";
-import { loadConfigFile, isValidProfileName, saveOAuthTokens, CONFIG_DIR } from "@linkedctl/core";
+import { loadConfigFile, isValidProfileName, saveOAuthTokens, CONFIG_DIR, DEFAULT_API_VERSION } from "@linkedctl/core";
 
 export function createCommand(): Command {
   const cmd = new Command("create");
   cmd.description("Create a new profile");
   cmd.argument("<name>", "profile name");
   cmd.requiredOption("--access-token <token>", "OAuth2 access token");
-  cmd.requiredOption("--api-version <version>", "LinkedIn API version (e.g. 202501)");
+  cmd.option("--api-version <version>", "LinkedIn API version", DEFAULT_API_VERSION);
 
   cmd.action(async (name: string, opts: { accessToken: string; apiVersion: string }) => {
     if (!isValidProfileName(name)) {

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 export type { OAuthCredentials, LinkedctlConfig, ConfigResult, ResolveOptions } from "./types.js";
-export { loadConfigFile, CONFIG_DIR } from "./loader.js";
+export { loadConfigFile, CONFIG_DIR, DEFAULT_API_VERSION } from "./loader.js";
 export type { LoadResult } from "./loader.js";
 export { validateConfig, isValidProfileName } from "./validate.js";
 export type { ValidationResult } from "./validate.js";

--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -7,6 +7,7 @@ import { homedir } from "node:os";
 import { parse } from "yaml";
 
 export const CONFIG_DIR = ".linkedctl";
+export const DEFAULT_API_VERSION = "202501";
 const CONFIG_FILE = ".linkedctl.yaml";
 
 export interface LoadResult {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,7 @@
 export {
   loadConfigFile,
   CONFIG_DIR,
+  DEFAULT_API_VERSION,
   validateConfig,
   isValidProfileName,
   applyEnvOverlay,


### PR DESCRIPTION
## Summary

- Extract `DEFAULT_API_VERSION` constant (`"202501"`) in `@linkedctl/core` and export it
- Change `--api-version` from required to optional in `profile create`, defaulting to `DEFAULT_API_VERSION`
- Use the shared constant in `auth setup` too (DRY)
- Add test for default api-version behavior; update existing tests

Closes #83

## Test plan

- [x] `pnpm test` — all 264 tests pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean
- [x] Verify `profile create <name> --access-token <tok>` uses default api-version
- [x] Verify `profile create <name> --access-token <tok> --api-version 202502` overrides the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)