### PR TITLE
(ux) add confirmation prompts for destructive operations

### DIFF
--- a/packages/cli/src/commands/auth/logout.test.ts
+++ b/packages/cli/src/commands/auth/logout.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import * as core from "@linkedctl/core";
+import * as readlinePromises from "node:readline/promises";
 import { logoutCommand } from "./logout.js";
 
 vi.mock("@linkedctl/core", async (importOriginal) => {
@@ -10,16 +11,37 @@ vi.mock("@linkedctl/core", async (importOriginal) => {
   return { ...actual };
 });
 
+vi.mock("node:readline/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof readlinePromises>();
+  return { ...actual };
+});
+
+function mockReadline(answer: string) {
+  const closeFn = vi.fn();
+
+  vi.spyOn(readlinePromises, "createInterface").mockReturnValue({
+    question: vi.fn().mockResolvedValue(answer),
+    close: closeFn,
+  } as never);
+
+  return { closeFn };
+}
+
 describe("auth logout", () => {
   let consoleSpy: ReturnType<typeof vi.spyOn>;
   let clearOAuthTokensSpy: ReturnType<typeof vi.spyOn>;
+  let originalIsTTY: boolean | undefined;
 
   beforeEach(() => {
     consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     clearOAuthTokensSpy = vi.spyOn(core, "clearOAuthTokens").mockResolvedValue(undefined);
+    originalIsTTY = process.stdin.isTTY;
+    // Default to non-TTY so existing tests don't need prompts
+    Object.defineProperty(process.stdin, "isTTY", { value: undefined, writable: true });
   });
 
   afterEach(() => {
+    Object.defineProperty(process.stdin, "isTTY", { value: originalIsTTY, writable: true });
     vi.restoreAllMocks();
   });
 
@@ -57,5 +79,76 @@ describe("auth logout", () => {
 
     const cmd = logoutCommand();
     await expect(cmd.parseAsync([], { from: "user" })).rejects.toThrow(/No OAuth credentials configured/);
+  });
+
+  it("prompts for confirmation in TTY mode", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true });
+    mockReadline("y");
+
+    vi.spyOn(core, "loadConfigFile").mockResolvedValue({
+      raw: {
+        oauth: { "access-token": "secret-token" },
+        "api-version": "202601",
+      },
+      path: "/some/path.yaml",
+    });
+
+    const cmd = logoutCommand();
+    await cmd.parseAsync([], { from: "user" });
+
+    expect(clearOAuthTokensSpy).toHaveBeenCalledWith({ profile: undefined });
+    expect(consoleSpy).toHaveBeenCalledWith('Credentials cleared for profile "default".');
+  });
+
+  it("aborts when user declines confirmation", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true });
+    mockReadline("n");
+
+    vi.spyOn(core, "loadConfigFile").mockResolvedValue({
+      raw: {
+        oauth: { "access-token": "secret-token" },
+        "api-version": "202601",
+      },
+      path: "/some/path.yaml",
+    });
+
+    const cmd = logoutCommand();
+    await expect(cmd.parseAsync([], { from: "user" })).rejects.toThrow("Aborted.");
+    expect(clearOAuthTokensSpy).not.toHaveBeenCalled();
+  });
+
+  it("skips confirmation with --force flag", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true });
+
+    vi.spyOn(core, "loadConfigFile").mockResolvedValue({
+      raw: {
+        oauth: { "access-token": "secret-token" },
+        "api-version": "202601",
+      },
+      path: "/some/path.yaml",
+    });
+
+    const cmd = logoutCommand();
+    await cmd.parseAsync(["--force"], { from: "user" });
+
+    expect(clearOAuthTokensSpy).toHaveBeenCalledWith({ profile: undefined });
+    expect(consoleSpy).toHaveBeenCalledWith('Credentials cleared for profile "default".');
+  });
+
+  it("skips confirmation in non-TTY mode", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: undefined, writable: true });
+
+    vi.spyOn(core, "loadConfigFile").mockResolvedValue({
+      raw: {
+        oauth: { "access-token": "secret-token" },
+        "api-version": "202601",
+      },
+      path: "/some/path.yaml",
+    });
+
+    const cmd = logoutCommand();
+    await cmd.parseAsync([], { from: "user" });
+
+    expect(clearOAuthTokensSpy).toHaveBeenCalledWith({ profile: undefined });
   });
 });

