### PR TITLE
(fix) use correct LinkedIn API version 202601

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Revoke the access token server-side and clear local credentials for a profile.
 LinkedCtl stores configuration in YAML files. Each file represents a single profile:
 
 ```yaml
-api-version: "202603"
+api-version: "202601"
 oauth:
     client-id: "YOUR_CLIENT_ID"
     client-secret: "YOUR_CLIENT_SECRET"
@@ -116,7 +116,7 @@ oauth:
 
 | Key                      | Description                           |
 | ------------------------ | ------------------------------------- |
-| `api-version`            | LinkedIn API version (e.g. `202603`)  |
+| `api-version`            | LinkedIn API version (e.g. `202601`)  |
 | `oauth.client-id`        | OAuth 2.0 client ID                   |
 | `oauth.client-secret`    | OAuth 2.0 client secret               |
 | `oauth.access-token`     | OAuth 2.0 access token                |
@@ -154,7 +154,7 @@ linkedctl --profile work post "Hello from my work account!"
 Manage profiles with the `profile` command:
 
 ```sh
-linkedctl profile create work --access-token YOUR_TOKEN --api-version 202603
+linkedctl profile create work --access-token YOUR_TOKEN --api-version 202601
 linkedctl profile list
 linkedctl profile show work
 linkedctl profile delete work
@@ -185,7 +185,7 @@ linkedctl auth token --access-token YOUR_TOKEN
 | `LINKEDCTL_CLIENT_ID`     | LinkedIn OAuth 2.0 client ID                             |
 | `LINKEDCTL_CLIENT_SECRET` | LinkedIn OAuth 2.0 client secret                         |
 | `LINKEDCTL_ACCESS_TOKEN`  | Direct access token (bypasses OAuth flow)                |
-| `LINKEDCTL_API_VERSION`   | LinkedIn API version string (e.g. `202603`) **required** |
+| `LINKEDCTL_API_VERSION`   | LinkedIn API version string (e.g. `202601`) **required** |
 
 Environment variables take precedence over config file values.
 
@@ -280,7 +280,7 @@ The `--format` option defaults to `table` in a terminal and `json` when piped.
 | Option                    | Description                                    |
 | ------------------------- | ---------------------------------------------- |
 | `--access-token <token>`  | OAuth 2.0 access token (required)              |
-| `--api-version <version>` | LinkedIn API version, e.g. `202603` (required) |
+| `--api-version <version>` | LinkedIn API version, e.g. `202601` (required) |
 
 ### `whoami` -- Show Current User
 

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -63,14 +63,14 @@ You can verify your available scopes under the **Auth** tab in the **OAuth 2.0 s
 
 ## 5. Set the API Version
 
-LinkedCtl requires a LinkedIn API version to be configured. LinkedIn uses date-based version strings (e.g. `202603`). You can find the current version in the [LinkedIn API documentation](https://learn.microsoft.com/en-us/linkedin/marketing/versioning).
+LinkedCtl requires a LinkedIn API version to be configured. LinkedIn uses date-based version strings (e.g. `202601`). You can find the current version in the [LinkedIn API documentation](https://learn.microsoft.com/en-us/linkedin/marketing/versioning).
 
 There are three ways to set the API version:
 
 **Option A: Config file** — add `api-version` to your config file:
 
 ```yaml
-api-version: "202603"
+api-version: "202601"
 ```
 
 LinkedCtl searches for config files in this order: `.linkedctl.yaml` in the current directory, then `~/.linkedctl.yaml` in the home directory. When using a named profile (e.g. `--profile work`), the config is stored at `~/.linkedctl/work.yaml` instead.
@@ -78,7 +78,7 @@ LinkedCtl searches for config files in this order: `.linkedctl.yaml` in the curr
 **Option B: Environment variable**:
 
 ```sh
-export LINKEDCTL_API_VERSION=202603
+export LINKEDCTL_API_VERSION=202601
 ```
 
 When using a named profile, prefix the variable with the uppercased profile name (hyphens become underscores). For example, profile `work` reads `LINKEDCTL_WORK_API_VERSION`.
@@ -86,7 +86,7 @@ When using a named profile, prefix the variable with the uppercased profile name
 **Option C: Profile creation** — when creating a named profile, pass `--api-version`:
 
 ```sh
-linkedctl profile create myprofile --access-token YOUR_TOKEN --api-version 202603
+linkedctl profile create myprofile --access-token YOUR_TOKEN --api-version 202601
 ```
 
 > **Note:** The API version is required. If it is not set, LinkedCtl will exit with a `ConfigError` message telling you to set `LINKEDCTL_API_VERSION`, use `--api-version`, or add `api-version` to your config file.
@@ -128,7 +128,7 @@ Instead of passing flags, you can set environment variables:
 ```sh
 export LINKEDCTL_CLIENT_ID=YOUR_CLIENT_ID
 export LINKEDCTL_CLIENT_SECRET=YOUR_CLIENT_SECRET
-export LINKEDCTL_API_VERSION=202603
+export LINKEDCTL_API_VERSION=202601
 linkedctl auth login
 ```
 

--- a/packages/cli/src/commands/auth/login.test.ts
+++ b/packages/cli/src/commands/auth/login.test.ts
@@ -148,7 +148,7 @@ describe("auth login", () => {
           "token-expires-at": "2025-01-01T00:00:00.000Z",
           scope: "openid profile",
         },
-        "api-version": "202603",
+        "api-version": "202601",
       },
       path: "/some/path.yaml",
     });
