### PR TITLE
(feat) add video upload via multipart flow (#11)

### DIFF
--- a/packages/cli/src/commands/media/index.ts
+++ b/packages/cli/src/commands/media/index.ts
@@ -3,12 +3,14 @@
 
 import { Command } from "commander";
 import { uploadImageCommand } from "./upload-image.js";
+import { uploadVideoCommand } from "./upload-video.js";
 
 export function mediaCommand(): Command {
   const cmd = new Command("media");
   cmd.description("Manage LinkedIn media assets");
 
   cmd.addCommand(uploadImageCommand());
+  cmd.addCommand(uploadVideoCommand());
 
   return cmd;
 }

--- a/packages/cli/src/commands/media/upload-video.test.ts
+++ b/packages/cli/src/commands/media/upload-video.test.ts
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { createProgram } from "../../program.js";
+
+vi.mock("@linkedctl/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@linkedctl/core")>();
+  return {
+    ...actual,
+    resolveConfig: vi.fn().mockResolvedValue({
+      config: {
+        oauth: { accessToken: "test-token" },
+        apiVersion: "202601",
+      },
+      warnings: [],
+    }),
+    getCurrentPersonUrn: vi.fn().mockResolvedValue("urn:li:person:person123"),
+    uploadVideo: vi.fn().mockResolvedValue("urn:li:video:V1234567890"),
+  };
+});
+
+const coreMock = await import("@linkedctl/core");
+
+describe("media upload-video", () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(coreMock.resolveConfig).mockResolvedValue({
+      config: {
+        oauth: { accessToken: "test-token" },
+        apiVersion: "202601",
+      },
+      warnings: [],
+    });
+    vi.mocked(coreMock.uploadVideo).mockResolvedValue("urn:li:video:V1234567890");
+    vi.mocked(coreMock.getCurrentPersonUrn).mockResolvedValue("urn:li:person:person123");
+    tempDir = await mkdtemp(join(tmpdir(), "linkedctl-test-"));
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("uploads a video file and outputs the video URN", async () => {
+    const filePath = join(tempDir, "clip.mp4");
+    await writeFile(filePath, Buffer.alloc(1024));
+
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "media", "upload-video", filePath]);
+
+    expect(coreMock.uploadVideo).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        owner: "urn:li:person:person123",
+        data: expect.any(Buffer),
+      }),
+    );
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+
+  it("outputs JSON when --format json is specified", async () => {
+    const filePath = join(tempDir, "clip.mp4");
+    await writeFile(filePath, Buffer.alloc(512));
+
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "media", "upload-video", filePath, "--format", "json"]);
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(JSON.parse(output)).toEqual({ urn: "urn:li:video:V1234567890" });
+  });
+
+  it("resolves config with profile from global options", async () => {
+    const filePath = join(tempDir, "clip.mp4");
+    await writeFile(filePath, Buffer.alloc(256));
+
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "--profile", "work", "media", "upload-video", filePath]);
+
+    expect(coreMock.resolveConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profile: "work",
+      }),
+    );
+  });
+
+  it("prints upload progress to stderr", async () => {
+    const filePath = join(tempDir, "clip.mp4");
+    await writeFile(filePath, Buffer.alloc(2048));
+
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "media", "upload-video", filePath]);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("2048 bytes"));
+  });
+
+  it("wraps API errors with actionable message", async () => {
+    const { LinkedInApiError } = await import("@linkedctl/core");
+    vi.mocked(coreMock.uploadVideo).mockRejectedValueOnce(new LinkedInApiError("Forbidden", 403));
+
+    const filePath = join(tempDir, "clip.mp4");
+    await writeFile(filePath, Buffer.alloc(128));
+
+    const program = createProgram();
+    program.exitOverride();
+
+    await expect(program.parseAsync(["node", "linkedctl", "media", "upload-video", filePath])).rejects.toThrow(
+      /Failed to upload video/,
+    );
+  });
+
+  it("throws when file does not exist", async () => {
+    const filePath = join(tempDir, "nonexistent.mp4");
+
+    const program = createProgram();
+    program.exitOverride();
+
+    await expect(program.parseAsync(["node", "linkedctl", "media", "upload-video", filePath])).rejects.toThrow(
+      /ENOENT/,
+    );
+  });
+
+  it("rejects invalid --format value", async () => {
+    const filePath = join(tempDir, "clip.mp4");
+    await writeFile(filePath, Buffer.alloc(128));
+
+    const program = createProgram();
+    for (const cmd of program.commands) {
+      cmd.exitOverride();
+      for (const sub of cmd.commands) sub.exitOverride();
+    }
+
+    await expect(
+      program.parseAsync(["node", "linkedctl", "media", "upload-video", filePath, "--format", "xml"]),
+    ).rejects.toThrow(/Allowed choices are json, table/);
+  });
+});

