### PR TITLE
(feat) add --text-file option for file-backed post content

### DIFF
--- a/packages/cli/src/commands/post/create.test.ts
+++ b/packages/cli/src/commands/post/create.test.ts
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { createProgram } from "../../program.js";
 
@@ -273,5 +277,112 @@ describe("post create", () => {
     await expect(program.parseAsync(["node", "linkedctl", "post", "create", "--text", "Hello"])).rejects.toThrow(
       /Failed to create post/,
     );
+  });
+
+  describe("--text-file", () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await mkdtemp(join(tmpdir(), "linkedctl-test-"));
+    });
+
+    afterEach(async () => {
+      await rm(tempDir, { recursive: true, force: true });
+    });
+
+    it("reads post text from a file on post create", async () => {
+      const filePath = join(tempDir, "draft.txt");
+      await writeFile(filePath, "Hello from file", "utf-8");
+
+      const program = createProgram();
+      await program.parseAsync(["node", "linkedctl", "post", "create", "--text-file", filePath]);
+
+      expect(coreMock.createTextPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          text: "Hello from file",
+        }),
+      );
+    });
+
+    it("reads post text from a file on post shorthand", async () => {
+      const filePath = join(tempDir, "draft.txt");
+      await writeFile(filePath, "Hello from file shorthand", "utf-8");
+
+      const program = createProgram();
+      await program.parseAsync(["node", "linkedctl", "post", "--text-file", filePath]);
+
+      expect(coreMock.createTextPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          text: "Hello from file shorthand",
+        }),
+      );
+    });
+
+    it("trims whitespace from file content", async () => {
+      const filePath = join(tempDir, "draft.txt");
+      await writeFile(filePath, "  Hello trimmed  \n\n", "utf-8");
+
+      const program = createProgram();
+      await program.parseAsync(["node", "linkedctl", "post", "create", "--text-file", filePath]);
+
+      expect(coreMock.createTextPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          text: "Hello trimmed",
+        }),
+      );
+    });
+
+    it("--text takes precedence over --text-file on post create", async () => {
+      const filePath = join(tempDir, "draft.txt");
+      await writeFile(filePath, "from file", "utf-8");
+
+      const program = createProgram();
+      await program.parseAsync([
+        "node",
+        "linkedctl",
+        "post",
+        "create",
+        "--text",
+        "from option",
+        "--text-file",
+        filePath,
+      ]);
+
+      expect(coreMock.createTextPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          text: "from option",
+        }),
+      );
+    });
+
+    it("--text takes precedence over --text-file on post shorthand", async () => {
+      const filePath = join(tempDir, "draft.txt");
+      await writeFile(filePath, "from file", "utf-8");
+
+      const program = createProgram();
+      await program.parseAsync(["node", "linkedctl", "post", "--text", "from option", "--text-file", filePath]);
+
+      expect(coreMock.createTextPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          text: "from option",
+        }),
+      );
+    });
+
+    it("produces a clear error when file is not found", async () => {
+      const filePath = join(tempDir, "nonexistent.txt");
+
+      const program = createProgram();
+      program.exitOverride();
+
+      await expect(
+        program.parseAsync(["node", "linkedctl", "post", "create", "--text-file", filePath]),
+      ).rejects.toThrow(/ENOENT/);
+    });
   });
 });

--- a/packages/cli/src/commands/post/create.ts
+++ b/packages/cli/src/commands/post/create.ts
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { readFile } from "node:fs/promises";
+
 import { Command, InvalidArgumentError, Option } from "commander";
 import { resolveConfig, LinkedInClient, getCurrentPersonUrn, createTextPost, LinkedInApiError } from "@linkedctl/core";
 import type { PostVisibility } from "@linkedctl/core";
@@ -10,18 +12,31 @@ import { readStdin } from "./stdin.js";
 
 interface CreateOpts {
   text?: string | undefined;
+  textFile?: string | undefined;
   visibility?: string | undefined;
   format?: string | undefined;
 }
 
 /**
- * Resolve the post text from --text option, positional argument, or stdin.
+ * Resolve the post text from --text option, --text-file, positional argument, or stdin.
  *
- * Precedence: --text > positional argument > stdin.
+ * Precedence: --text > --text-file > positional argument > stdin.
  */
