### PR TITLE
(feat) add server.json for MCP Registry listing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,13 @@ jobs:
             exit 1
           fi
           pnpm -r exec npm version "$VERSION" --no-git-tag-version --allow-same-version
+          VERSION="$VERSION" node -e "
+            const fs = require('fs');
+            const s = JSON.parse(fs.readFileSync('server.json', 'utf8'));
+            s.version = process.env.VERSION;
+            s.packages.forEach(p => { p.version = process.env.VERSION; });
+            fs.writeFileSync('server.json', JSON.stringify(s, null, 2) + '\n');
+          "
 
       - run: pnpm build
 

--- a/server.json
+++ b/server.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.alexey-pelykh/linkedctl",
+  "description": "CLI and MCP server for the LinkedIn API",
+  "repository": {
+    "url": "https://github.com/alexey-pelykh/linkedctl",
+    "source": "github"
+  },
+  "version": "0.0.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "linkedctl",
+      "version": "0.0.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        }
+      ],
+      "environmentVariables": [
+        {
+          "name": "LINKEDCTL_ACCESS_TOKEN",
+          "description": "LinkedIn OAuth2 access token",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "LINKEDCTL_CLIENT_ID",
+          "description": "LinkedIn OAuth2 client ID",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "LINKEDCTL_CLIENT_SECRET",
+          "description": "LinkedIn OAuth2 client secret",
+          "isRequired": false,
+          "isSecret": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `server.json` at repo root following the [MCP Registry schema](https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json) to make LinkedCtl's MCP server discoverable through the registry
- Configure npm package `linkedctl` with stdio transport and `mcp` subcommand as package argument
- Document OAuth2 environment variables (`LINKEDCTL_ACCESS_TOKEN`, `LINKEDCTL_CLIENT_ID`, `LINKEDCTL_CLIENT_SECRET`)
- Update release workflow to stamp `server.json` version alongside `package.json` versions

## Test plan

- [x] `server.json` validates as well-formed JSON
- [x] All schema constraints verified (name pattern, description length, required fields)
- [x] Prettier formatting passes
- [x] Build, lint, and all 315 unit tests pass
- [x] Release workflow version stamping logic verified

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)