--- a/packages/cli/src/commands/auth/logout.ts
+++ b/packages/cli/src/commands/auth/logout.ts
@@ -3,12 +3,14 @@
 
 import { Command } from "commander";
 import { loadConfigFile, validateConfig, clearOAuthTokens } from "@linkedctl/core";
+import { confirmOrAbort } from "../../confirm.js";
 
 export function logoutCommand(): Command {
   const cmd = new Command("logout");
   cmd.description("Clear stored credentials from the active config");
+  cmd.option("-f, --force", "skip confirmation prompt");
 
-  cmd.action(async (_opts: Record<string, unknown>, actionCmd: Command) => {
+  cmd.action(async (opts: { force?: true }, actionCmd: Command) => {
     const rootOpts = actionCmd.optsWithGlobals();
     const profileFlag = typeof rootOpts["profile"] === "string" ? rootOpts["profile"] : undefined;
 
@@ -22,8 +24,10 @@ export function logoutCommand(): Command {
       );
     }
 
-    await clearOAuthTokens({ profile: profileFlag });
     const label = profileFlag ?? "default";
+    await confirmOrAbort(`Clear credentials for profile "${label}"?`, opts.force === true);
+
+    await clearOAuthTokens({ profile: profileFlag });
     console.log(`Credentials cleared for profile "${label}".`);
   });
 

--- a/packages/cli/src/commands/auth/revoke.test.ts
+++ b/packages/cli/src/commands/auth/revoke.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import * as core from "@linkedctl/core";
+import * as readlinePromises from "node:readline/promises";
 import { revokeCommand } from "./revoke.js";
 
 vi.mock("@linkedctl/core", async (importOriginal) => {
@@ -10,18 +11,39 @@ vi.mock("@linkedctl/core", async (importOriginal) => {
   return { ...actual };
 });
 
+vi.mock("node:readline/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof readlinePromises>();
+  return { ...actual };
+});
+
+function mockReadline(answer: string) {
+  const closeFn = vi.fn();
+
+  vi.spyOn(readlinePromises, "createInterface").mockReturnValue({
+    question: vi.fn().mockResolvedValue(answer),
+    close: closeFn,
+  } as never);
+
+  return { closeFn };
+}
+
 describe("auth revoke", () => {
   let consoleSpy: ReturnType<typeof vi.spyOn>;
   let warnSpy: ReturnType<typeof vi.spyOn>;
   let clearOAuthTokensSpy: ReturnType<typeof vi.spyOn>;
+  let originalIsTTY: boolean | undefined;
 
   beforeEach(() => {
     consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     clearOAuthTokensSpy = vi.spyOn(core, "clearOAuthTokens").mockResolvedValue(undefined);
+    originalIsTTY = process.stdin.isTTY;
+    // Default to non-TTY so existing tests don't need prompts
+    Object.defineProperty(process.stdin, "isTTY", { value: undefined, writable: true });
   });
 
   afterEach(() => {
+    Object.defineProperty(process.stdin, "isTTY", { value: originalIsTTY, writable: true });
     vi.restoreAllMocks();
   });
 
@@ -127,5 +149,71 @@ describe("auth revoke", () => {
     expect(consoleSpy).toHaveBeenCalledWith(
       expect.stringContaining("No complete credentials for server-side revocation"),
     );
+  });
+
+  it("prompts for confirmation in TTY mode", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true });
+    mockReadline("y");
+
+    vi.spyOn(core, "revokeAccessToken").mockResolvedValueOnce(undefined);
+    vi.spyOn(core, "loadConfigFile").mockResolvedValue({
+      raw: {
+        oauth: {
+          "access-token": "secret-token",
+          "client-id": "my-client-id",
+          "client-secret": "my-client-secret",
+        },
+        "api-version": "202601",
+      },
+      path: "/some/path.yaml",
+    });
+
+    const cmd = revokeCommand();
+    await cmd.parseAsync([], { from: "user" });
+
+    expect(clearOAuthTokensSpy).toHaveBeenCalledWith({ profile: undefined });
+  });
+
+  it("aborts when user declines confirmation", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true });
+    mockReadline("n");
+
+    vi.spyOn(core, "loadConfigFile").mockResolvedValue({
+      raw: {
+        oauth: {
+          "access-token": "secret-token",
+          "client-id": "my-client-id",
+          "client-secret": "my-client-secret",
+        },
+        "api-version": "202601",
+      },
+      path: "/some/path.yaml",
+    });
+
+    const cmd = revokeCommand();
+    await expect(cmd.parseAsync([], { from: "user" })).rejects.toThrow("Aborted.");
+    expect(clearOAuthTokensSpy).not.toHaveBeenCalled();
+  });
+
+  it("skips confirmation with --force flag", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true });
+
+    vi.spyOn(core, "revokeAccessToken").mockResolvedValueOnce(undefined);
+    vi.spyOn(core, "loadConfigFile").mockResolvedValue({
+      raw: {
+        oauth: {
+          "access-token": "secret-token",
+          "client-id": "my-client-id",
+          "client-secret": "my-client-secret",
+        },
+        "api-version": "202601",
+      },
+      path: "/some/path.yaml",
+    });
+
+    const cmd = revokeCommand();
+    await cmd.parseAsync(["--force"], { from: "user" });
+
+    expect(clearOAuthTokensSpy).toHaveBeenCalledWith({ profile: undefined });
   });
 });