-async function resolveText(textOpt: string | undefined, textArg: string | undefined): Promise<string> {
+async function resolveText(
+  textOpt: string | undefined,
+  textFileOpt: string | undefined,
+  textArg: string | undefined,
+): Promise<string> {
   if (textOpt !== undefined && textOpt !== "") {
     return textOpt;
+  }
+
+  if (textFileOpt !== undefined && textFileOpt !== "") {
+    const content = await readFile(textFileOpt, "utf-8");
+    const trimmed = content.trim();
+    if (trimmed !== "") {
+      return trimmed;
+    }
   }
 
   if (textArg !== undefined && textArg !== "") {
@@ -35,14 +50,16 @@ async function resolveText(textOpt: string | undefined, textArg: string | undefi
     }
   }
 
-  throw new Error('No text provided. Use --text "message", pass text as an argument, or pipe text via stdin.');
+  throw new Error(
+    'No text provided. Use --text "message", --text-file <path>, pass text as an argument, or pipe text via stdin.',
+  );
 }
 
 /**
  * Shared action handler for creating a text post.
  */
 export async function createPostAction(textArg: string | undefined, opts: CreateOpts, cmd: Command): Promise<void> {
-  const text = await resolveText(opts.text, textArg);
+  const text = await resolveText(opts.text, opts.textFile, textArg);
   const globals = cmd.optsWithGlobals<{ profile?: string | undefined }>();
 
   const { config } = await resolveConfig({
@@ -78,9 +95,10 @@ export async function createPostAction(textArg: string | undefined, opts: Create
 
 export function createCommand(): Command {
   const cmd = new Command("create");
-  cmd.description("Create a text post on LinkedIn (text: --text > positional > stdin)");
+  cmd.description("Create a text post on LinkedIn (text: --text > --text-file > positional > stdin)");
   cmd.argument("[text]", "text content of the post");
-  cmd.option("--text <text>", "text content of the post (takes precedence over positional argument)");
+  cmd.option("--text <text>", "text content of the post (takes precedence over --text-file and positional argument)");
+  cmd.option("--text-file <path>", "read post text from a UTF-8 file");
   cmd.addOption(
     new Option("--visibility <visibility>", "post visibility (PUBLIC or CONNECTIONS)")
       .choices(["PUBLIC", "CONNECTIONS"])

--- a/packages/cli/src/commands/post/index.ts
+++ b/packages/cli/src/commands/post/index.ts
@@ -10,8 +10,9 @@ export function postCommand(): Command {
 
   cmd.enablePositionalOptions();
 
-  cmd.argument("[text]", "shorthand: create a post with the given text (text > stdin)");
-  cmd.option("--text <text>", "text content of the post (takes precedence over positional argument)");
+  cmd.argument("[text]", "shorthand: create a post with the given text (text > text-file > stdin)");
+  cmd.option("--text <text>", "text content of the post (takes precedence over --text-file and positional argument)");
+  cmd.option("--text-file <path>", "read post text from a UTF-8 file");
   cmd.addOption(
     new Option("--visibility <visibility>", "post visibility (PUBLIC or CONNECTIONS)")
       .choices(["PUBLIC", "CONNECTIONS"])


### PR DESCRIPTION
## Summary

- Add `--text-file <path>` option to `post create` and `post` shorthand commands to read post text from a UTF-8 file
- Resolution order: `--text` > `--text-file` > positional argument > stdin > error
- File content is trimmed (consistent with stdin behavior); missing file surfaces clear ENOENT error

Closes #82

## Test plan

- [x] `post create --text-file draft.txt` reads text from file
- [x] `post --text-file draft.txt` (shorthand) reads text from file
- [x] File content whitespace is trimmed
- [x] `--text` takes precedence over `--text-file` on both `post create` and `post` shorthand
- [x] Missing file produces clear ENOENT error
- [x] All existing tests pass (build, typecheck, lint, format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)