### PR TITLE
(fix) add actionable guidance to all error messages

### DIFF
--- a/packages/cli/src/commands/auth/callback-server.ts
+++ b/packages/cli/src/commands/auth/callback-server.ts
@@ -65,7 +65,12 @@ export async function startCallbackServer(port: number): Promise<{
     if (code === null || state === null) {
       res.writeHead(400, { "Content-Type": "text/html" });
       res.end(ERROR_HTML);
-      rejectResult(new Error("Missing code or state in callback"));
+      rejectResult(
+        new Error(
+          "Missing code or state in callback. " +
+            'The OAuth2 flow may have been interrupted. Run "linkedctl auth login" to try again.',
+        ),
+      );
       return;
     }
 

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -123,7 +123,10 @@ export function loginCommand(): Command {
       const callback = await result;
 
       if (callback.state !== state) {
-        throw new Error("OAuth2 state mismatch — possible CSRF attack");
+        throw new Error(
+          "OAuth2 state mismatch — possible CSRF attack. " +
+            'The authorization response may have been tampered with. Run "linkedctl auth login" to try again.',
+        );
       }
 
       const tokens = await exchangeAuthorizationCode(oauth2Config, callback.code, codeVerifier);

--- a/packages/cli/src/commands/auth/logout.ts
+++ b/packages/cli/src/commands/auth/logout.ts
@@ -16,7 +16,10 @@ export function logoutCommand(): Command {
     const { config } = validateConfig(raw);
 
     if (config.oauth === undefined) {
-      throw new Error("No OAuth credentials configured.");
+      throw new Error(
+        'No OAuth credentials configured. Run "linkedctl auth setup" to configure credentials, ' +
+          'or "linkedctl auth login" to authenticate.',
+      );
     }
 
     await clearOAuthTokens({ profile: profileFlag });

--- a/packages/cli/src/commands/auth/setup.ts
+++ b/packages/cli/src/commands/auth/setup.ts
@@ -65,12 +65,18 @@ export function setupCommand(): Command {
     try {
       const clientId = await rl.question("Client ID: ");
       if (clientId.trim() === "") {
-        throw new Error("Client ID cannot be empty.");
+        throw new Error(
+          "Client ID cannot be empty. " +
+            'Find your Client ID in the "Auth" tab of your app at https://www.linkedin.com/developers/apps',
+        );
       }
 
       const clientSecret = await rl.question("Client Secret: ");
       if (clientSecret.trim() === "") {
-        throw new Error("Client Secret cannot be empty.");
+        throw new Error(
+          "Client Secret cannot be empty. " +
+            'Find your Client Secret in the "Auth" tab of your app at https://www.linkedin.com/developers/apps',
+        );
       }
 
       const writeOpts = profileFlag !== undefined ? { profile: profileFlag } : undefined;
@@ -103,7 +109,11 @@ export function setupCommand(): Command {
       }
 
       if (scopes.length === 0) {
-        throw new Error("At least one LinkedIn product must be enabled for OAuth to work.");
+        throw new Error(
+          "At least one LinkedIn product must be enabled for OAuth to work. " +
+            'Enable products under the "Products" tab of your app at https://www.linkedin.com/developers/apps ' +
+            "and then re-run this setup.",
+        );
       }
 
       const scope = [...new Set(scopes)].join(" ");

--- a/packages/cli/src/commands/profile/delete.ts
+++ b/packages/cli/src/commands/profile/delete.ts
@@ -14,7 +14,7 @@ export function deleteCommand(): Command {
 
   cmd.action(async (name: string) => {
     if (!isValidProfileName(name)) {
-      throw new Error(`Invalid profile name "${name}".`);
+      throw new Error(`Invalid profile name "${name}". Names must not contain path separators or be empty.`);
     }
 
     const profilePath = join(homedir(), CONFIG_DIR, `${name}.yaml`);
@@ -23,7 +23,7 @@ export function deleteCommand(): Command {
       await unlink(profilePath);
     } catch (error: unknown) {
       if (error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT") {
-        throw new Error(`Profile "${name}" not found.`);
+        throw new Error(`Profile "${name}" not found. Run "linkedctl profile list" to see available profiles.`);
       }
       throw error;
     }

--- a/packages/cli/src/commands/profile/show.ts
+++ b/packages/cli/src/commands/profile/show.ts
@@ -18,12 +18,12 @@ export function showCommand(): Command {
 
   cmd.action(async (name: string) => {
     if (!isValidProfileName(name)) {
-      throw new Error(`Invalid profile name "${name}".`);
+      throw new Error(`Invalid profile name "${name}". Names must not contain path separators or be empty.`);
     }
 
     const { raw, path } = await loadConfigFile({ profile: name });
     if (path === undefined) {
-      throw new Error(`Profile "${name}" not found.`);
+      throw new Error(`Profile "${name}" not found. Run "linkedctl profile list" to see available profiles.`);
     }
 
     const { config } = validateConfig(raw);


### PR DESCRIPTION
## Summary

- Add what/why/how guidance to all error messages that were missing actionable next steps
- Covers `callback-server.ts`, `login.ts`, `logout.ts`, `profile/delete.ts`, `profile/show.ts`, and `auth/setup.ts`
- Aligns invalid profile name messages in `delete` and `show` with the existing pattern in `create`

Closes #81

## Test plan

- [x] All 144 unit tests pass
- [x] Formatting check passes
- [x] Lint passes
- [x] Existing test assertions still match (substring/regex patterns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)