### PR TITLE
(ux) profile list: show token status and metadata

### DIFF
--- a/packages/cli/src/commands/profile/list.test.ts
+++ b/packages/cli/src/commands/profile/list.test.ts
@@ -2,6 +2,7 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import * as core from "@linkedctl/core";
 import { listCommand } from "./list.js";
 
 vi.mock("node:os", async (importOriginal) => {
@@ -20,8 +21,23 @@ vi.mock("node:fs/promises", async (importOriginal) => {
   };
 });
 
+vi.mock("@linkedctl/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof core>();
+  return { ...actual };
+});
+
 const { homedir } = await import("node:os");
 const { readdir } = await import("node:fs/promises");
+
+/**
+ * Build a minimal JWT with the given payload claims.
+ */
+function buildJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const signature = "fake-signature";
+  return `${header}.${body}.${signature}`;
+}
 
 describe("profile list", () => {
   let consoleSpy: ReturnType<typeof vi.spyOn>;
@@ -56,28 +72,13 @@ describe("profile list", () => {
     expect(consoleSpy).toHaveBeenCalledWith("No profiles configured.");
   });
 
-  it("lists profile names from yaml files", async () => {
-    vi.mocked(readdir).mockResolvedValue(["personal.yaml", "work.yaml"] as unknown as Awaited<
-      ReturnType<typeof readdir>
-    >);
-
-    const cmd = listCommand();
-    await cmd.parseAsync([], { from: "user" });
-
-    expect(consoleSpy).toHaveBeenCalledWith("personal");
-    expect(consoleSpy).toHaveBeenCalledWith("work");
-  });
-
   it("ignores non-yaml files", async () => {
-    vi.mocked(readdir).mockResolvedValue(["personal.yaml", "notes.txt", ".DS_Store"] as unknown as Awaited<
-      ReturnType<typeof readdir>
-    >);
+    vi.mocked(readdir).mockResolvedValue(["notes.txt", ".DS_Store"] as unknown as Awaited<ReturnType<typeof readdir>>);
 
     const cmd = listCommand();
     await cmd.parseAsync([], { from: "user" });
 
-    expect(consoleSpy).toHaveBeenCalledWith("personal");
-    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    expect(consoleSpy).toHaveBeenCalledWith("No profiles configured.");
   });
 
   it("re-throws unexpected filesystem errors", async () => {
@@ -87,5 +88,188 @@ describe("profile list", () => {
 
     const cmd = listCommand();
     await expect(cmd.parseAsync([], { from: "user" })).rejects.toThrow(/I\/O error/);
+  });
+
+  it("shows not configured for profile without config file", async () => {
+    vi.mocked(readdir).mockResolvedValue(["test.yaml"] as unknown as Awaited<ReturnType<typeof readdir>>);
+    vi.spyOn(core, "loadConfigFile").mockResolvedValue({ raw: undefined, path: undefined });
+
+    const cmd = listCommand();
+    await cmd.parseAsync(["--format", "json"], { from: "user" });
+
+    const output = JSON.parse(consoleSpy.mock.calls[0]?.[0] as string) as unknown[];
+    expect(output).toEqual([{ name: "test", status: "not configured" }]);
+  });
+
+  it("shows not configured when access token is missing", async () => {
+    vi.mocked(readdir).mockResolvedValue(["work.yaml"] as unknown as Awaited<ReturnType<typeof readdir>>);
+    vi.spyOn(core, "loadConfigFile").mockResolvedValue({
+      raw: { oauth: { "client-id": "abc" } },
+      path: "/mock/home/.linkedctl/work.yaml",
+    });
+
+    const cmd = listCommand();
+    await cmd.parseAsync(["--format", "json"], { from: "user" });
+
+    const output = JSON.parse(consoleSpy.mock.calls[0]?.[0] as string) as unknown[];
+    expect(output).toEqual([{ name: "work", status: "not configured" }]);
+  });
+
+  it("shows authenticated for valid JWT token", async () => {
+    const futureExp = Math.floor(Date.now() / 1000) + 86400 * 45; // 45 days
+    const token = buildJwt({ exp: futureExp, sub: "user" });
+
+    vi.mocked(readdir).mockResolvedValue(["personal.yaml"] as unknown as Awaited<ReturnType<typeof readdir>>);
+    vi.spyOn(core, "loadConfigFile").mockResolvedValue({
+      raw: { oauth: { "access-token": token } },
+      path: "/mock/home/.linkedctl/personal.yaml",
+    });
+
+    const cmd = listCommand();
+    await cmd.parseAsync(["--format", "json"], { from: "user" });
+
+    const output = JSON.parse(consoleSpy.mock.calls[0]?.[0] as string) as Record<string, unknown>[];
+    expect(output).toHaveLength(1);
+    expect(output).toEqual([
+      expect.objectContaining({
+        name: "personal",
+        status: "authenticated",
+        expiresAt: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/) as unknown,
+        expires: expect.stringMatching(/^in \d+d/) as unknown,
+      }),
+    ]);
+  });
+
+  it("shows expired for expired JWT token", async () => {
+    const pastExp = Math.floor(Date.now() / 1000) - 86400 * 3; // 3 days ago
+    const token = buildJwt({ exp: pastExp });
+
+    vi.mocked(readdir).mockResolvedValue(["work.yaml"] as unknown as Awaited<ReturnType<typeof readdir>>);
+    vi.spyOn(core, "loadConfigFile").mockResolvedValue({
+      raw: { oauth: { "access-token": token } },
+      path: "/mock/home/.linkedctl/work.yaml",
+    });
+
+    const cmd = listCommand();
+    await cmd.parseAsync(["--format", "json"], { from: "user" });
+
+    const output = JSON.parse(consoleSpy.mock.calls[0]?.[0] as string) as Record<string, unknown>[];
+    expect(output).toHaveLength(1);
+    expect(output).toEqual([
+      expect.objectContaining({
+        name: "work",
+        status: "expired",
+        expiresAt: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/) as unknown,
+        expires: expect.stringMatching(/\d+d ago$/) as unknown,
+      }),
+    ]);
+  });
+
+  it("shows authenticated without expiry for opaque token", async () => {
+    vi.mocked(readdir).mockResolvedValue(["dev.yaml"] as unknown as Awaited<ReturnType<typeof readdir>>);
+    vi.spyOn(core, "loadConfigFile").mockResolvedValue({
+      raw: { oauth: { "access-token": "AQVh7cKZopaque" } },
+      path: "/mock/home/.linkedctl/dev.yaml",
+    });
+
+    const cmd = listCommand();
+    await cmd.parseAsync(["--format", "json"], { from: "user" });
+
+    const output = JSON.parse(consoleSpy.mock.calls[0]?.[0] as string) as unknown[];
+    expect(output).toEqual([{ name: "dev", status: "authenticated" }]);
+  });
+
+  it("lists multiple profiles with mixed statuses", async () => {
+    const validToken = buildJwt({ exp: Math.floor(Date.now() / 1000) + 86400 * 10 });
+    const expiredToken = buildJwt({ exp: Math.floor(Date.now() / 1000) - 86400 });
+
+    vi.mocked(readdir).mockResolvedValue(["personal.yaml", "work.yaml", "test.yaml"] as unknown as Awaited<
+      ReturnType<typeof readdir>
+    >);
+    vi.spyOn(core, "loadConfigFile").mockImplementation(async (options) => {
+      const profile = options?.profile;
+      if (profile === "personal") {
+        return { raw: { oauth: { "access-token": validToken } }, path: `/mock/home/.linkedctl/${profile}.yaml` };
+      }
+      if (profile === "work") {
+        return { raw: { oauth: { "access-token": expiredToken } }, path: `/mock/home/.linkedctl/${profile}.yaml` };
+      }
+      return { raw: undefined, path: undefined };
+    });
+
+    const cmd = listCommand();
+    await cmd.parseAsync(["--format", "json"], { from: "user" });
+
+    const output = JSON.parse(consoleSpy.mock.calls[0]?.[0] as string) as Record<string, unknown>[];
+    expect(output).toHaveLength(3);
+    expect(output).toEqual([
+      expect.objectContaining({ name: "personal", status: "authenticated" }),
+      expect.objectContaining({ name: "work", status: "expired" }),
+      expect.objectContaining({ name: "test", status: "not configured" }),
+    ]);
+  });
+
+  it("outputs table format with name, status, and expires columns", async () => {
+    const validToken = buildJwt({ exp: Math.floor(Date.now() / 1000) + 86400 * 45 });
+
+    vi.mocked(readdir).mockResolvedValue(["personal.yaml", "test.yaml"] as unknown as Awaited<
+      ReturnType<typeof readdir>
+    >);
+    vi.spyOn(core, "loadConfigFile").mockImplementation(async (options) => {
+      if (options?.profile === "personal") {
+        return { raw: { oauth: { "access-token": validToken } }, path: "/mock/home/.linkedctl/personal.yaml" };
+      }
+      return { raw: undefined, path: undefined };
+    });
+
+    const cmd = listCommand();
+    await cmd.parseAsync(["--format", "table"], { from: "user" });
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    const lines = output.split("\n");
+    // Header line should have column names
+    expect(lines[0]).toMatch(/name\s+status\s+expires/);
+    // Separator line
+    expect(lines[1]).toMatch(/─+/);
+    // Data lines
+    expect(lines[2]).toMatch(/personal\s+authenticated\s+in \d+d/);
+    expect(lines[3]).toMatch(/test\s+not configured/);
+  });
+
+  it("excludes expiresAt from table format", async () => {
+    const validToken = buildJwt({ exp: Math.floor(Date.now() / 1000) + 86400 });
+
+    vi.mocked(readdir).mockResolvedValue(["p.yaml"] as unknown as Awaited<ReturnType<typeof readdir>>);
+    vi.spyOn(core, "loadConfigFile").mockResolvedValue({
+      raw: { oauth: { "access-token": validToken } },
+      path: "/mock/home/.linkedctl/p.yaml",
+    });
+
+    const cmd = listCommand();
+    await cmd.parseAsync(["--format", "table"], { from: "user" });
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(output).not.toContain("expiresAt");
+  });
+
+  it("includes expiresAt in json format", async () => {
+    const futureExp = Math.floor(Date.now() / 1000) + 86400;
+    const token = buildJwt({ exp: futureExp });
+
+    vi.mocked(readdir).mockResolvedValue(["p.yaml"] as unknown as Awaited<ReturnType<typeof readdir>>);
+    vi.spyOn(core, "loadConfigFile").mockResolvedValue({
+      raw: { oauth: { "access-token": token } },
+      path: "/mock/home/.linkedctl/p.yaml",
+    });
+
+    const cmd = listCommand();
+    await cmd.parseAsync(["--format", "json"], { from: "user" });
+
+    const output = JSON.parse(consoleSpy.mock.calls[0]?.[0] as string) as Record<string, unknown>[];
+    expect(output).toEqual([
+      expect.objectContaining({
+        expiresAt: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/) as unknown,
+      }),
+    ]);
   });
 });

