### PR TITLE
(fix) clarify post text argument precedence

### DIFF
--- a/packages/cli/src/commands/post/create.test.ts
+++ b/packages/cli/src/commands/post/create.test.ts
@@ -167,6 +167,30 @@ describe("post create", () => {
     );
   });
 
+  it("creates a post with positional argument on post create", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "post", "create", "Hello positional"]);
+
+    expect(coreMock.createTextPost).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        text: "Hello positional",
+      }),
+    );
+  });
+
+  it("--text takes precedence over positional argument on post create", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "post", "create", "positional", "--text", "from option"]);
+
+    expect(coreMock.createTextPost).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        text: "from option",
+      }),
+    );
+  });
+
   it("wraps API errors with actionable message", async () => {
     const { LinkedInApiError } = await import("@linkedctl/core");
     vi.mocked(coreMock.createTextPost).mockRejectedValueOnce(new LinkedInApiError("Forbidden", 403));

--- a/packages/cli/src/commands/post/create.ts
+++ b/packages/cli/src/commands/post/create.ts
@@ -15,11 +15,17 @@ interface CreateOpts {
 }
 
 /**
- * Resolve the post text from options, arguments, or stdin.
+ * Resolve the post text from --text option, positional argument, or stdin.
+ *
+ * Precedence: --text > positional argument > stdin.
  */
-async function resolveText(textOpt: string | undefined): Promise<string> {
+async function resolveText(textOpt: string | undefined, textArg: string | undefined): Promise<string> {
   if (textOpt !== undefined && textOpt !== "") {
     return textOpt;
+  }
+
+  if (textArg !== undefined && textArg !== "") {
+    return textArg;
   }
 
   if (!process.stdin.isTTY) {
@@ -35,8 +41,8 @@ async function resolveText(textOpt: string | undefined): Promise<string> {
 /**
  * Shared action handler for creating a text post.
  */
-export async function createPostAction(textOpt: string | undefined, opts: CreateOpts, cmd: Command): Promise<void> {
-  const text = await resolveText(textOpt);
+export async function createPostAction(textArg: string | undefined, opts: CreateOpts, cmd: Command): Promise<void> {
+  const text = await resolveText(opts.text, textArg);
   const globals = cmd.optsWithGlobals<{ profile?: string | undefined }>();
 
   const { config } = await resolveConfig({
@@ -72,8 +78,9 @@ export async function createPostAction(textOpt: string | undefined, opts: Create
 
 export function createCommand(): Command {
   const cmd = new Command("create");
-  cmd.description("Create a text post on LinkedIn");
-  cmd.option("--text <text>", "text content of the post");
+  cmd.description("Create a text post on LinkedIn (text: --text > positional > stdin)");
+  cmd.argument("[text]", "text content of the post");
+  cmd.option("--text <text>", "text content of the post (takes precedence over positional argument)");
   cmd.addOption(
     new Option("--visibility <visibility>", "post visibility (PUBLIC or CONNECTIONS)")
       .choices(["PUBLIC", "CONNECTIONS"])
@@ -81,8 +88,8 @@ export function createCommand(): Command {
   );
   cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
 
-  cmd.action(async (opts: CreateOpts, actionCmd: Command) => {
-    await createPostAction(opts.text, opts, actionCmd);
+  cmd.action(async (text: string | undefined, opts: CreateOpts, actionCmd: Command) => {
+    await createPostAction(text, opts, actionCmd);
   });
 
   return cmd;

--- a/packages/cli/src/commands/post/index.ts
+++ b/packages/cli/src/commands/post/index.ts
@@ -8,7 +8,7 @@ export function postCommand(): Command {
   const cmd = new Command("post");
   cmd.description("Manage LinkedIn posts");
 
-  cmd.argument("[text]", "shorthand: create a post with the given text");
+  cmd.argument("[text]", "shorthand: create a post with the given text (text > stdin)");
   cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
 
   cmd.action(async (text: string | undefined, opts: Record<string, unknown>, actionCmd: Command) => {


### PR DESCRIPTION
## Summary

- Add `[text]` positional argument to `post create` subcommand for consistency with `post` shorthand
- Update `resolveText` to enforce clear precedence: `--text` option > positional argument > stdin
- Document text resolution order in help text for both `post` and `post create`
- Add tests verifying positional argument and `--text` precedence on `post create`

Closes #80

## Test plan

- [x] `post create "hello"` uses positional text
- [x] `post create "hello" --text "world"` uses `--text` value (`"world"`)
- [x] Existing `post "hello"` shorthand still works
- [x] All 146 unit tests pass
- [x] Lint, format, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)