### PR TITLE
(fix) display clean error messages without stack traces

### DIFF
--- a/packages/linkedctl/src/cli.ts
+++ b/packages/linkedctl/src/cli.ts
@@ -19,4 +19,10 @@ mcpCommand.action(async () => {
 });
 program.addCommand(mcpCommand);
 
-await program.parseAsync(process.argv);
+try {
+  await program.parseAsync(process.argv);
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`error: ${message}`);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary

- Wraps `program.parseAsync()` in a try-catch in the CLI entry point so command errors display as a clean `error: <message>` line instead of a raw stack trace with file paths
- Uses `process.exitCode = 1` (not `process.exit(1)`) to allow async cleanup

**Before:**
```
file:///…/packages/cli/dist/commands/post/create.js:20
    throw new Error('No text provided…');
          ^

Error: No text provided. Use --text "message", pass text as an argument, or pipe text via stdin.
    at resolveText (file:///…)
```

**After:**
```
error: No text provided. Use --text "message", pass text as an argument, or pipe text via stdin.
```

## Test plan

- [x] `linkedctl post` — clean error, exit code 1
- [x] `linkedctl post create` — clean error, exit code 1
- [x] All 147 unit tests pass
- [x] Lint, typecheck, format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)