--- a/packages/cli/src/commands/media/upload-video.ts
+++ b/packages/cli/src/commands/media/upload-video.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { readFile, stat } from "node:fs/promises";
+
+import { Command, Option } from "commander";
+import { resolveConfig, LinkedInClient, getCurrentPersonUrn, uploadVideo, LinkedInApiError } from "@linkedctl/core";
+import { resolveFormat, formatOutput } from "../../output/index.js";
+import type { OutputFormat } from "../../output/index.js";
+
+interface UploadVideoOpts {
+  format?: string | undefined;
+}
+
+export function uploadVideoCommand(): Command {
+  const cmd = new Command("upload-video");
+  cmd.description("Upload a video to LinkedIn via multipart upload");
+  cmd.argument("<file>", "path to the video file (MP4)");
+  cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
+
+  cmd.addHelpText(
+    "after",
+    `
+Examples:
+  linkedctl media upload-video clip.mp4
+  linkedctl media upload-video ~/Videos/demo.mp4 --format json`,
+  );
+
+  cmd.action(async (file: string, opts: UploadVideoOpts, actionCmd: Command) => {
+    const globals = actionCmd.optsWithGlobals<{ profile?: string | undefined; json?: boolean | undefined }>();
+
+    const fileStat = await stat(file);
+    if (!fileStat.isFile()) {
+      throw new Error(`Not a file: ${file}`);
+    }
+
+    const data = await readFile(file);
+
+    const { config } = await resolveConfig({
+      profile: globals.profile,
+      requiredScopes: ["openid", "profile", "email", "w_member_social"],
+    });
+    const accessToken = config.oauth?.accessToken ?? "";
+    const apiVersion = config.apiVersion ?? "";
+    const client = new LinkedInClient({ accessToken, apiVersion });
+
+    const ownerUrn = await getCurrentPersonUrn(client);
+
+    try {
+      console.error(`Uploading video (${data.byteLength} bytes)…`);
+      const videoUrn = await uploadVideo(client, { owner: ownerUrn, data });
+
+      const format = resolveFormat(opts.format as OutputFormat | undefined, process.stdout, globals.json === true);
+      const output = formatOutput({ urn: videoUrn }, format);
+      console.log(output);
+    } catch (error) {
+      if (error instanceof LinkedInApiError) {
+        throw new Error(`Failed to upload video: ${error.message}`);
+      }
+      throw error;
+    }
+  });
+
+  return cmd;
+}

--- a/packages/core/src/http/linkedin-client.test.ts
+++ b/packages/core/src/http/linkedin-client.test.ts
@@ -502,4 +502,61 @@ describe("LinkedInClient", () => {
       ).rejects.toThrow(LinkedInApiError);
     });
   });