@@ -184,7 +184,7 @@ describe("auth login", () => {
           "token-expires-at": "2025-01-01T00:00:00.000Z",
           scope: "openid profile",
         },
-        "api-version": "202603",
+        "api-version": "202601",
       },
       path: "/some/path.yaml",
     });
@@ -212,7 +212,7 @@ describe("auth login", () => {
           "client-secret": "profile-client-secret",
           scope: "openid profile",
         },
-        "api-version": "202603",
+        "api-version": "202601",
       },
       path: "/some/path.yaml",
     });
@@ -324,7 +324,7 @@ describe("auth login", () => {
           "client-secret": "my-secret",
           scope: "openid profile",
         },
-        "api-version": "202603",
+        "api-version": "202601",
       },
       path: "/some/path.yaml",
     });

--- a/packages/cli/src/commands/auth/logout.test.ts
+++ b/packages/cli/src/commands/auth/logout.test.ts
@@ -27,7 +27,7 @@ describe("auth logout", () => {
     vi.spyOn(core, "loadConfigFile").mockResolvedValue({
       raw: {
         oauth: { "access-token": "secret-token" },
-        "api-version": "202603",
+        "api-version": "202601",
       },
       path: "/some/path.yaml",
     });
@@ -41,7 +41,7 @@ describe("auth logout", () => {
 
   it("throws when no OAuth credentials configured", async () => {
     vi.spyOn(core, "loadConfigFile").mockResolvedValue({
-      raw: { "api-version": "202603" },
+      raw: { "api-version": "202601" },
       path: "/some/path.yaml",
     });
 

--- a/packages/cli/src/commands/auth/refresh.test.ts
+++ b/packages/cli/src/commands/auth/refresh.test.ts
@@ -35,7 +35,7 @@ describe("auth refresh", () => {
           "refresh-token": "existing-refresh-token",
           "token-expires-at": "2025-01-01T00:00:00.000Z",
         },
-        "api-version": "202603",
+        "api-version": "202601",
       },
       path: "/some/path.yaml",
     });
@@ -73,7 +73,7 @@ describe("auth refresh", () => {
           "client-secret": "csecret",
           "refresh-token": "original-refresh-token",
         },
-        "api-version": "202603",
+        "api-version": "202601",
       },
       path: "/some/path.yaml",
     });
@@ -115,7 +115,7 @@ describe("auth refresh", () => {
           "client-id": "cid",
           "client-secret": "csecret",
         },
-        "api-version": "202603",
+        "api-version": "202601",
       },
       path: "/some/path.yaml",
     });
@@ -132,7 +132,7 @@ describe("auth refresh", () => {
         oauth: {
           "access-token": "tok",
         },
-        "api-version": "202603",
+        "api-version": "202601",
       },
       path: "/some/path.yaml",
     });
