### PR TITLE
(ux) MCP error messages should not reference CLI commands

### DIFF
--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -79,7 +79,7 @@ export function createMcpServer(): McpServer {
           content: [
             {
               type: "text" as const,
-              text: `Profile: ${label}\nStatus: not configured\nRun "linkedctl auth login" to set up authentication.`,
+              text: `Profile: ${label}\nStatus: not configured\nConfigure OAuth credentials in your LinkedCtl config file to set up authentication.`,
             },
           ],
         };
@@ -103,7 +103,7 @@ export function createMcpServer(): McpServer {
           content: [
             {
               type: "text" as const,
-              text: `Profile: ${label}\nStatus: expired\nExpired: ${expiry.expiresAt.toISOString()}\nRun "linkedctl auth login" to re-authenticate.`,
+              text: `Profile: ${label}\nStatus: expired\nExpired: ${expiry.expiresAt.toISOString()}\nConfigure OAuth credentials in your LinkedCtl config file to re-authenticate.`,
             },
           ],
         };


### PR DESCRIPTION
## Summary

- Replace `Run "linkedctl auth login"` CLI command references in MCP `auth_status` tool responses with channel-appropriate config file guidance
- "not configured" status now says: "Configure OAuth credentials in your LinkedCtl config file to set up authentication."
- "expired" status now says: "Configure OAuth credentials in your LinkedCtl config file to re-authenticate."

Closes #99

## Test plan

- [x] All 12 existing MCP server tests pass (no test changes needed — assertions use `stringContaining` on status text, not guidance text)
- [x] Build, typecheck, lint all pass
- [x] Verified no remaining `linkedctl` CLI command references in MCP error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)