### PR TITLE
(ux) improve auth setup PKCE question defaults

### DIFF
--- a/packages/cli/src/commands/auth/setup.test.ts
+++ b/packages/cli/src/commands/auth/setup.test.ts
@@ -213,6 +213,7 @@ describe("auth setup", () => {
       expect(saveOAuthPkceSpy).toHaveBeenCalledWith(true, undefined);
       const output = stderrSpy.mock.calls.map((c) => c[0]).join("");
       expect(output).toContain("PKCE: enabled");
+      expect(output).toContain("If login fails, re-run setup and answer No");
     });
   });
 
@@ -222,6 +223,8 @@ describe("auth setup", () => {
     const program = wrapInProgram(setupCommand());
     return program.parseAsync(["auth", "setup"], { from: "user" }).then(() => {
       expect(saveOAuthPkceSpy).toHaveBeenCalledWith(false, undefined);
+      const output = stderrSpy.mock.calls.map((c) => c[0]).join("");
+      expect(output).not.toContain("If login fails, re-run setup and answer No");
     });
   });
 

--- a/packages/cli/src/commands/auth/setup.ts
+++ b/packages/cli/src/commands/auth/setup.ts
@@ -120,11 +120,14 @@ export function setupCommand(): Command {
       await saveOAuthScope(scope, writeOpts);
 
       process.stderr.write("\n");
-      process.stderr.write("PKCE (Proof Key for Code Exchange) improves security for native OAuth apps.\n");
-      process.stderr.write("LinkedIn requires PKCE to be enabled for your app by LinkedIn support.\n");
-      const pkceAnswer = await rl.question("Is PKCE enabled for your app? [y/N] ");
+      process.stderr.write("PKCE (Proof Key for Code Exchange) adds extra security to the OAuth flow.\n");
+      process.stderr.write("Most apps don't need this unless LinkedIn has specifically enabled it for your app.\n");
+      const pkceAnswer = await rl.question("Enable PKCE? [y/N] ");
       const pkce = pkceAnswer.trim().toLowerCase() === "y" || pkceAnswer.trim().toLowerCase() === "yes";
       await saveOAuthPkce(pkce, writeOpts);
+      if (pkce) {
+        process.stderr.write("  If login fails, re-run setup and answer No to this question.\n");
+      }
       await saveApiVersion(DEFAULT_API_VERSION, writeOpts);
 
       if (profileFlag !== undefined) {


### PR DESCRIPTION
## Summary

- Reworded the PKCE prompt to clearly explain what it does and that most apps don't need it unless LinkedIn has specifically enabled it
- Changed the question from "Is PKCE enabled for your app?" to "Enable PKCE?" for clarity
- Added a fallback note when PKCE is enabled: "If login fails, re-run setup and answer No to this question"

Closes #103

## Test plan

- [x] Existing tests updated and passing (17/17)
- [x] Verified fallback note appears when PKCE is enabled
- [x] Verified fallback note does NOT appear when PKCE is disabled
- [x] Typecheck, lint, and formatting all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)