### PR TITLE
(feat) add --format support to auth status

### DIFF
--- a/packages/cli/src/commands/auth/status.test.ts
+++ b/packages/cli/src/commands/auth/status.test.ts
@@ -40,10 +40,12 @@ describe("auth status", () => {
     });
 
     const cmd = statusCommand();
-    await cmd.parseAsync([], { from: "user" });
+    await cmd.parseAsync(["--format", "table"], { from: "user" });
 
-    expect(consoleSpy).toHaveBeenCalledWith("Profile: default");
-    expect(consoleSpy).toHaveBeenCalledWith("Status: not configured");
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain("default");
+    expect(output).toContain("not configured");
     expect(consoleErrorSpy).toHaveBeenCalledWith('Run "linkedctl auth login" to set up authentication.');
   });
 
@@ -57,10 +59,12 @@ describe("auth status", () => {
     });
 
     const cmd = statusCommand();
-    await cmd.parseAsync([], { from: "user" });
+    await cmd.parseAsync(["--format", "table"], { from: "user" });
 
-    expect(consoleSpy).toHaveBeenCalledWith("Profile: default");
-    expect(consoleSpy).toHaveBeenCalledWith("Status: not configured");
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain("default");
+    expect(output).toContain("not configured");
     expect(consoleErrorSpy).toHaveBeenCalledWith('Run "linkedctl auth login" to set up authentication.');
   });
 
@@ -77,11 +81,12 @@ describe("auth status", () => {
     });
 
     const cmd = statusCommand();
-    await cmd.parseAsync([], { from: "user" });
+    await cmd.parseAsync(["--format", "table"], { from: "user" });
 
-    expect(consoleSpy).toHaveBeenCalledWith("Profile: default");
-    expect(consoleSpy).toHaveBeenCalledWith("Status: authenticated");
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("remaining)"));
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain("authenticated");
+    expect(output).toContain("remaining)");
   });
 
   it("shows expired status with guidance for expired JWT", async () => {
@@ -97,10 +102,11 @@ describe("auth status", () => {
     });
 
     const cmd = statusCommand();
-    await cmd.parseAsync([], { from: "user" });
+    await cmd.parseAsync(["--format", "table"], { from: "user" });
 
-    expect(consoleSpy).toHaveBeenCalledWith("Profile: default");
-    expect(consoleSpy).toHaveBeenCalledWith("Status: expired");
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain("expired");
     expect(consoleErrorSpy).toHaveBeenCalledWith('Run "linkedctl auth login" to re-authenticate.');
   });
 
@@ -114,10 +120,112 @@ describe("auth status", () => {
     });
 
     const cmd = statusCommand();
-    await cmd.parseAsync([], { from: "user" });
+    await cmd.parseAsync(["--format", "table"], { from: "user" });
 
-    expect(consoleSpy).toHaveBeenCalledWith("Profile: default");
-    expect(consoleSpy).toHaveBeenCalledWith("Status: authenticated");
-    expect(consoleSpy).toHaveBeenCalledWith("Expiry: unknown (token is not a JWT)");
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain("authenticated");
+    expect(output).toContain("unknown (token is not a JWT)");
+  });
+
+  it("outputs JSON when --format json is specified for not configured", async () => {
+    vi.spyOn(core, "loadConfigFile").mockResolvedValue({
+      raw: undefined,
+      path: undefined,
+    });
+
+    const cmd = statusCommand();
+    await cmd.parseAsync(["--format", "json"], { from: "user" });
+
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    const parsed = JSON.parse(consoleSpy.mock.calls[0]?.[0] as string) as Record<string, unknown>;
+    expect(parsed).toEqual({
+      profile: "default",
+      status: "not configured",
+      expiresAt: null,
+      remainingSeconds: null,
+    });
+  });
+
+  it("outputs JSON when --format json is specified for valid JWT", async () => {
+    const futureExp = Math.floor(Date.now() / 1000) + 86400 * 3;
+    const token = buildJwt({ exp: futureExp, sub: "user" });
+
+    vi.spyOn(core, "loadConfigFile").mockResolvedValue({
+      raw: {
+        oauth: { "access-token": token },
+        "api-version": "202601",
+      },
+      path: "/some/path.yaml",
+    });
+
+    const cmd = statusCommand();
+    await cmd.parseAsync(["--format", "json"], { from: "user" });
+
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    const parsed = JSON.parse(consoleSpy.mock.calls[0]?.[0] as string) as Record<string, unknown>;
+    expect(parsed).toEqual({
+      profile: "default",
+      status: "authenticated",
+      expiresAt: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/) as unknown,
+      remainingSeconds: expect.any(Number) as unknown,
+    });
+    expect(parsed["remainingSeconds"]).toBeGreaterThan(0);
+  });
+
+  it("outputs JSON when --format json is specified for expired JWT", async () => {
+    const pastExp = Math.floor(Date.now() / 1000) - 3600;
+    const token = buildJwt({ exp: pastExp });
+
+    vi.spyOn(core, "loadConfigFile").mockResolvedValue({
+      raw: {
+        oauth: { "access-token": token },
+        "api-version": "202601",
+      },
+      path: "/some/path.yaml",
+    });
+
+    const cmd = statusCommand();
+    await cmd.parseAsync(["--format", "json"], { from: "user" });
+
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    const parsed = JSON.parse(consoleSpy.mock.calls[0]?.[0] as string) as Record<string, unknown>;
+    expect(parsed).toEqual({
+      profile: "default",
+      status: "expired",
+      expiresAt: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/) as unknown,
+      remainingSeconds: 0,
+    });
+  });
+
+  it("outputs JSON when --format json is specified for opaque token", async () => {
+    vi.spyOn(core, "loadConfigFile").mockResolvedValue({
+      raw: {
+        oauth: { "access-token": "AQVh7cKZopaque" },
+        "api-version": "202601",
+      },
+      path: "/some/path.yaml",
+    });
+
+    const cmd = statusCommand();
+    await cmd.parseAsync(["--format", "json"], { from: "user" });
+
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    const parsed = JSON.parse(consoleSpy.mock.calls[0]?.[0] as string) as Record<string, unknown>;
+    expect(parsed).toEqual({
+      profile: "default",
+      status: "authenticated",
+      expiresAt: null,
+      remainingSeconds: null,
+    });
+  });
+
+  it("rejects invalid --format value", async () => {
+    const cmd = statusCommand();
+    cmd.exitOverride();
+
+    await expect(cmd.parseAsync(["--format", "xml"], { from: "user" })).rejects.toThrow(
+      /Allowed choices are json, table/,
+    );
   });
 });

