### PR TITLE
(feat) add first-run getting-started message

### DIFF
--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -14,4 +14,12 @@ describe("createProgram", () => {
     const program = createProgram();
     expect(program.version()).toBeUndefined();
   });
+
+  it("includes getting-started hint in help output", () => {
+    const program = createProgram();
+    let helpOutput = "";
+    program.configureOutput({ writeOut: (str: string) => (helpOutput += str) });
+    program.outputHelp();
+    expect(helpOutput).toContain("Get started: linkedctl auth setup");
+  });
 });

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -26,5 +26,7 @@ export function createProgram(version?: string): Command {
   program.addCommand(profileCommand());
   program.addCommand(whoamiCommand());
 
+  program.addHelpText("after", "\nGet started: linkedctl auth setup");
+
   return program;
 }


### PR DESCRIPTION
## Summary

- Adds a "Get started: linkedctl auth setup" hint after the default help output when running `linkedctl` with no arguments
- Standard `--help` output remains unchanged and includes the hint as well

Closes #85

## Test plan

- [x] New test verifies getting-started hint appears in help output
- [x] All 145 existing tests pass
- [x] Build, typecheck, lint, and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)