### PR TITLE
(feat) add exit code discipline

### DIFF
--- a/packages/cli/src/exit-codes.test.ts
+++ b/packages/cli/src/exit-codes.test.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, expect, it } from "vitest";
+import { ExitCode } from "./exit-codes.js";
+
+describe("ExitCode", () => {
+  it("defines SUCCESS as 0", () => {
+    expect(ExitCode.SUCCESS).toBe(0);
+  });
+
+  it("defines RUNTIME_ERROR as 1", () => {
+    expect(ExitCode.RUNTIME_ERROR).toBe(1);
+  });
+
+  it("defines USAGE_ERROR as 2", () => {
+    expect(ExitCode.USAGE_ERROR).toBe(2);
+  });
+});

--- a/packages/cli/src/exit-codes.ts
+++ b/packages/cli/src/exit-codes.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * CLI exit codes.
+ *
+ * - {@link ExitCode.SUCCESS} (0) — command completed successfully
+ * - {@link ExitCode.RUNTIME_ERROR} (1) — runtime failure (API, network, auth)
+ * - {@link ExitCode.USAGE_ERROR} (2) — invalid arguments or options
+ */
+export const ExitCode = {
+  SUCCESS: 0,
+  RUNTIME_ERROR: 1,
+  USAGE_ERROR: 2,
+} as const;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,4 +3,5 @@
 
 export type { OutputFormat } from "./output/index.js";
 export { detectFormat, resolveFormat, formatJson, formatTable, formatOutput, isColorEnabled } from "./output/index.js";
+export { ExitCode } from "./exit-codes.js";
 export { createProgram } from "./program.js";

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { CommanderError } from "commander";
 import { describe, expect, it } from "vitest";
 import { createProgram } from "./program.js";
 
@@ -21,5 +22,32 @@ describe("createProgram", () => {
     program.configureOutput({ writeOut: (str: string) => (helpOutput += str) });
     program.outputHelp();
     expect(helpOutput).toContain("Get started: linkedctl auth setup");
+  });
+
+  it("documents exit codes in help output", () => {
+    const program = createProgram();
+    let helpOutput = "";
+    program.configureOutput({ writeOut: (str: string) => (helpOutput += str) });
+    program.outputHelp();
+    expect(helpOutput).toContain("Exit codes:");
+    expect(helpOutput).toContain("0   success");
+    expect(helpOutput).toContain("1   runtime error");
+    expect(helpOutput).toContain("2   usage error");
+  });
+
+  it("throws CommanderError on unknown option instead of exiting", async () => {
+    const program = createProgram();
+    program.configureOutput({ writeErr: () => {} });
+
+    await expect(program.parseAsync(["node", "linkedctl", "--unknown-option"])).rejects.toThrow(CommanderError);
+  });
+
+  it("throws CommanderError with exit code 0 for --help", async () => {
+    const program = createProgram();
+    program.configureOutput({ writeOut: () => {} });
+
+    const error = await program.parseAsync(["node", "linkedctl", "--help"]).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(CommanderError);
+    expect((error as CommanderError).exitCode).toBe(0);
   });
 });

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -27,7 +27,16 @@ export function createProgram(version?: string): Command {
   program.addCommand(profileCommand());
   program.addCommand(whoamiCommand());
 
-  program.addHelpText("after", "\nGet started: linkedctl auth setup");
+  program.exitOverride();
+
+  program.addHelpText(
+    "after",
+    "\nGet started: linkedctl auth setup" +
+      "\n\nExit codes:" +
+      "\n  0   success" +
+      "\n  1   runtime error (API failure, network, auth)" +
+      "\n  2   usage error (invalid arguments or options)",
+  );
 
   return program;
 }

--- a/packages/linkedctl/src/cli.ts
+++ b/packages/linkedctl/src/cli.ts
@@ -3,8 +3,8 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { createRequire } from "node:module";
-import { Command } from "commander";
-import { createProgram } from "@linkedctl/cli";
+import { Command, CommanderError } from "commander";
+import { createProgram, ExitCode } from "@linkedctl/cli";
 import { startStdioServer } from "@linkedctl/mcp/stdio";
 
 const require = createRequire(import.meta.url);
@@ -22,7 +22,14 @@ program.addCommand(mcpCommand);
 try {
   await program.parseAsync(process.argv);
 } catch (error) {
-  const message = error instanceof Error ? error.message : String(error);
-  console.error(`error: ${message}`);
-  process.exitCode = 1;
+  if (error instanceof CommanderError) {
+    if (error.exitCode !== 0) {
+      // Usage error — Commander already printed the message
+      process.exitCode = ExitCode.USAGE_ERROR;
+    }
+  } else {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`error: ${message}`);
+    process.exitCode = ExitCode.RUNTIME_ERROR;
+  }
 }


### PR DESCRIPTION
## Summary

- Configure Commander `exitOverride()` so usage errors (invalid arguments, unknown options) exit with code **2** instead of the default 1
- Runtime errors (API failures, network, auth) continue to exit with code **1**
- Help/version display exits cleanly with code **0**
- Document exit codes in `--help` output

Closes #78

## Test plan

- [x] New tests verify `ExitCode` constants (0, 1, 2)
- [x] New tests verify exit codes documented in help output
- [x] New tests verify `CommanderError` thrown on unknown options (not `process.exit`)
- [x] New tests verify `--help` produces `CommanderError` with exit code 0
- [x] All 193 existing CLI tests pass (including those with manual `exitOverride()` calls)
- [x] Build, typecheck, lint, format checks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)