+
+  describe("uploadBinary", () => {
+    it("sends PUT with binary data and Authorization header", async () => {
+      const response = new Response(null, {
+        status: 200,
+        headers: { ETag: '"etag-123"' },
+      });
+      fetchSpy.mockResolvedValueOnce(response);
+
+      const client = new LinkedInClient(CLIENT_OPTIONS);
+      const data = Buffer.from("chunk-data");
+      await client.uploadBinary("https://upload.example.com/chunk/1", data);
+
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [url, init] = fetchSpy.mock.calls[0];
+      expect(url).toBe("https://upload.example.com/chunk/1");
+      expect(init.method).toBe("PUT");
+      expect(init.headers.get("Authorization")).toBe("Bearer test-token");
+      expect(init.headers.get("Content-Type")).toBe("application/octet-stream");
+      expect(init.headers.get("User-Agent")).toBe("test-agent");
+      expect(init.body).toBe(data);
+    });
+
+    it("does not send REST.li protocol headers", async () => {
+      fetchSpy.mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+      const client = new LinkedInClient(CLIENT_OPTIONS);
+      await client.uploadBinary("https://upload.example.com/chunk/1", Buffer.from("data"));
+
+      const [, init] = fetchSpy.mock.calls[0];
+      expect(init.headers.has("LinkedIn-Version")).toBe(false);
+      expect(init.headers.has("X-Restli-Protocol-Version")).toBe(false);
+    });
+
+    it("returns the raw Response", async () => {
+      const response = new Response(null, {
+        status: 200,
+        headers: { ETag: '"etag-456"' },
+      });
+      fetchSpy.mockResolvedValueOnce(response);
+
+      const client = new LinkedInClient(CLIENT_OPTIONS);
+      const result = await client.uploadBinary("https://upload.example.com/chunk/1", Buffer.from("data"));
+
+      expect(result.headers.get("ETag")).toBe('"etag-456"');
+    });
+
+    it("throws LinkedInApiError on non-OK response", async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({ error: "bad request" }, 400));
+
+      const client = new LinkedInClient(CLIENT_OPTIONS);
+
+      await expect(client.uploadBinary("https://upload.example.com/chunk/1", Buffer.from("data"))).rejects.toThrow(
+        LinkedInApiError,
+      );
+    });
+  });
 });

--- a/packages/core/src/http/linkedin-client.ts
+++ b/packages/core/src/http/linkedin-client.ts
@@ -89,6 +89,33 @@ export class LinkedInClient {
   }
 
   /**
+   * Upload binary data via PUT to an absolute URL (e.g. a presigned upload URL).
+   *
+   * Sets the Authorization and User-Agent headers but skips REST.li
+   * protocol headers since upload endpoints are not REST.li resources.
+   * Returns the raw Response so callers can inspect headers (e.g. ETag).
+   */
+  async uploadBinary(url: string, data: Buffer): Promise<Response> {
+    const headers = new Headers();
+    headers.set("Authorization", `Bearer ${this.accessToken}`);
+    headers.set("User-Agent", this.userAgent);
+    headers.set("Content-Type", "application/octet-stream");
+
+    const response = await fetch(url, {
+      method: "PUT",
+      headers,
+      body: data,
+    });
+
+    if (!response.ok) {
+      const body = await this.tryReadBody(response);
+      throw new LinkedInApiError(`Upload failed (HTTP ${response.status})`, response.status, body);
+    }
+
+    return response;
+  }
+
+  /**
    * Execute an HTTP request with retry logic and error handling.
    * Returns the raw successful Response.
    */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,3 +53,11 @@ export { SUPPORTED_IMAGE_TYPES } from "./media/types.js";
 export { createTextPost } from "./posts/posts-service.js";
 export type { CreateTextPostOptions } from "./posts/posts-service.js";
 export type { PostVisibility } from "./posts/types.js";
+export { initializeVideoUpload, uploadVideoChunk, finalizeVideoUpload, uploadVideo } from "./video/video-service.js";
+export type {
+  InitializeVideoUploadRequest,
+  InitializeVideoUploadResponse,
+  VideoUploadInstruction,
+  FinalizeVideoUploadRequest,
+  UploadVideoOptions,
+} from "./video/types.js";