--- a/packages/cli/src/commands/auth/status.ts
+++ b/packages/cli/src/commands/auth/status.ts
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { loadConfigFile, validateConfig, getTokenExpiry } from "@linkedctl/core";
+import type { OutputFormat } from "../../output/index.js";
+import { resolveFormat, formatOutput } from "../../output/index.js";
 
 /**
  * Format remaining time until token expiry as a human-readable string.
@@ -27,42 +29,70 @@ function formatTimeRemaining(expiresAt: Date): string {
 export function statusCommand(): Command {
   const cmd = new Command("status");
   cmd.description("Show authentication status for the active profile");
+  cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
 
-  cmd.action(async (_opts: Record<string, unknown>, actionCmd: Command) => {
+  cmd.action(async (opts: Record<string, unknown>, actionCmd: Command) => {
     const rootOpts = actionCmd.optsWithGlobals();
     const profileFlag = typeof rootOpts["profile"] === "string" ? rootOpts["profile"] : undefined;
 
+    const format = resolveFormat(opts["format"] as OutputFormat | undefined, process.stdout);
     const { raw } = await loadConfigFile({ profile: profileFlag });
     const { config } = validateConfig(raw);
     const label = profileFlag ?? "default";
 
     if (config.oauth?.accessToken === undefined || config.oauth.accessToken === "") {
-      console.log(`Profile: ${label}`);
-      console.log("Status: not configured");
+      const data =
+        format === "json"
+          ? { profile: label, status: "not configured", expiresAt: null, remainingSeconds: null }
+          : { profile: label, status: "not configured" };
+      console.log(formatOutput(data, format));
       console.error('Run "linkedctl auth login" to set up authentication.');
       return;
     }
 
     const expiry = getTokenExpiry(config.oauth.accessToken);
 
-    console.log(`Profile: ${label}`);
-
     if (expiry === undefined) {
-      console.log("Status: authenticated");
-      console.log("Expiry: unknown (token is not a JWT)");
+      const data =
+        format === "json"
+          ? { profile: label, status: "authenticated", expiresAt: null, remainingSeconds: null }
+          : { profile: label, status: "authenticated", expires: "unknown (token is not a JWT)" };
+      console.log(formatOutput(data, format));
       return;
     }
 
     if (expiry.isExpired) {
-      console.log("Status: expired");
-      console.log(`Expired: ${expiry.expiresAt.toISOString()}`);
+      const data =
+        format === "json"
+          ? {
+              profile: label,
+              status: "expired",
+              expiresAt: expiry.expiresAt.toISOString(),
+              remainingSeconds: 0,
+            }
+          : { profile: label, status: "expired", expires: expiry.expiresAt.toISOString() };
+      console.log(formatOutput(data, format));
       console.error('Run "linkedctl auth login" to re-authenticate.');
       return;
     }
 
+    const remainingMs = expiry.expiresAt.getTime() - Date.now();
+    const remainingSeconds = Math.floor(remainingMs / 1000);
     const remaining = formatTimeRemaining(expiry.expiresAt);
-    console.log("Status: authenticated");
-    console.log(`Expires: ${expiry.expiresAt.toISOString()} (${remaining} remaining)`);
+    const data =
+      format === "json"
+        ? {
+            profile: label,
+            status: "authenticated",
+            expiresAt: expiry.expiresAt.toISOString(),
+            remainingSeconds,
+          }
+        : {
+            profile: label,
+            status: "authenticated",
+            expires: `${expiry.expiresAt.toISOString()} (${remaining} remaining)`,
+          };
+    console.log(formatOutput(data, format));
   });
 
   return cmd;


### PR DESCRIPTION
## Summary

- Adds `--format` option (`json` | `table`) to `auth status` command, following the established pattern from `whoami`, `post create`, and `profile list`
- JSON output includes structured fields: `profile`, `status`, `expiresAt`, `remainingSeconds`
- Table output preserves the existing human-readable key-value display
- Guidance messages (e.g., "Run linkedctl auth login") remain on stderr regardless of format

## Test plan

- [x] JSON format tests for all status scenarios (not configured, authenticated, expired, opaque token)
- [x] Table format tests for all existing scenarios updated
- [x] Invalid `--format` value rejection test
- [x] Full test suite passes (192/192)
- [x] Typecheck, lint, and formatting clean

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)