### PR TITLE
(fix) add missing --text and --visibility options to post shorthand

### DIFF
--- a/packages/cli/src/commands/post/create.test.ts
+++ b/packages/cli/src/commands/post/create.test.ts
@@ -70,6 +70,42 @@ describe("post create", () => {
     );
   });
 
+  it("creates a post with shorthand --text option", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "post", "--text", "Hello from text option"]);
+
+    expect(coreMock.createTextPost).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        text: "Hello from text option",
+      }),
+    );
+  });
+
+  it("--text takes precedence over positional argument on post shorthand", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "post", "positional", "--text", "from option"]);
+
+    expect(coreMock.createTextPost).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        text: "from option",
+      }),
+    );
+  });
+
+  it("uses CONNECTIONS visibility on post shorthand", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "post", "--text", "Private", "--visibility", "CONNECTIONS"]);
+
+    expect(coreMock.createTextPost).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        visibility: "CONNECTIONS",
+      }),
+    );
+  });
+
   it("uses CONNECTIONS visibility when specified", async () => {
     const program = createProgram();
     await program.parseAsync([

--- a/packages/cli/src/commands/post/index.ts
+++ b/packages/cli/src/commands/post/index.ts
@@ -8,7 +8,15 @@ export function postCommand(): Command {
   const cmd = new Command("post");
   cmd.description("Manage LinkedIn posts");
 
+  cmd.enablePositionalOptions();
+
   cmd.argument("[text]", "shorthand: create a post with the given text (text > stdin)");
+  cmd.option("--text <text>", "text content of the post (takes precedence over positional argument)");
+  cmd.addOption(
+    new Option("--visibility <visibility>", "post visibility (PUBLIC or CONNECTIONS)")
+      .choices(["PUBLIC", "CONNECTIONS"])
+      .default("PUBLIC"),
+  );
   cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
 
   cmd.action(async (text: string | undefined, opts: Record<string, unknown>, actionCmd: Command) => {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -17,6 +17,7 @@ export function createProgram(version?: string): Command {
   if (version !== undefined) {
     program.version(version);
   }
+  program.enablePositionalOptions();
   program.option("--profile <name>", "profile to use from config file");
   program.option("--no-color", "disable color output");
 


### PR DESCRIPTION
## Summary

- The `post` shorthand command (`linkedctl post "text"`) only defined a positional argument and `--format`, but the no-text error message suggested `--text` which was only available on the `post create` subcommand
- Running `linkedctl post --text "msg"` gave `error: unknown option '--text'`
- Added `--text`, `--visibility`, and `enablePositionalOptions()` so the shorthand has full feature parity with `post create`, and Commander correctly scopes options between parent and subcommand

## Test plan

- [x] New tests: shorthand `--text`, shorthand text precedence, shorthand `--visibility`
- [x] All 150 existing tests pass (no regressions)
- [x] Manual verification: `linkedctl post --text "msg"` no longer errors with "unknown option"
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)