### PR TITLE
(ux) make profile create work without --access-token

### DIFF
--- a/packages/cli/src/commands/profile/create.test.ts
+++ b/packages/cli/src/commands/profile/create.test.ts
@@ -76,6 +76,21 @@ describe("profile create", () => {
     expect(consoleSpy).toHaveBeenCalledWith('Profile "personal" created.');
   });
 
+  it("creates an empty profile without access token", async () => {
+    const cmd = createCommand();
+    await cmd.parseAsync(["work"], { from: "user" });
+
+    expect(loadConfigFileSpy).toHaveBeenCalledWith({ profile: "work" });
+    expect(vi.mocked(mkdir)).toHaveBeenCalledWith(join("/mock/home", ".linkedctl"), { recursive: true });
+    expect(vi.mocked(writeFile)).toHaveBeenCalledWith(
+      join("/mock/home", ".linkedctl", "work.yaml"),
+      `api-version: "${core.DEFAULT_API_VERSION}"\n`,
+      { mode: 0o600 },
+    );
+    expect(saveOAuthTokensSpy).not.toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalledWith('Profile "work" created.');
+  });
+
   it("throws when profile already exists", async () => {
     loadConfigFileSpy.mockResolvedValue({
       raw: { "api-version": "202601" },

--- a/packages/cli/src/commands/profile/create.ts
+++ b/packages/cli/src/commands/profile/create.ts
@@ -11,10 +11,10 @@ export function createCommand(): Command {
   const cmd = new Command("create");
   cmd.description("Create a new profile");
   cmd.argument("<name>", "profile name");
-  cmd.requiredOption("--access-token <token>", "OAuth2 access token");
+  cmd.option("--access-token <token>", "OAuth2 access token");
   cmd.option("--api-version <version>", "LinkedIn API version", DEFAULT_API_VERSION);
 
-  cmd.action(async (name: string, opts: { accessToken: string; apiVersion: string }) => {
+  cmd.action(async (name: string, opts: { accessToken?: string; apiVersion: string }) => {
     if (!isValidProfileName(name)) {
       throw new Error(`Invalid profile name "${name}". Names must not contain path separators or be empty.`);
     }
@@ -32,8 +32,10 @@ export function createCommand(): Command {
     const profilePath = join(profileDir, `${name}.yaml`);
     await writeFile(profilePath, `api-version: "${opts.apiVersion}"\n`, { mode: 0o600 });
 
-    // Save the access token (merges into existing file)
-    await saveOAuthTokens({ accessToken: opts.accessToken }, { profile: name });
+    // Save the access token if provided (merges into existing file)
+    if (opts.accessToken !== undefined) {
+      await saveOAuthTokens({ accessToken: opts.accessToken }, { profile: name });
+    }
 
     console.log(`Profile "${name}" created.`);
   });


### PR DESCRIPTION
## Summary

- Makes `--access-token` optional in `profile create`, allowing empty profiles that can be populated via `auth setup` → `auth login`
- The `--access-token` flag remains available for backward-compatible direct token import
- Adds test coverage for the no-token profile creation flow

Closes #97

## Test plan

- [x] Unit tests pass (154 tests, including new test for empty profile creation)
- [x] Type-check passes
- [x] Lint passes
- [x] Formatting passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)