@@ -150,7 +150,7 @@ describe("auth refresh", () => {
           "client-secret": "csecret",
           "refresh-token": "expired-refresh-token",
         },
-        "api-version": "202603",
+        "api-version": "202601",
       },
       path: "/some/path.yaml",
     });

--- a/packages/cli/src/commands/auth/revoke.test.ts
+++ b/packages/cli/src/commands/auth/revoke.test.ts
@@ -35,7 +35,7 @@ describe("auth revoke", () => {
           "client-id": "my-client-id",
           "client-secret": "my-client-secret",
         },
-        "api-version": "202603",
+        "api-version": "202601",
       },
       path: "/some/path.yaml",
     });
@@ -59,7 +59,7 @@ describe("auth revoke", () => {
           "client-id": "my-client-id",
           "client-secret": "my-client-secret",
         },
-        "api-version": "202603",
+        "api-version": "202601",
       },
       path: "/some/path.yaml",
     });
@@ -78,7 +78,7 @@ describe("auth revoke", () => {
         oauth: {
           "access-token": "secret-token",
         },
-        "api-version": "202603",
+        "api-version": "202601",
       },
       path: "/some/path.yaml",
     });
@@ -100,7 +100,7 @@ describe("auth revoke", () => {
           "client-id": "cid",
           "client-secret": "csecret",
         },
-        "api-version": "202603",
+        "api-version": "202601",
       },
       path: "/some/path.yaml",
     });
