### PR TITLE
(docs) add MCP client installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,12 @@ See the [OAuth Setup Guide](https://github.com/alexey-pelykh/linkedctl/blob/main
 
 ## MCP Integration
 
-### Claude Code
+### MCP Client Configuration
 
-```sh
-claude mcp add linkedctl -- npx linkedctl mcp
-```
+<details>
+<summary><b>Claude Desktop</b></summary>
 
-### Claude Desktop
-
-Add to `claude_desktop_config.json`:
+Add to your Claude Desktop configuration (`claude_desktop_config.json`):
 
 ```json
 {
@@ -67,6 +64,53 @@ Add to `claude_desktop_config.json`:
     }
 }
 ```
+
+</details>
+
+<details>
+<summary><b>Claude Code</b></summary>
+
+```sh
+claude mcp add linkedctl -- npx linkedctl mcp
+```
+
+</details>
+
+<details>
+<summary><b>Cursor</b></summary>
+
+Add to `.cursor/mcp.json` in your project root:
+
+```json
+{
+    "mcpServers": {
+        "linkedctl": {
+            "command": "npx",
+            "args": ["linkedctl", "mcp"]
+        }
+    }
+}
+```
+
+</details>
+
+<details>
+<summary><b>Windsurf</b></summary>
+
+Add to `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+    "mcpServers": {
+        "linkedctl": {
+            "command": "npx",
+            "args": ["linkedctl", "mcp"]
+        }
+    }
+}
+```
+
+</details>
 
 ### Available Tools
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -16,6 +16,59 @@ This package provides an MCP server that exposes LinkedIn API operations as tool
 
 For full MCP integration documentation and available tools, see the [main project](https://github.com/alexey-pelykh/linkedctl).
 
+> **Note:** For end-user usage with Claude Desktop or other MCP clients, install the [`linkedctl`](https://www.npmjs.com/package/linkedctl) umbrella package instead. This package is for programmatic access to the MCP server.
+
+## Usage with Claude Desktop
+
+Add to your Claude Desktop configuration (`claude_desktop_config.json`):
+
+```json
+{
+    "mcpServers": {
+        "linkedctl": {
+            "command": "npx",
+            "args": ["linkedctl", "mcp"]
+        }
+    }
+}
+```
+
+## Usage with Claude Code
+
+```sh
+claude mcp add linkedctl -- npx linkedctl mcp
+```
+
+## Usage with Cursor
+
+Add to `.cursor/mcp.json` in your project root:
+
+```json
+{
+    "mcpServers": {
+        "linkedctl": {
+            "command": "npx",
+            "args": ["linkedctl", "mcp"]
+        }
+    }
+}
+```
+
+## Usage with Windsurf
+
+Add to `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+    "mcpServers": {
+        "linkedctl": {
+            "command": "npx",
+            "args": ["linkedctl", "mcp"]
+        }
+    }
+}
+```
+
 ## License
 
 [AGPL-3.0-only](https://www.gnu.org/licenses/agpl-3.0.txt)


### PR DESCRIPTION
## Summary

- Add Cursor and Windsurf MCP configuration to the main README alongside existing Claude Desktop and Claude Code sections, using collapsible `<details>` format
- Add all four MCP client configurations (Claude Desktop, Claude Code, Cursor, Windsurf) to the `@linkedctl/mcp` package README
- Add a note directing end-users to the `linkedctl` umbrella package

Closes #108

## Test plan

- [ ] Verify collapsible sections render correctly on GitHub
- [ ] Verify JSON configuration snippets are syntactically valid
- [ ] Verify Prettier formatting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)