--- a/packages/cli/src/commands/auth/revoke.ts
+++ b/packages/cli/src/commands/auth/revoke.ts
@@ -3,12 +3,14 @@
 
 import { Command } from "commander";
 import { loadConfigFile, validateConfig, clearOAuthTokens, revokeAccessToken } from "@linkedctl/core";
+import { confirmOrAbort } from "../../confirm.js";
 
 export function revokeCommand(): Command {
   const cmd = new Command("revoke");
   cmd.description("Revoke the access token server-side and clear local credentials");
+  cmd.option("-f, --force", "skip confirmation prompt");
 
-  cmd.action(async (_opts: Record<string, unknown>, actionCmd: Command) => {
+  cmd.action(async (opts: { force?: true }, actionCmd: Command) => {
     const rootOpts = actionCmd.optsWithGlobals();
     const profileFlag = typeof rootOpts["profile"] === "string" ? rootOpts["profile"] : undefined;
 
@@ -19,6 +21,8 @@ export function revokeCommand(): Command {
     const clientId = config.oauth?.clientId;
     const clientSecret = config.oauth?.clientSecret;
     const label = profileFlag ?? "default";
+
+    await confirmOrAbort(`Revoke access token and clear credentials for profile "${label}"?`, opts.force === true);
 
     if (accessToken === undefined || accessToken === "" || clientId === undefined || clientSecret === undefined) {
       await clearOAuthTokens({ profile: profileFlag });

--- a/packages/cli/src/commands/profile/delete.test.ts
+++ b/packages/cli/src/commands/profile/delete.test.ts
@@ -4,6 +4,7 @@
 import { join } from "node:path";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import * as core from "@linkedctl/core";
+import * as readlinePromises from "node:readline/promises";
 import { deleteCommand } from "./delete.js";
 
 vi.mock("@linkedctl/core", async (importOriginal) => {
@@ -27,20 +28,41 @@ vi.mock("node:fs/promises", async (importOriginal) => {
   };
 });
 
+vi.mock("node:readline/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof readlinePromises>();
+  return { ...actual };
+});
+
 const { homedir } = await import("node:os");
 const { unlink } = await import("node:fs/promises");
 
+function mockReadline(answer: string) {
+  const closeFn = vi.fn();
+
+  vi.spyOn(readlinePromises, "createInterface").mockReturnValue({
+    question: vi.fn().mockResolvedValue(answer),
+    close: closeFn,
+  } as never);
+
+  return { closeFn };
+}
+
 describe("profile delete", () => {
   let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let originalIsTTY: boolean | undefined;
 
   beforeEach(() => {
     vi.clearAllMocks();
     consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     vi.mocked(homedir).mockReturnValue("/mock/home");
     vi.mocked(unlink).mockResolvedValue(undefined);
+    originalIsTTY = process.stdin.isTTY;
+    // Default to non-TTY so existing tests don't need prompts
+    Object.defineProperty(process.stdin, "isTTY", { value: undefined, writable: true });
   });
 
   afterEach(() => {
+    Object.defineProperty(process.stdin, "isTTY", { value: originalIsTTY, writable: true });
     vi.restoreAllMocks();
   });
 
@@ -73,5 +95,44 @@ describe("profile delete", () => {
 
     const cmd = deleteCommand();
     await expect(cmd.parseAsync(["work"], { from: "user" })).rejects.toThrow(/I\/O error/);
+  });
+
+  it("prompts for confirmation in TTY mode", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true });
+    mockReadline("y");
+
+    const cmd = deleteCommand();
+    await cmd.parseAsync(["work"], { from: "user" });
+
+    expect(vi.mocked(unlink)).toHaveBeenCalledWith(join("/mock/home", ".linkedctl", "work.yaml"));
+    expect(consoleSpy).toHaveBeenCalledWith('Profile "work" deleted.');
+  });
+
+  it("aborts when user declines confirmation", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true });
+    mockReadline("n");
+
+    const cmd = deleteCommand();
+    await expect(cmd.parseAsync(["work"], { from: "user" })).rejects.toThrow("Aborted.");
+    expect(vi.mocked(unlink)).not.toHaveBeenCalled();
+  });
+
+  it("skips confirmation with --force flag", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true });
+
+    const cmd = deleteCommand();
+    await cmd.parseAsync(["work", "--force"], { from: "user" });
+
+    expect(vi.mocked(unlink)).toHaveBeenCalledWith(join("/mock/home", ".linkedctl", "work.yaml"));
+    expect(consoleSpy).toHaveBeenCalledWith('Profile "work" deleted.');
+  });
+
+  it("skips confirmation in non-TTY mode", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: undefined, writable: true });
+
+    const cmd = deleteCommand();
+    await cmd.parseAsync(["work"], { from: "user" });
+
+    expect(vi.mocked(unlink)).toHaveBeenCalledWith(join("/mock/home", ".linkedctl", "work.yaml"));
   });
 });