--- a/packages/core/src/video/types.ts
+++ b/packages/core/src/video/types.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * Request payload for the LinkedIn video initializeUpload action.
+ */
+export interface InitializeVideoUploadRequest {
+  /** Owner URN (e.g. `urn:li:person:abc123`). */
+  owner: string;
+  /** Total file size in bytes. */
+  fileSizeBytes: number;
+}
+
+/**
+ * A single upload instruction returned by initializeUpload.
+ */
+export interface VideoUploadInstruction {
+  /** Presigned URL to upload the chunk to via PUT. */
+  uploadUrl: string;
+  /** Byte offset of the first byte in this chunk (inclusive). */
+  firstByte: number;
+  /** Byte offset of the last byte in this chunk (inclusive). */
+  lastByte: number;
+}
+
+/**
+ * Response from the LinkedIn video initializeUpload action.
+ */
+export interface InitializeVideoUploadResponse {
+  value: {
+    /** Expiration timestamp for the upload URLs. */
+    uploadUrlsExpireAt: number;
+    /** The video URN assigned to this upload. */
+    video: string;
+    /** Ordered list of chunk upload instructions. */
+    uploadInstructions: VideoUploadInstruction[];
+    /** Token required for the finalizeUpload call. */
+    uploadToken: string;
+  };
+}
+
+/**
+ * Request payload for the LinkedIn video finalizeUpload action.
+ */
+export interface FinalizeVideoUploadRequest {
+  /** The video URN from initializeUpload. */
+  video: string;
+  /** The upload token from initializeUpload. */
+  uploadToken: string;
+  /** ETags collected from each chunk upload, in order. */
+  uploadedPartIds: string[];
+}
+
+/**
+ * Options for the high-level uploadVideo function.
+ */
+export interface UploadVideoOptions {
+  /** Owner URN (e.g. `urn:li:person:abc123`). */
+  owner: string;
+  /** Raw video file data. */
+  data: Buffer;
+}