@@ -116,7 +116,7 @@ describe("auth revoke", () => {
 
   it("clears credentials when no OAuth section exists", async () => {
     vi.spyOn(core, "loadConfigFile").mockResolvedValue({
-      raw: { "api-version": "202603" },
+      raw: { "api-version": "202601" },
       path: "/some/path.yaml",
     });
 

--- a/packages/cli/src/commands/auth/status.test.ts
+++ b/packages/cli/src/commands/auth/status.test.ts
@@ -51,7 +51,7 @@ describe("auth status", () => {
     vi.spyOn(core, "loadConfigFile").mockResolvedValue({
       raw: {
         oauth: { "access-token": "" },
-        "api-version": "202603",
+        "api-version": "202601",
       },
       path: "/some/path.yaml",
     });
@@ -71,7 +71,7 @@ describe("auth status", () => {
     vi.spyOn(core, "loadConfigFile").mockResolvedValue({
       raw: {
         oauth: { "access-token": token },
-        "api-version": "202603",
+        "api-version": "202601",
       },
       path: "/some/path.yaml",
     });
@@ -91,7 +91,7 @@ describe("auth status", () => {
     vi.spyOn(core, "loadConfigFile").mockResolvedValue({
       raw: {
         oauth: { "access-token": token },
-        "api-version": "202603",
+        "api-version": "202601",
       },
       path: "/some/path.yaml",
     });
@@ -108,7 +108,7 @@ describe("auth status", () => {
     vi.spyOn(core, "loadConfigFile").mockResolvedValue({
       raw: {
         oauth: { "access-token": "AQVh7cKZopaque" },
-        "api-version": "202603",
+        "api-version": "202601",
       },
       path: "/some/path.yaml",
     });

--- a/packages/cli/src/commands/post/create.test.ts
+++ b/packages/cli/src/commands/post/create.test.ts
@@ -11,7 +11,7 @@ vi.mock("@linkedctl/core", async (importOriginal) => {
     resolveConfig: vi.fn().mockResolvedValue({
       config: {
         oauth: { accessToken: "test-token" },
-        apiVersion: "202603",
+        apiVersion: "202601",
       },
       warnings: [],
     }),
@@ -31,7 +31,7 @@ describe("post create", () => {
     vi.mocked(coreMock.resolveConfig).mockResolvedValue({
       config: {
         oauth: { accessToken: "test-token" },
-        apiVersion: "202603",
+        apiVersion: "202601",
       },
       warnings: [],
     });

--- a/packages/cli/src/commands/profile/create.test.ts
+++ b/packages/cli/src/commands/profile/create.test.ts
@@ -78,7 +78,7 @@ describe("profile create", () => {
 
   it("throws when profile already exists", async () => {
     loadConfigFileSpy.mockResolvedValue({
-      raw: { "api-version": "202603" },
+      raw: { "api-version": "202601" },
       path: "/mock/home/.linkedctl/personal.yaml",
     });
 
@@ -97,7 +97,7 @@ describe("profile create", () => {
 
   it("does not write files when profile already exists", async () => {
     loadConfigFileSpy.mockResolvedValue({
-      raw: { "api-version": "202603" },
+      raw: { "api-version": "202601" },
       path: "/mock/home/.linkedctl/personal.yaml",
     });
 

--- a/packages/cli/src/commands/profile/show.test.ts
+++ b/packages/cli/src/commands/profile/show.test.ts
@@ -28,7 +28,7 @@ describe("profile show", () => {
     loadConfigFileSpy.mockResolvedValue({
       raw: {
         oauth: { "access-token": "abcdefghijklmnop" },
-        "api-version": "202603",
+        "api-version": "202601",
       },
       path: "/mock/home/.linkedctl/personal.yaml",
     });
@@ -38,7 +38,7 @@ describe("profile show", () => {
 
     expect(consoleSpy).toHaveBeenCalledWith("Profile: personal");
     expect(consoleSpy).toHaveBeenCalledWith("  access-token: abcd****mnop");
-    expect(consoleSpy).toHaveBeenCalledWith("  api-version: 202603");
+    expect(consoleSpy).toHaveBeenCalledWith("  api-version: 202601");
   });
 
   it("shows all redacted oauth fields when present", async () => {
@@ -51,7 +51,7 @@ describe("profile show", () => {
           "refresh-token": "refreshrefreshrefresh",
           "token-expires-at": "2099-12-31T23:59:59Z",
         },
-        "api-version": "202603",
+        "api-version": "202601",
       },
       path: "/mock/home/.linkedctl/work.yaml",
     });
@@ -65,14 +65,14 @@ describe("profile show", () => {
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("  access-token: toke****oken"));
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("  refresh-token: refr****resh"));
     expect(consoleSpy).toHaveBeenCalledWith("  token-expires-at: 2099-12-31T23:59:59Z");
-    expect(consoleSpy).toHaveBeenCalledWith("  api-version: 202603");
+    expect(consoleSpy).toHaveBeenCalledWith("  api-version: 202601");
   });
 
   it("shows short secrets as fully redacted", async () => {
     loadConfigFileSpy.mockResolvedValue({
       raw: {
         oauth: { "access-token": "short" },
-        "api-version": "202603",
+        "api-version": "202601",
       },
       path: "/mock/home/.linkedctl/personal.yaml",
     });

--- a/packages/cli/src/commands/whoami.test.ts
+++ b/packages/cli/src/commands/whoami.test.ts
@@ -30,7 +30,7 @@ describe("whoami", () => {
     resolveConfigSpy = vi.spyOn(core, "resolveConfig").mockResolvedValue({
       config: {
         oauth: { accessToken: "test-token" },
-        apiVersion: "202603",
+        apiVersion: "202601",
       },
       warnings: [],
     });

--- a/packages/core/src/config/env.test.ts
+++ b/packages/core/src/config/env.test.ts
@@ -6,7 +6,7 @@ import { applyEnvOverlay } from "./env.js";
 
 describe("applyEnvOverlay", () => {
   it("returns config unchanged when no env vars are set", () => {
-    const config = { apiVersion: "202603", oauth: { accessToken: "tok" } };
+    const config = { apiVersion: "202601", oauth: { accessToken: "tok" } };
     const result = applyEnvOverlay(config, { env: {} });
     expect(result).toEqual(config);
   });
@@ -20,7 +20,7 @@ describe("applyEnvOverlay", () => {
   });
 
   it("overlays api-version from env", () => {
-    const config = { apiVersion: "202603" };
+    const config = { apiVersion: "202601" };
     const result = applyEnvOverlay(config, {
       env: { LINKEDCTL_API_VERSION: "202502" },
     });
@@ -57,7 +57,7 @@ describe("applyEnvOverlay", () => {
 
   it("preserves file values when env vars are not set", () => {
     const config = {
-      apiVersion: "202603",
+      apiVersion: "202601",
       oauth: { accessToken: "file-tok", clientId: "file-cid" },
     };
     const result = applyEnvOverlay(config, {
@@ -65,7 +65,7 @@ describe("applyEnvOverlay", () => {
     });
     expect(result.oauth?.accessToken).toBe("env-tok");
     expect(result.oauth?.clientId).toBe("file-cid");
-    expect(result.apiVersion).toBe("202603");
+    expect(result.apiVersion).toBe("202601");
   });
 
   it("overlays scope from env", () => {
@@ -77,11 +77,11 @@ describe("applyEnvOverlay", () => {
   });
 
   it("does not mutate the original config", () => {
-    const config = { apiVersion: "202603", oauth: { accessToken: "original" } };
+    const config = { apiVersion: "202601", oauth: { accessToken: "original" } };
     applyEnvOverlay(config, {
       env: { LINKEDCTL_ACCESS_TOKEN: "new", LINKEDCTL_API_VERSION: "202502" },
     });
-    expect(config.apiVersion).toBe("202603");
+    expect(config.apiVersion).toBe("202601");
     expect(config.oauth.accessToken).toBe("original");
   });
 });

--- a/packages/core/src/config/loader.test.ts
+++ b/packages/core/src/config/loader.test.ts
@@ -38,11 +38,11 @@ describe("loadConfigFile", () => {
   it("loads profile-specific file from ~/.linkedctl/{profile}.yaml", async () => {
     const profileDir = join(dir, CONFIG_DIR);
     await mkdir(profileDir, { recursive: true });
-    await writeFile(join(profileDir, "work.yaml"), 'api-version: "202603"\n');
+    await writeFile(join(profileDir, "work.yaml"), 'api-version: "202601"\n');
 
     const result = await loadConfigFile({ profile: "work", home: dir });
     expect(result.path).toBe(join(profileDir, "work.yaml"));
-    expect(result.raw).toEqual({ "api-version": "202603" });
+    expect(result.raw).toEqual({ "api-version": "202601" });
   });
 
   it("loads CWD .linkedctl.yaml before home", async () => {
@@ -93,7 +93,7 @@ describe("loadConfigFile", () => {
   client-id: "cid"
   client-secret: "csecret"
   access-token: "tok"
-api-version: "202603"
+api-version: "202601"
 `,
     );
 
@@ -104,7 +104,7 @@ api-version: "202603"
         "client-secret": "csecret",
         "access-token": "tok",
       },
-      "api-version": "202603",
+      "api-version": "202601",
     });
   });
 });

--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -7,7 +7,7 @@ import { homedir } from "node:os";
 import { parse } from "yaml";
 
 export const CONFIG_DIR = ".linkedctl";
-export const DEFAULT_API_VERSION = "202603";
+export const DEFAULT_API_VERSION = "202601";
 const CONFIG_FILE = ".linkedctl.yaml";
 
 export interface LoadResult {

--- a/packages/core/src/config/resolve.test.ts
+++ b/packages/core/src/config/resolve.test.ts
@@ -29,13 +29,13 @@ describe("resolveConfig", () => {
       join(dir, ".linkedctl.yaml"),
       `oauth:
   access-token: "my-token"
-api-version: "202603"
+api-version: "202601"
 `,
     );
 
     const { config, warnings } = await resolveConfig({ home: dir, cwd: dir, env: {} });
     expect(config.oauth?.accessToken).toBe("my-token");
-    expect(config.apiVersion).toBe("202603");
+    expect(config.apiVersion).toBe("202601");
     expect(warnings).toEqual([]);
   });
 
@@ -48,7 +48,7 @@ api-version: "202603"
       join(cwd, ".linkedctl.yaml"),
       `oauth:
   access-token: "cwd-token"
-api-version: "202603"
+api-version: "202601"
 `,
     );
 
@@ -63,7 +63,7 @@ api-version: "202603"
       join(profileDir, "work.yaml"),
       `oauth:
   access-token: "work-token"
-api-version: "202603"
+api-version: "202601"
 `,
     );
 
@@ -77,7 +77,7 @@ api-version: "202603"
       join(dir, ".linkedctl.yaml"),
       `oauth:
   access-token: "file-token"
-api-version: "202603"
+api-version: "202601"
 `,
     );
 
@@ -97,7 +97,7 @@ api-version: "202603"
       join(profileDir, "work.yaml"),
       `oauth:
   access-token: "file-token"
-api-version: "202603"
+api-version: "202601"
 `,
     );
 
@@ -111,7 +111,7 @@ api-version: "202603"
 
   it("throws ConfigError when access token is missing", async () => {
     await mkdir(dir, { recursive: true });
-    await writeFile(join(dir, ".linkedctl.yaml"), 'api-version: "202603"\n');
+    await writeFile(join(dir, ".linkedctl.yaml"), 'api-version: "202601"\n');
 
     await expect(resolveConfig({ home: dir, cwd: dir, env: {} })).rejects.toThrow(ConfigError);
     await expect(resolveConfig({ home: dir, cwd: dir, env: {} })).rejects.toThrow(/No access token configured/);
@@ -141,10 +141,10 @@ api-version: "202603"
     const { config } = await resolveConfig({
       home: dir,
       cwd: dir,
-      env: { LINKEDCTL_ACCESS_TOKEN: "env-tok", LINKEDCTL_API_VERSION: "202603" },
+      env: { LINKEDCTL_ACCESS_TOKEN: "env-tok", LINKEDCTL_API_VERSION: "202601" },
     });
     expect(config.oauth?.accessToken).toBe("env-tok");
-    expect(config.apiVersion).toBe("202603");
+    expect(config.apiVersion).toBe("202601");
   });
 
   it("throws ConfigError when required scopes are missing", async () => {
@@ -154,7 +154,7 @@ api-version: "202603"
       `oauth:
   access-token: "tok"
   scope: "openid profile"
-api-version: "202603"
+api-version: "202601"
 `,
     );
 
@@ -170,7 +170,7 @@ api-version: "202603"
       `oauth:
   access-token: "tok"
   scope: "openid profile email"
-api-version: "202603"
+api-version: "202601"
 `,
     );
 
@@ -189,7 +189,7 @@ api-version: "202603"
       join(dir, ".linkedctl.yaml"),
       `oauth:
   access-token: "tok"
-api-version: "202603"
+api-version: "202601"
 `,
     );
 
@@ -208,7 +208,7 @@ api-version: "202603"
       join(dir, ".linkedctl.yaml"),
       `oauth:
   access-token: "tok"
-api-version: "202603"
+api-version: "202601"
 unknown-field: "val"
 `,
     );
@@ -223,7 +223,7 @@ unknown-field: "val"
       join(dir, ".linkedctl.yaml"),
       `oauth:
   access-token: ""
-api-version: "202603"
+api-version: "202601"
 `,
     );
 

--- a/packages/core/src/config/validate.test.ts
+++ b/packages/core/src/config/validate.test.ts
@@ -29,20 +29,20 @@ describe("validateConfig", () => {
   });
 
   it("validates api-version as string", () => {
-    const result = validateConfig({ "api-version": "202603" });
-    expect(result.config.apiVersion).toBe("202603");
+    const result = validateConfig({ "api-version": "202601" });
+    expect(result.config.apiVersion).toBe("202601");
     expect(result.errors).toEqual([]);
   });
 
   it("errors when api-version is not a string", () => {
-    const result = validateConfig({ "api-version": 202603 });
+    const result = validateConfig({ "api-version": 202601 });
     expect(result.errors).toEqual([expect.stringContaining('"api-version" must be a string')]);
   });
 
   it("warns on unknown top-level keys", () => {
-    const result = validateConfig({ "unknown-key": "value", "api-version": "202603" });
+    const result = validateConfig({ "unknown-key": "value", "api-version": "202601" });
     expect(result.warnings).toEqual([expect.stringContaining('"unknown-key"')]);
-    expect(result.config.apiVersion).toBe("202603");
+    expect(result.config.apiVersion).toBe("202601");
   });
 
   it("validates oauth section with all fields", () => {

--- a/packages/core/src/config/writer.test.ts
+++ b/packages/core/src/config/writer.test.ts
@@ -51,7 +51,7 @@ describe("saveOAuthTokens", () => {
       `oauth:
   client-id: "cid"
   client-secret: "csecret"
-api-version: "202603"
+api-version: "202601"
 `,
     );
 
@@ -61,7 +61,7 @@ api-version: "202603"
     const parsed = parse(content) as Record<string, unknown>;
     expect((parsed["oauth"] as Record<string, unknown>)["client-id"]).toBe("cid");
     expect((parsed["oauth"] as Record<string, unknown>)["access-token"]).toBe("new-tok");
-    expect(parsed["api-version"]).toBe("202603");
+    expect(parsed["api-version"]).toBe("202601");
   });
 
   it("writes to profile-specific path", async () => {
@@ -174,11 +174,11 @@ describe("saveApiVersion", () => {
   });
 
   it("creates config file with api-version", async () => {
-    await saveApiVersion("202603", { home: dir, cwd: dir });
+    await saveApiVersion("202601", { home: dir, cwd: dir });
 
     const content = await readFile(join(dir, ".linkedctl.yaml"), "utf-8");
     const parsed = parse(content) as Record<string, unknown>;
-    expect(parsed["api-version"]).toBe("202603");
+    expect(parsed["api-version"]).toBe("202601");
   });
 
   it("preserves existing fields when saving api-version", async () => {
@@ -191,11 +191,11 @@ describe("saveApiVersion", () => {
 `,
     );
 
-    await saveApiVersion("202603", { home: dir, cwd: dir });
+    await saveApiVersion("202601", { home: dir, cwd: dir });
 
     const content = await readFile(join(dir, ".linkedctl.yaml"), "utf-8");
     const parsed = parse(content) as Record<string, unknown>;
-    expect(parsed["api-version"]).toBe("202603");
+    expect(parsed["api-version"]).toBe("202601");
     expect((parsed["oauth"] as Record<string, unknown>)["client-id"]).toBe("cid");
   });
 });
@@ -221,7 +221,7 @@ describe("clearOAuthTokens", () => {
   access-token: "tok"
   refresh-token: "rtok"
   token-expires-at: "2026-05-01T00:00:00Z"
-api-version: "202603"
+api-version: "202601"
 `,
     );
 
@@ -235,18 +235,18 @@ api-version: "202603"
     expect(oauth["access-token"]).toBeUndefined();
     expect(oauth["refresh-token"]).toBeUndefined();
     expect(oauth["token-expires-at"]).toBeUndefined();
-    expect(parsed["api-version"]).toBe("202603");
+    expect(parsed["api-version"]).toBe("202601");
   });
 
   it("handles config with no oauth section", async () => {
     await mkdir(dir, { recursive: true });
-    await writeFile(join(dir, ".linkedctl.yaml"), 'api-version: "202603"\n');
+    await writeFile(join(dir, ".linkedctl.yaml"), 'api-version: "202601"\n');
 
     await clearOAuthTokens({ home: dir, cwd: dir });
 
     const content = await readFile(join(dir, ".linkedctl.yaml"), "utf-8");
     const parsed = parse(content) as Record<string, unknown>;
-    expect(parsed["api-version"]).toBe("202603");
+    expect(parsed["api-version"]).toBe("202601");
   });
 
   it("clears tokens from profile-specific file", async () => {

--- a/packages/core/src/http/errors.test.ts
+++ b/packages/core/src/http/errors.test.ts
@@ -73,25 +73,25 @@ describe("LinkedInRateLimitError", () => {
 
 describe("LinkedInUpgradeRequiredError", () => {
   it("has status 426 and correct name", () => {
-    const error = new LinkedInUpgradeRequiredError("202603");
+    const error = new LinkedInUpgradeRequiredError("202601");
     expect(error.status).toBe(426);
     expect(error.name).toBe("LinkedInUpgradeRequiredError");
   });
 
   it("includes api version in message", () => {
-    const error = new LinkedInUpgradeRequiredError("202603");
-    expect(error.message).toContain("202603");
+    const error = new LinkedInUpgradeRequiredError("202601");
+    expect(error.message).toContain("202601");
     expect(error.message).toContain("no longer supported");
   });
 
   it("is an instance of LinkedInApiError", () => {
-    const error = new LinkedInUpgradeRequiredError("202603");
+    const error = new LinkedInUpgradeRequiredError("202601");
     expect(error).toBeInstanceOf(LinkedInApiError);
   });
 
   it("stores response body", () => {
     const body = { message: "Upgrade Required" };
-    const error = new LinkedInUpgradeRequiredError("202603", body);
+    const error = new LinkedInUpgradeRequiredError("202601", body);
     expect(error.responseBody).toEqual(body);
   });
 });

--- a/packages/core/src/http/linkedin-client.test.ts
+++ b/packages/core/src/http/linkedin-client.test.ts
@@ -31,7 +31,7 @@ function emptyResponse(status: number): Response {
 
 const CLIENT_OPTIONS = {
   accessToken: "test-token",
-  apiVersion: "202603",
+  apiVersion: "202601",
   userAgent: "test-agent",
 } as const;
 
@@ -64,7 +64,7 @@ describe("LinkedInClient", () => {
       const headers = init.headers;
 
       expect(headers.get("Authorization")).toBe("Bearer test-token");
-      expect(headers.get("LinkedIn-Version")).toBe("202603");
+      expect(headers.get("LinkedIn-Version")).toBe("202601");
       expect(headers.get("X-Restli-Protocol-Version")).toBe("2.0.0");
       expect(headers.get("User-Agent")).toBe("test-agent");
     });
@@ -74,7 +74,7 @@ describe("LinkedInClient", () => {
 
       const client = new LinkedInClient({
         accessToken: "token",
-        apiVersion: "202603",
+        apiVersion: "202601",
       });
       await client.request("/test");
 
@@ -195,7 +195,7 @@ describe("LinkedInClient", () => {
       const client = new LinkedInClient(CLIENT_OPTIONS);
 
       await expect(client.request("/v2/me")).rejects.toThrow(LinkedInUpgradeRequiredError);
-      await expect(client.request("/v2/me")).rejects.toThrow(/202603/);
+      await expect(client.request("/v2/me")).rejects.toThrow(/202601/);
     });
 
     it("does not retry on 426", async () => {

--- a/packages/core/src/http/linkedin-client.ts
+++ b/packages/core/src/http/linkedin-client.ts
@@ -18,7 +18,7 @@ const BACKOFF_MAX_MS = 30_000;
 export interface LinkedInClientOptions {
   /** OAuth2 access token. */
   accessToken: string;
-  /** LinkedIn API version identifier (e.g. "202603"). */
+  /** LinkedIn API version identifier (e.g. "202601"). */
   apiVersion: string;
   /** Base URL for the LinkedIn API. */
   baseUrl?: string | undefined;

--- a/packages/core/src/userinfo/userinfo.test.ts
+++ b/packages/core/src/userinfo/userinfo.test.ts
@@ -38,7 +38,7 @@ describe("getUserInfo", () => {
   it("calls the /v2/userinfo endpoint and returns the response", async () => {
     fetchSpy.mockResolvedValueOnce(jsonResponse(SAMPLE_USERINFO));
 
-    const client = new LinkedInClient({ accessToken: "test-token", apiVersion: "202603" });
+    const client = new LinkedInClient({ accessToken: "test-token", apiVersion: "202601" });
     const result = await getUserInfo(client);
 
     expect(result).toEqual(SAMPLE_USERINFO);
@@ -50,7 +50,7 @@ describe("getUserInfo", () => {
     const withLocale = { ...SAMPLE_USERINFO, locale: { country: "US", language: "en" } };
     fetchSpy.mockResolvedValueOnce(jsonResponse(withLocale));
 
-    const client = new LinkedInClient({ accessToken: "test-token", apiVersion: "202603" });
+    const client = new LinkedInClient({ accessToken: "test-token", apiVersion: "202601" });
     const result = await getUserInfo(client);
 
     expect(result.locale).toEqual({ country: "US", language: "en" });


### PR DESCRIPTION
## Summary

- Fix default API version from `202603` (non-existent) to `202601` (latest supported per [LinkedIn API docs](https://learn.microsoft.com/en-us/linkedin/marketing/versioning))
- LinkedIn API versions are specific monthly releases; only released versions are accepted

## Test plan

- [x] All 315 unit tests pass
- [x] Build succeeds
- [x] Zero remaining references to `202603`

🤖 Generated with [Claude Code](https://claude.com/claude-code)