### PR TITLE
(feat) add global --json and --quiet flags

### DIFF
--- a/packages/cli/src/commands/post/create.ts
+++ b/packages/cli/src/commands/post/create.ts
@@ -60,7 +60,7 @@ async function resolveText(
  */
 export async function createPostAction(textArg: string | undefined, opts: CreateOpts, cmd: Command): Promise<void> {
   const text = await resolveText(opts.text, opts.textFile, textArg);
-  const globals = cmd.optsWithGlobals<{ profile?: string | undefined }>();
+  const globals = cmd.optsWithGlobals<{ profile?: string | undefined; json?: boolean | undefined }>();
 
   const { config } = await resolveConfig({
     profile: globals.profile,
@@ -82,7 +82,7 @@ export async function createPostAction(textArg: string | undefined, opts: Create
       visibility,
     });
 
-    const format = resolveFormat(opts.format as OutputFormat | undefined, process.stdout);
+    const format = resolveFormat(opts.format as OutputFormat | undefined, process.stdout, globals.json === true);
     const output = formatOutput({ urn: postUrn }, format);
     console.log(output);
   } catch (error) {

--- a/packages/cli/src/commands/profile/list.ts
+++ b/packages/cli/src/commands/profile/list.ts
@@ -81,7 +81,7 @@ export function listCommand(): Command {
   cmd.description("List all profiles");
   cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
 
-  cmd.action(async (opts: Record<string, unknown>) => {
+  cmd.action(async (opts: Record<string, unknown>, actionCmd: Command) => {
     const profileDir = join(homedir(), CONFIG_DIR);
     let entries: string[];
     try {
@@ -103,7 +103,8 @@ export function listCommand(): Command {
 
     const profiles = await Promise.all(names.map((name) => getProfileStatus(name)));
 
-    const format = resolveFormat(opts["format"] as OutputFormat | undefined, process.stdout);
+    const globalJson = actionCmd.optsWithGlobals<{ json?: boolean }>().json === true;
+    const format = resolveFormat(opts["format"] as OutputFormat | undefined, process.stdout, globalJson);
 
     const data =
       format === "json" ? profiles : profiles.map((p) => ({ name: p.name, status: p.status, expires: p.expires }));

--- a/packages/cli/src/commands/whoami.test.ts
+++ b/packages/cli/src/commands/whoami.test.ts
@@ -116,4 +116,51 @@ describe("whoami", () => {
     expect(parsed).not.toHaveProperty("given_name");
     expect(parsed).not.toHaveProperty("email_verified");
   });
+
+  it("outputs JSON when global --json is set", async () => {
+    const originalIsTTY = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, "isTTY", { value: true, writable: true });
+
+    try {
+      const { Command } = await import("commander");
+      const parent = new Command("linkedctl");
+      parent.enablePositionalOptions();
+      parent.option("--json", "force JSON output");
+      const cmd = whoamiCommand();
+      parent.addCommand(cmd);
+
+      await parent.parseAsync(["--json", "whoami"], { from: "user" });
+
+      expect(consoleSpy).toHaveBeenCalledOnce();
+      const output = consoleSpy.mock.calls[0]?.[0] as string;
+      const parsed = JSON.parse(output) as Record<string, unknown>;
+      expect(parsed).toHaveProperty("name", "Jane Doe");
+    } finally {
+      Object.defineProperty(process.stdout, "isTTY", { value: originalIsTTY, writable: true });
+    }
+  });
+
+  it("per-command --format takes precedence over global --json", async () => {
+    const originalIsTTY = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, "isTTY", { value: false, writable: true });
+
+    try {
+      const { Command } = await import("commander");
+      const parent = new Command("linkedctl");
+      parent.enablePositionalOptions();
+      parent.option("--json", "force JSON output");
+      const cmd = whoamiCommand();
+      parent.addCommand(cmd);
+
+      await parent.parseAsync(["--json", "whoami", "--format", "table"], { from: "user" });
+
+      expect(consoleSpy).toHaveBeenCalledOnce();
+      const output = consoleSpy.mock.calls[0]?.[0] as string;
+      // Table format uses aligned columns, not JSON
+      expect(() => JSON.parse(output)).toThrow();
+      expect(output).toContain("Jane Doe");
+    } finally {
+      Object.defineProperty(process.stdout, "isTTY", { value: originalIsTTY, writable: true });
+    }
+  });
 });

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -32,7 +32,8 @@ Examples:
 
     const userInfo = await getUserInfo(client);
 
-    const format = resolveFormat(opts["format"] as OutputFormat | undefined, process.stdout);
+    const globalJson = rootOpts["json"] === true;
+    const format = resolveFormat(opts["format"] as OutputFormat | undefined, process.stdout, globalJson);
 
     const data = {
       name: userInfo.name,

--- a/packages/cli/src/output/format.test.ts
+++ b/packages/cli/src/output/format.test.ts
@@ -35,4 +35,16 @@ describe("resolveFormat", () => {
     expect(resolveFormat(undefined, { isTTY: true })).toBe("table");
     expect(resolveFormat(undefined, { isTTY: false })).toBe("json");
   });
+
+  it("returns 'json' when globalJson is true and no explicit format", () => {
+    expect(resolveFormat(undefined, { isTTY: true }, true)).toBe("json");
+  });
+
+  it("returns explicit format even when globalJson is true", () => {
+    expect(resolveFormat("table", { isTTY: false }, true)).toBe("table");
+  });
+
+  it("falls back to TTY detection when globalJson is false", () => {
+    expect(resolveFormat(undefined, { isTTY: true }, false)).toBe("table");
+  });
 });

--- a/packages/cli/src/output/format.ts
+++ b/packages/cli/src/output/format.ts
@@ -15,8 +15,20 @@ export function detectFormat(stream: { isTTY?: boolean }): OutputFormat {
 }
 
 /**
- * Resolve the effective output format: an explicit choice overrides TTY detection.
+ * Resolve the effective output format.
+ *
+ * Precedence: per-command `--format` > global `--json` > TTY auto-detection.
  */
-export function resolveFormat(explicit: OutputFormat | undefined, stream: { isTTY?: boolean }): OutputFormat {
-  return explicit ?? detectFormat(stream);
+export function resolveFormat(
+  explicit: OutputFormat | undefined,
+  stream: { isTTY?: boolean },
+  globalJson?: boolean,
+): OutputFormat {
+  if (explicit !== undefined) {
+    return explicit;
+  }
+  if (globalJson === true) {
+    return "json";
+  }
+  return detectFormat(stream);
 }

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -50,4 +50,21 @@ describe("createProgram", () => {
     expect(error).toBeInstanceOf(CommanderError);
     expect((error as CommanderError).exitCode).toBe(0);
   });
+
+  it("registers --json global option", () => {
+    const program = createProgram();
+    let helpOutput = "";
+    program.configureOutput({ writeOut: (str: string) => (helpOutput += str) });
+    program.outputHelp();
+    expect(helpOutput).toContain("--json");
+  });
+
+  it("registers --quiet / -q global option", () => {
+    const program = createProgram();
+    let helpOutput = "";
+    program.configureOutput({ writeOut: (str: string) => (helpOutput += str) });
+    program.outputHelp();
+    expect(helpOutput).toContain("--quiet");
+    expect(helpOutput).toContain("-q");
+  });
 });

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -19,7 +19,17 @@ export function createProgram(version?: string): Command {
   }
   program.enablePositionalOptions();
   program.option("--profile <name>", "profile to use from config file");
+  program.option("--json", "force JSON output on all data-producing commands");
+  program.option("-q, --quiet", "suppress informational output");
   program.option("--no-color", "disable color output");
+
+  program.hook("preAction", (thisCommand: Command) => {
+    const opts = thisCommand.optsWithGlobals<{ quiet?: boolean }>();
+    if (opts.quiet === true) {
+      console.error = () => {};
+      console.warn = () => {};
+    }
+  });
 
   program.addCommand(authCommand());
   program.addCommand(completionCommand(program));


### PR DESCRIPTION
## Summary

- Adds `--json` global flag that forces JSON output on all data-producing commands (`whoami`, `profile list`, `post create`), overriding TTY auto-detection
- Adds `-q` / `--quiet` global flag that suppresses informational `stderr` output (`console.error`, `console.warn`) via a Commander `preAction` hook
- Per-command `--format` retains precedence over `--json` (format > json > TTY detection)

Closes #76

## Test plan

- [x] `resolveFormat` tests cover globalJson precedence (3 new tests)
- [x] `program` tests verify both flags are registered in help output
- [x] `whoami` tests verify `--json` overrides TTY and `--format` takes precedence over `--json`
- [x] Full test suite passes (194 CLI + 153 core + 15 MCP tests)
- [x] Typecheck, lint, and format checks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)