### PR TITLE
(fix) validate --visibility and --format option choices

### DIFF
--- a/packages/cli/src/commands/post/create.test.ts
+++ b/packages/cli/src/commands/post/create.test.ts
@@ -131,6 +131,42 @@ describe("post create", () => {
     );
   });
 
+  it("rejects invalid --visibility value", async () => {
+    const program = createProgram();
+    for (const cmd of program.commands) {
+      cmd.exitOverride();
+      for (const sub of cmd.commands) sub.exitOverride();
+    }
+
+    await expect(
+      program.parseAsync(["node", "linkedctl", "post", "create", "--text", "Hello", "--visibility", "PRIVATE"]),
+    ).rejects.toThrow(/Allowed choices are PUBLIC, CONNECTIONS/);
+  });
+
+  it("rejects invalid --format value on post create", async () => {
+    const program = createProgram();
+    for (const cmd of program.commands) {
+      cmd.exitOverride();
+      for (const sub of cmd.commands) sub.exitOverride();
+    }
+
+    await expect(
+      program.parseAsync(["node", "linkedctl", "post", "create", "--text", "Hello", "--format", "xml"]),
+    ).rejects.toThrow(/Allowed choices are json, table/);
+  });
+
+  it("rejects invalid --format value on post shorthand", async () => {
+    const program = createProgram();
+    for (const cmd of program.commands) {
+      cmd.exitOverride();
+      for (const sub of cmd.commands) sub.exitOverride();
+    }
+
+    await expect(program.parseAsync(["node", "linkedctl", "post", "Hello", "--format", "xml"])).rejects.toThrow(
+      /Allowed choices are json, table/,
+    );
+  });
+
   it("wraps API errors with actionable message", async () => {
     const { LinkedInApiError } = await import("@linkedctl/core");
     vi.mocked(coreMock.createTextPost).mockRejectedValueOnce(new LinkedInApiError("Forbidden", 403));

--- a/packages/cli/src/commands/post/create.ts
+++ b/packages/cli/src/commands/post/create.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { resolveConfig, LinkedInClient, getCurrentPersonUrn, createTextPost, LinkedInApiError } from "@linkedctl/core";
 import type { PostVisibility } from "@linkedctl/core";
 import { resolveFormat, formatOutput } from "../../output/index.js";
@@ -74,8 +74,12 @@ export function createCommand(): Command {
   const cmd = new Command("create");
   cmd.description("Create a text post on LinkedIn");
   cmd.option("--text <text>", "text content of the post");
-  cmd.option("--visibility <visibility>", "post visibility (PUBLIC or CONNECTIONS)", "PUBLIC");
-  cmd.option("--format <format>", "output format (json or table)");
+  cmd.addOption(
+    new Option("--visibility <visibility>", "post visibility (PUBLIC or CONNECTIONS)")
+      .choices(["PUBLIC", "CONNECTIONS"])
+      .default("PUBLIC"),
+  );
+  cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
 
   cmd.action(async (opts: CreateOpts, actionCmd: Command) => {
     await createPostAction(opts.text, opts, actionCmd);

--- a/packages/cli/src/commands/post/index.ts
+++ b/packages/cli/src/commands/post/index.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { createCommand, createPostAction } from "./create.js";
 
 export function postCommand(): Command {
@@ -9,7 +9,7 @@ export function postCommand(): Command {
   cmd.description("Manage LinkedIn posts");
 
   cmd.argument("[text]", "shorthand: create a post with the given text");
-  cmd.option("--format <format>", "output format (json or table)");
+  cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
 
   cmd.action(async (text: string | undefined, opts: Record<string, unknown>, actionCmd: Command) => {
     await createPostAction(text, opts, actionCmd);

--- a/packages/cli/src/commands/whoami.test.ts
+++ b/packages/cli/src/commands/whoami.test.ts
@@ -95,6 +95,15 @@ describe("whoami", () => {
     expect(resolveConfigSpy).toHaveBeenCalledWith({ profile: "work", requiredScopes: ["openid", "profile", "email"] });
   });
 
+  it("rejects invalid --format value", async () => {
+    const cmd = whoamiCommand();
+    cmd.exitOverride();
+
+    await expect(cmd.parseAsync(["--format", "xml"], { from: "user" })).rejects.toThrow(
+      /Allowed choices are json, table/,
+    );
+  });
+
   it("outputs only name, email, and picture in JSON format", async () => {
     const cmd = whoamiCommand();
     await cmd.parseAsync(["--format", "json"], { from: "user" });

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { resolveConfig, LinkedInClient, getUserInfo } from "@linkedctl/core";
 import type { OutputFormat } from "../output/index.js";
 import { resolveFormat, formatOutput } from "../output/index.js";
@@ -9,7 +9,7 @@ import { resolveFormat, formatOutput } from "../output/index.js";
 export function whoamiCommand(): Command {
   const cmd = new Command("whoami");
   cmd.description("Display the current authenticated user's profile");
-  cmd.option("--format <format>", "output format (json, table)");
+  cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
 
   cmd.action(async (opts: Record<string, unknown>, actionCmd: Command) => {
     const rootOpts = actionCmd.optsWithGlobals();


### PR DESCRIPTION
## Summary

- Use Commander's `Option.choices()` to validate `--visibility` and `--format` options across all CLI commands
- Invalid values now produce clear Commander errors listing allowed choices (e.g., `Allowed choices are PUBLIC, CONNECTIONS`)
- Affected: `post create` (visibility + format), `post` shorthand (format), `whoami` (format)

Closes #77

## Test plan

- [x] Tests verify rejection of invalid `--visibility` values (e.g., `PRIVATE`)
- [x] Tests verify rejection of invalid `--format` values (e.g., `xml`) on `post create`, `post` shorthand, and `whoami`
- [x] Existing tests for valid values continue to pass
- [x] All CI checks pass (format, typecheck, lint, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)