### PR TITLE
(fix) accept case-insensitive --visibility values

### DIFF
--- a/packages/cli/src/commands/post/create.test.ts
+++ b/packages/cli/src/commands/post/create.test.ts
@@ -167,6 +167,42 @@ describe("post create", () => {
     );
   });
 
+  it("accepts lowercase --visibility value and normalizes to uppercase", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "post", "create", "--text", "Hello", "--visibility", "connections"]);
+
+    expect(coreMock.createTextPost).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        visibility: "CONNECTIONS",
+      }),
+    );
+  });
+
+  it("accepts mixed-case --visibility value and normalizes to uppercase", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "post", "create", "--text", "Hello", "--visibility", "Public"]);
+
+    expect(coreMock.createTextPost).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        visibility: "PUBLIC",
+      }),
+    );
+  });
+
+  it("accepts lowercase --visibility on post shorthand", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "post", "--text", "Hello", "--visibility", "public"]);
+
+    expect(coreMock.createTextPost).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        visibility: "PUBLIC",
+      }),
+    );
+  });
+
   it("rejects invalid --visibility value", async () => {
     const program = createProgram();
     for (const cmd of program.commands) {

--- a/packages/cli/src/commands/post/create.ts
+++ b/packages/cli/src/commands/post/create.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { Command, Option } from "commander";
+import { Command, InvalidArgumentError, Option } from "commander";
 import { resolveConfig, LinkedInClient, getCurrentPersonUrn, createTextPost, LinkedInApiError } from "@linkedctl/core";
 import type { PostVisibility } from "@linkedctl/core";
 import { resolveFormat, formatOutput } from "../../output/index.js";
@@ -84,6 +84,13 @@ export function createCommand(): Command {
   cmd.addOption(
     new Option("--visibility <visibility>", "post visibility (PUBLIC or CONNECTIONS)")
       .choices(["PUBLIC", "CONNECTIONS"])
+      .argParser((v: string) => {
+        const normalized = v.toUpperCase();
+        if (!["PUBLIC", "CONNECTIONS"].includes(normalized)) {
+          throw new InvalidArgumentError("Allowed choices are PUBLIC, CONNECTIONS.");
+        }
+        return normalized;
+      })
       .default("PUBLIC"),
   );
   cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));

--- a/packages/cli/src/commands/post/index.ts
+++ b/packages/cli/src/commands/post/index.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { Command, Option } from "commander";
+import { Command, InvalidArgumentError, Option } from "commander";
 import { createCommand, createPostAction } from "./create.js";
 
 export function postCommand(): Command {
@@ -15,6 +15,13 @@ export function postCommand(): Command {
   cmd.addOption(
     new Option("--visibility <visibility>", "post visibility (PUBLIC or CONNECTIONS)")
       .choices(["PUBLIC", "CONNECTIONS"])
+      .argParser((v: string) => {
+        const normalized = v.toUpperCase();
+        if (!["PUBLIC", "CONNECTIONS"].includes(normalized)) {
+          throw new InvalidArgumentError("Allowed choices are PUBLIC, CONNECTIONS.");
+        }
+        return normalized;
+      })
       .default("PUBLIC"),
   );
   cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));


### PR DESCRIPTION
## Summary

- Normalize `--visibility` input to uppercase via custom `argParser` so that `public`, `Public`, and `PUBLIC` all resolve correctly
- Applies to both `post create` subcommand and the `post` shorthand
- Adds 3 tests covering lowercase, mixed-case, and shorthand paths

Closes #100

## Test plan

- [x] Existing tests pass (153/153)
- [x] New tests verify lowercase `connections` → `CONNECTIONS`
- [x] New tests verify mixed-case `Public` → `PUBLIC`
- [x] New tests verify shorthand `--visibility public` → `PUBLIC`
- [x] Invalid values (e.g. `PRIVATE`) still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)