--- a/packages/core/src/video/video-service.test.ts
+++ b/packages/core/src/video/video-service.test.ts
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, expect, it, vi } from "vitest";
+import { finalizeVideoUpload, initializeVideoUpload, uploadVideo, uploadVideoChunk } from "./video-service.js";
+import type { LinkedInClient } from "../http/linkedin-client.js";
+import type { InitializeVideoUploadResponse } from "./types.js";
+
+function mockClient(overrides?: Partial<LinkedInClient>): LinkedInClient {
+  return {
+    request: vi.fn(),
+    uploadBinary: vi.fn(),
+    ...overrides,
+  } as unknown as LinkedInClient;
+}
+
+const INIT_RESPONSE: InitializeVideoUploadResponse = {
+  value: {
+    uploadUrlsExpireAt: Date.now() + 3600_000,
+    video: "urn:li:video:C5F10AQGyzL",
+    uploadInstructions: [
+      { uploadUrl: "https://upload.example.com/chunk/0", firstByte: 0, lastByte: 4_194_303 },
+      { uploadUrl: "https://upload.example.com/chunk/1", firstByte: 4_194_304, lastByte: 5_000_000 },
+    ],
+    uploadToken: "upload-token-abc",
+  },
+};
+
+describe("initializeVideoUpload", () => {
+  it("calls client.request with correct path and body", async () => {
+    const client = mockClient({ request: vi.fn().mockResolvedValue(INIT_RESPONSE) });
+
+    const result = await initializeVideoUpload(client, {
+      owner: "urn:li:person:abc",
+      fileSizeBytes: 5_000_001,
+    });
+
+    expect(client.request).toHaveBeenCalledWith("/rest/videos?action=initializeUpload", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        initializeUploadRequest: {
+          owner: "urn:li:person:abc",
+          fileSizeBytes: 5_000_001,
+        },
+      }),
+    });
+    expect(result).toEqual(INIT_RESPONSE);
+  });
+});
+
+describe("uploadVideoChunk", () => {
+  it("uploads chunk and returns ETag", async () => {
+    const response = new Response(null, {
+      status: 200,
+      headers: { ETag: '"etag-chunk-0"' },
+    });
+    const client = mockClient({ uploadBinary: vi.fn().mockResolvedValue(response) });
+    const chunk = Buffer.alloc(1024);
+
+    const etag = await uploadVideoChunk(client, "https://upload.example.com/chunk/0", chunk);
+
+    expect(client.uploadBinary).toHaveBeenCalledWith("https://upload.example.com/chunk/0", chunk);
+    expect(etag).toBe('"etag-chunk-0"');
+  });
+
+  it("throws when ETag header is missing", async () => {
+    const response = new Response(null, { status: 200 });
+    const client = mockClient({ uploadBinary: vi.fn().mockResolvedValue(response) });
+
+    await expect(uploadVideoChunk(client, "https://upload.example.com/chunk/0", Buffer.alloc(1))).rejects.toThrow(
+      /ETag/,
+    );
+  });
+});
+
+describe("finalizeVideoUpload", () => {
+  it("calls client.request with correct path and body", async () => {
+    const client = mockClient({ request: vi.fn().mockResolvedValue(undefined) });
+
+    await finalizeVideoUpload(client, {
+      video: "urn:li:video:C5F10AQGyzL",
+      uploadToken: "upload-token-abc",
+      uploadedPartIds: ['"etag-0"', '"etag-1"'],
+    });
+
+    expect(client.request).toHaveBeenCalledWith("/rest/videos?action=finalizeUpload", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        finalizeUploadRequest: {
+          video: "urn:li:video:C5F10AQGyzL",
+          uploadToken: "upload-token-abc",
+          uploadedPartIds: ['"etag-0"', '"etag-1"'],
+        },
+      }),
+    });
+  });
+});
+
+describe("uploadVideo", () => {
+  it("orchestrates initialize, chunk uploads, and finalize", async () => {
+    const requestMock = vi
+      .fn()
+      .mockResolvedValueOnce(INIT_RESPONSE) // initializeUpload
+      .mockResolvedValueOnce(undefined); // finalizeUpload
+
+    const uploadBinaryMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 200, headers: { ETag: '"etag-0"' } }))
+      .mockResolvedValueOnce(new Response(null, { status: 200, headers: { ETag: '"etag-1"' } }));
+
+    const client = mockClient({ request: requestMock, uploadBinary: uploadBinaryMock });
+
+    const data = Buffer.alloc(5_000_001);
+    const videoUrn = await uploadVideo(client, {
+      owner: "urn:li:person:abc",
+      data,
+    });
+
+    expect(videoUrn).toBe("urn:li:video:C5F10AQGyzL");
+
+    // Verify initialize was called
+    expect(requestMock).toHaveBeenCalledWith(
+      "/rest/videos?action=initializeUpload",
+      expect.objectContaining({ method: "POST" }),
+    );
+
+    // Verify chunks were uploaded in order
+    expect(uploadBinaryMock).toHaveBeenCalledTimes(2);
+    const firstChunk = uploadBinaryMock.mock.calls[0]?.[1] as Buffer;
+    expect(firstChunk.byteLength).toBe(4_194_304);
+    const secondChunk = uploadBinaryMock.mock.calls[1]?.[1] as Buffer;
+    expect(secondChunk.byteLength).toBe(805_697);
+
+    // Verify finalize was called with collected ETags
+    expect(requestMock).toHaveBeenCalledWith(
+      "/rest/videos?action=finalizeUpload",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          finalizeUploadRequest: {
+            video: "urn:li:video:C5F10AQGyzL",
+            uploadToken: "upload-token-abc",
+            uploadedPartIds: ['"etag-0"', '"etag-1"'],
+          },
+        }),
+      }),
+    );
+  });
+
+  it("handles a single-chunk upload", async () => {
+    const singleChunkResponse: InitializeVideoUploadResponse = {
+      value: {
+        uploadUrlsExpireAt: Date.now() + 3600_000,
+        video: "urn:li:video:small",
+        uploadInstructions: [{ uploadUrl: "https://upload.example.com/chunk/0", firstByte: 0, lastByte: 999 }],
+        uploadToken: "token-small",
+      },
+    };
+
+    const requestMock = vi.fn().mockResolvedValueOnce(singleChunkResponse).mockResolvedValueOnce(undefined);
+
+    const uploadBinaryMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 200, headers: { ETag: '"etag-only"' } }));
+
+    const client = mockClient({ request: requestMock, uploadBinary: uploadBinaryMock });
+
+    const data = Buffer.alloc(1000);
+    const videoUrn = await uploadVideo(client, {
+      owner: "urn:li:person:abc",
+      data,
+    });
+
+    expect(videoUrn).toBe("urn:li:video:small");
+    expect(uploadBinaryMock).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/src/video/video-service.ts
+++ b/packages/core/src/video/video-service.ts
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { LinkedInClient } from "../http/linkedin-client.js";
+import type {
+  FinalizeVideoUploadRequest,
+  InitializeVideoUploadRequest,
+  InitializeVideoUploadResponse,
+  UploadVideoOptions,
+} from "./types.js";
+
+/**
+ * Initialize a video upload with LinkedIn.
+ *
+ * Returns the video URN, upload instructions (presigned URLs), and upload token.
+ */
+export async function initializeVideoUpload(
+  client: LinkedInClient,
+  options: InitializeVideoUploadRequest,
+): Promise<InitializeVideoUploadResponse> {
+  return client.request<InitializeVideoUploadResponse>("/rest/videos?action=initializeUpload", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      initializeUploadRequest: {
+        owner: options.owner,
+        fileSizeBytes: options.fileSizeBytes,
+      },
+    }),
+  });
+}
+
+/**
+ * Upload a single binary chunk to a presigned upload URL.
+ *
+ * Returns the ETag header from the response.
+ */
+export async function uploadVideoChunk(client: LinkedInClient, uploadUrl: string, chunk: Buffer): Promise<string> {
+  const response = await client.uploadBinary(uploadUrl, chunk);
+  const etag = response.headers.get("etag");
+  if (etag === null) {
+    throw new Error("Upload response missing ETag header");
+  }
+  return etag;
+}
+
+/**
+ * Finalize a video upload after all chunks have been uploaded.
+ */
+export async function finalizeVideoUpload(client: LinkedInClient, options: FinalizeVideoUploadRequest): Promise<void> {
+  await client.request<undefined>("/rest/videos?action=finalizeUpload", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      finalizeUploadRequest: {
+        video: options.video,
+        uploadToken: options.uploadToken,
+        uploadedPartIds: options.uploadedPartIds,
+      },
+    }),
+  });
+}
+
+/**
+ * Upload a video to LinkedIn via the multipart flow:
+ * initialize → chunk upload → finalize.
+ *
+ * Splits the file into chunks matching the upload instructions,
+ * uploads each chunk, collects ETags, and finalizes.
+ *
+ * Returns the video URN.
+ */
+export async function uploadVideo(client: LinkedInClient, options: UploadVideoOptions): Promise<string> {
+  const { owner, data } = options;
+
+  const initResponse = await initializeVideoUpload(client, {
+    owner,
+    fileSizeBytes: data.byteLength,
+  });
+
+  const { video, uploadInstructions, uploadToken } = initResponse.value;
+
+  const etags: string[] = [];
+  for (const instruction of uploadInstructions) {
+    const chunk = data.subarray(instruction.firstByte, instruction.lastByte + 1);
+    const etag = await uploadVideoChunk(client, instruction.uploadUrl, chunk);
+    etags.push(etag);
+  }
+
+  await finalizeVideoUpload(client, {
+    video,
+    uploadToken,
+    uploadedPartIds: etags,
+  });
+
+  return video;
+}


### PR DESCRIPTION
## Summary

- Adds `linkedctl media upload-video <file>` CLI command for uploading videos to LinkedIn
- Implements the full multipart upload flow: initialize → chunk upload (with ETag collection) → finalize
- Adds `uploadBinary` method to `LinkedInClient` for binary PUT to presigned upload URLs
- Creates `@linkedctl/core` video service with `initializeVideoUpload`, `uploadVideoChunk`, `finalizeVideoUpload`, and high-level `uploadVideo` orchestrator

## Test plan

- [x] Core: `video-service.test.ts` — unit tests for initialize, chunk upload, finalize, and full orchestrator (6 tests)
- [x] Core: `linkedin-client.test.ts` — unit tests for `uploadBinary` method (4 new tests)
- [x] CLI: `upload-video.test.ts` — command integration tests covering output formats, profile resolution, error wrapping, and file validation (7 tests)
- [x] All existing tests pass (390 total)
- [x] Build, typecheck, lint, and format checks pass

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)