--- a/packages/cli/src/commands/profile/list.ts
+++ b/packages/cli/src/commands/profile/list.ts
@@ -4,14 +4,84 @@
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { readdir } from "node:fs/promises";
-import { Command } from "commander";
-import { CONFIG_DIR } from "@linkedctl/core";
+import { Command, Option } from "commander";
+import { CONFIG_DIR, loadConfigFile, validateConfig, getTokenExpiry } from "@linkedctl/core";
+import type { OutputFormat } from "../../output/index.js";
+import { resolveFormat, formatOutput } from "../../output/index.js";
+
+interface ProfileInfo {
+  name: string;
+  status: "authenticated" | "expired" | "not configured";
+  expiresAt?: string | undefined;
+  expires?: string | undefined;
+}
+
+/**
+ * Format the time delta between now and an expiry date as a human-readable string.
+ * Future dates produce "in Xd Yh"; past dates produce "Xd Yh ago".
+ */
+function formatTimeDelta(expiresAt: Date): string {
+  const diffMs = expiresAt.getTime() - Date.now();
+  const absDiffMs = Math.abs(diffMs);
+  const totalMinutes = Math.floor(absDiffMs / 60_000);
+  const totalHours = Math.floor(totalMinutes / 60);
+  const days = Math.floor(totalHours / 24);
+  const hours = totalHours % 24;
+
+  let duration: string;
+  if (days > 0) {
+    duration = hours > 0 ? `${String(days)}d ${String(hours)}h` : `${String(days)}d`;
+  } else if (totalHours > 0) {
+    const minutes = totalMinutes % 60;
+    duration = minutes > 0 ? `${String(totalHours)}h ${String(minutes)}m` : `${String(totalHours)}h`;
+  } else {
+    duration = `${String(totalMinutes)}m`;
+  }
+
+  return diffMs >= 0 ? `in ${duration}` : `${duration} ago`;
+}
+
+async function getProfileStatus(name: string): Promise<ProfileInfo> {
+  const { raw } = await loadConfigFile({ profile: name });
+  if (raw === undefined) {
+    return { name, status: "not configured" };
+  }
+
+  const { config } = validateConfig(raw);
+
+  if (config.oauth?.accessToken === undefined || config.oauth.accessToken === "") {
+    return { name, status: "not configured" };
+  }
+
+  const expiry = getTokenExpiry(config.oauth.accessToken);
+
+  if (expiry === undefined) {
+    return { name, status: "authenticated" };
+  }
+
+  if (expiry.isExpired) {
+    return {
+      name,
+      status: "expired",
+      expiresAt: expiry.expiresAt.toISOString(),
+      expires: formatTimeDelta(expiry.expiresAt),
+    };
+  }
+
+  return {
+    name,
+    status: "authenticated",
+    expiresAt: expiry.expiresAt.toISOString(),
+    expires: formatTimeDelta(expiry.expiresAt),
+  };
+}
 
 export function listCommand(): Command {
   const cmd = new Command("list");
   cmd.description("List all profiles");
+  cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
 
-  cmd.action(async () => {
+  cmd.action(async (opts: Record<string, unknown>) => {
     const profileDir = join(homedir(), CONFIG_DIR);
     let entries: string[];
     try {
@@ -31,9 +101,14 @@ export function listCommand(): Command {
       return;
     }
 
-    for (const name of names) {
-      console.log(name);
-    }
+    const profiles = await Promise.all(names.map((name) => getProfileStatus(name)));
+
+    const format = resolveFormat(opts["format"] as OutputFormat | undefined, process.stdout);
+
+    const data =
+      format === "json" ? profiles : profiles.map((p) => ({ name: p.name, status: p.status, expires: p.expires }));
+
+    console.log(formatOutput(data, format));
   });
 
   return cmd;


### PR DESCRIPTION
## Summary

- Enhanced `linkedctl profile list` to show token status (authenticated/expired/not configured) and expiry information for each profile
- Added `--format` option (json/table) following existing CLI output patterns
- Table format shows concise 3-column view (name, status, expires); JSON format includes full metadata with ISO timestamps

## Test plan

- [x] Build passes (`pnpm build`)
- [x] All 161 CLI tests pass including 13 profile list tests (`pnpm test`)
- [x] Typecheck passes (`pnpm typecheck`)
- [x] Lint passes (`pnpm lint`)
- [x] Format check passes (`pnpm format:check`)

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)