--- a/packages/cli/src/commands/profile/delete.ts
+++ b/packages/cli/src/commands/profile/delete.ts
@@ -6,16 +6,20 @@ import { homedir } from "node:os";
 import { unlink } from "node:fs/promises";
 import { Command } from "commander";
 import { isValidProfileName, CONFIG_DIR } from "@linkedctl/core";
+import { confirmOrAbort } from "../../confirm.js";
 
 export function deleteCommand(): Command {
   const cmd = new Command("delete");
   cmd.description("Delete a profile");
   cmd.argument("<name>", "profile name");
+  cmd.option("-f, --force", "skip confirmation prompt");
 
-  cmd.action(async (name: string) => {
+  cmd.action(async (name: string, opts: { force?: true }) => {
     if (!isValidProfileName(name)) {
       throw new Error(`Invalid profile name "${name}". Names must not contain path separators or be empty.`);
     }
+
+    await confirmOrAbort(`Delete profile "${name}"?`, opts.force === true);
 
     const profilePath = join(homedir(), CONFIG_DIR, `${name}.yaml`);
 

--- a/packages/cli/src/confirm.test.ts
+++ b/packages/cli/src/confirm.test.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import * as readlinePromises from "node:readline/promises";
+import { confirmOrAbort } from "./confirm.js";
+
+vi.mock("node:readline/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof readlinePromises>();
+  return { ...actual };
+});
+
+function mockReadline(answer: string) {
+  const closeFn = vi.fn();
+
+  vi.spyOn(readlinePromises, "createInterface").mockReturnValue({
+    question: vi.fn().mockResolvedValue(answer),
+    close: closeFn,
+  } as never);
+
+  return { closeFn };
+}
+
+describe("confirmOrAbort", () => {
+  let originalIsTTY: boolean | undefined;
+
+  beforeEach(() => {
+    originalIsTTY = process.stdin.isTTY;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stdin, "isTTY", { value: originalIsTTY, writable: true });
+    vi.restoreAllMocks();
+  });
+
+  it("skips prompt when force is true", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true });
+    const createInterfaceSpy = vi.spyOn(readlinePromises, "createInterface");
+
+    await confirmOrAbort("Delete?", true);
+
+    expect(createInterfaceSpy).not.toHaveBeenCalled();
+  });
+
+  it("skips prompt when stdin is not a TTY", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: undefined, writable: true });
+    const createInterfaceSpy = vi.spyOn(readlinePromises, "createInterface");
+
+    await confirmOrAbort("Delete?", false);
+
+    expect(createInterfaceSpy).not.toHaveBeenCalled();
+  });
+
+  it("proceeds when user answers y", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true });
+    const { closeFn } = mockReadline("y");
+
+    await confirmOrAbort("Delete?", false);
+
+    expect(closeFn).toHaveBeenCalled();
+  });
+
+  it("proceeds when user answers yes", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true });
+    const { closeFn } = mockReadline("yes");
+
+    await confirmOrAbort("Delete?", false);
+
+    expect(closeFn).toHaveBeenCalled();
+  });
+
+  it("proceeds when user answers Y (case-insensitive)", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true });
+    const { closeFn } = mockReadline("Y");
+
+    await confirmOrAbort("Delete?", false);
+
+    expect(closeFn).toHaveBeenCalled();
+  });
+
+  it("aborts when user answers n", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true });
+    const { closeFn } = mockReadline("n");
+
+    await expect(confirmOrAbort("Delete?", false)).rejects.toThrow("Aborted.");
+    expect(closeFn).toHaveBeenCalled();
+  });
+
+  it("aborts when user presses enter (empty input)", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true });
+    const { closeFn } = mockReadline("");
+
+    await expect(confirmOrAbort("Delete?", false)).rejects.toThrow("Aborted.");
+    expect(closeFn).toHaveBeenCalled();
+  });
+
+  it("includes message in prompt", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: true, writable: true });
+    mockReadline("y");
+
+    await confirmOrAbort("Delete profile?", false);
+
+    expect(vi.mocked(readlinePromises.createInterface)).toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/confirm.ts
+++ b/packages/cli/src/confirm.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { createInterface } from "node:readline/promises";
+
+/**
+ * Prompt the user for confirmation in interactive (TTY) mode.
+ * Skips the prompt and proceeds when `--force` is set or stdin is not a TTY.
+ * Throws if the user declines.
+ */
+export async function confirmOrAbort(message: string, force: boolean): Promise<void> {
+  if (force || !process.stdin.isTTY) {
+    return;
+  }
+
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    const answer = await rl.question(`${message} [y/N] `);
+    if (answer.trim().toLowerCase() !== "y" && answer.trim().toLowerCase() !== "yes") {
+      throw new Error("Aborted.");
+    }
+  } finally {
+    rl.close();
+  }
+}


### PR DESCRIPTION
## Summary

- Add interactive confirmation prompts to `profile delete`, `auth logout`, and `auth revoke` commands
- Skip prompt automatically in non-TTY contexts (piped/scripted) for script-friendliness
- Add `-f, --force` flag to bypass confirmation in interactive mode
- Extract shared `confirmOrAbort` utility in `packages/cli/src/confirm.ts`

Closes #102

## Test plan

- [x] `confirmOrAbort` utility: 8 unit tests (force skip, non-TTY skip, y/yes/Y accept, n/empty reject, close cleanup)
- [x] `profile delete`: 4 new tests (TTY prompt, decline abort, `--force` skip, non-TTY skip)
- [x] `auth logout`: 4 new tests (TTY prompt, decline abort, `--force` skip, non-TTY skip)
- [x] `auth revoke`: 3 new tests (TTY prompt, decline abort, `--force` skip)
- [x] All existing tests continue to pass (non-TTY default)
- [x] Build, typecheck, lint, format-check all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)