### PR TITLE
(ux) add usage examples to help text for common commands

### DIFF
--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -31,6 +31,15 @@ export function loginCommand(): Command {
   cmd.option("--port <number>", "local callback server port", String(DEFAULT_REDIRECT_PORT));
   cmd.option("--pkce", "use PKCE flow (requires LinkedIn to enable it for your app)");
 
+  cmd.addHelpText(
+    "after",
+    `
+Examples:
+  linkedctl auth login
+  linkedctl auth login --client-id <id> --client-secret <secret>
+  linkedctl auth login --profile work`,
+  );
+
   cmd.action(async (opts: { clientId?: string; clientSecret?: string; scope?: string; port: string; pkce?: true }) => {
     const program = cmd.parent?.parent;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/packages/cli/src/commands/post/create.ts
+++ b/packages/cli/src/commands/post/create.ts
@@ -95,6 +95,15 @@ export function createCommand(): Command {
   );
   cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
 
+  cmd.addHelpText(
+    "after",
+    `
+Examples:
+  linkedctl post create "Hello from LinkedCtl!"
+  linkedctl post create --text "Hello" --visibility CONNECTIONS
+  echo "Hello" | linkedctl post create`,
+  );
+
   cmd.action(async (text: string | undefined, opts: CreateOpts, actionCmd: Command) => {
     await createPostAction(text, opts, actionCmd);
   });

--- a/packages/cli/src/commands/post/index.ts
+++ b/packages/cli/src/commands/post/index.ts
@@ -26,6 +26,15 @@ export function postCommand(): Command {
   );
   cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
 
+  cmd.addHelpText(
+    "after",
+    `
+Examples:
+  linkedctl post "Hello from LinkedCtl!"
+  linkedctl post --text "Hello" --visibility CONNECTIONS
+  echo "Hello" | linkedctl post`,
+  );
+
   cmd.action(async (text: string | undefined, opts: Record<string, unknown>, actionCmd: Command) => {
     await createPostAction(text, opts, actionCmd);
   });

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -11,6 +11,15 @@ export function whoamiCommand(): Command {
   cmd.description("Display the current authenticated user's profile");
   cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
 
+  cmd.addHelpText(
+    "after",
+    `
+Examples:
+  linkedctl whoami
+  linkedctl whoami --format json
+  linkedctl whoami --profile work`,
+  );
+
   cmd.action(async (opts: Record<string, unknown>, actionCmd: Command) => {
     const rootOpts = actionCmd.optsWithGlobals();
     const profileFlag = typeof rootOpts["profile"] === "string" ? rootOpts["profile"] : undefined;


### PR DESCRIPTION
## Summary

- Add `addHelpText("after", ...)` with 2-3 usage examples to `post create`, `post` (shorthand), `auth login`, and `whoami` commands
- Follows the existing pattern established by the `completion` command
- Addresses UX audit finding CLI-UX-009: examples are the fastest way to learn a CLI

Closes #104

## Test plan

- [x] Build passes
- [x] TypeScript type-check passes
- [x] ESLint passes
- [x] Prettier formatting passes
- [x] All 330 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)