### PR TITLE
(feat) add glama.json for Glama AI marketplace listing

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["alexey-pelykh"]
+}


### PR DESCRIPTION
## Summary

- Adds `glama.json` to register LinkedCtl's MCP server on the [Glama AI marketplace](https://glama.ai/mcp/servers)
- Follows the Glama schema (`https://glama.ai/mcp/schemas/server.json`) with `alexey-pelykh` as maintainer
- Modeled after QontoCtl's reference implementation

Closes #107

## Test plan

- [x] Verify `glama.json` validates against the Glama schema
- [x] Verify Prettier formatting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)