### PR TITLE
(ux) standardize profile show output with formatOutput

### DIFF
--- a/packages/cli/src/commands/profile/show.test.ts
+++ b/packages/cli/src/commands/profile/show.test.ts
@@ -24,7 +24,7 @@ describe("profile show", () => {
     vi.restoreAllMocks();
   });
 
-  it("shows profile with redacted access token", async () => {
+  it("outputs table format with redacted access token", async () => {
     loadConfigFileSpy.mockResolvedValue({
       raw: {
         oauth: { "access-token": "abcdefghijklmnop" },
@@ -34,14 +34,16 @@ describe("profile show", () => {
     });
 
     const cmd = showCommand();
-    await cmd.parseAsync(["personal"], { from: "user" });
+    await cmd.parseAsync(["personal", "--format", "table"], { from: "user" });
 
-    expect(consoleSpy).toHaveBeenCalledWith("Profile: personal");
-    expect(consoleSpy).toHaveBeenCalledWith("  access-token: abcd****mnop");
-    expect(consoleSpy).toHaveBeenCalledWith("  api-version: 202601");
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain("personal");
+    expect(output).toContain("abcd****mnop");
+    expect(output).toContain("202601");
   });
 
-  it("shows all redacted oauth fields when present", async () => {
+  it("outputs table format with all redacted oauth fields", async () => {
     loadConfigFileSpy.mockResolvedValue({
       raw: {
         oauth: {
@@ -57,18 +59,20 @@ describe("profile show", () => {
     });
 
     const cmd = showCommand();
-    await cmd.parseAsync(["work"], { from: "user" });
+    await cmd.parseAsync(["work", "--format", "table"], { from: "user" });
 
-    expect(consoleSpy).toHaveBeenCalledWith("Profile: work");
-    expect(consoleSpy).toHaveBeenCalledWith("  client-id: abcd****mnop");
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("  client-secret: secr****cret"));
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("  access-token: toke****oken"));
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("  refresh-token: refr****resh"));
-    expect(consoleSpy).toHaveBeenCalledWith("  token-expires-at: 2099-12-31T23:59:59Z");
-    expect(consoleSpy).toHaveBeenCalledWith("  api-version: 202601");
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain("work");
+    expect(output).toContain("abcd****mnop");
+    expect(output).toContain("secr****cret");
+    expect(output).toContain("toke****oken");
+    expect(output).toContain("refr****resh");
+    expect(output).toContain("2099-12-31T23:59:59Z");
+    expect(output).toContain("202601");
   });
 
-  it("shows short secrets as fully redacted", async () => {
+  it("outputs table format with short secrets fully redacted", async () => {
     loadConfigFileSpy.mockResolvedValue({
       raw: {
         oauth: { "access-token": "short" },
@@ -78,20 +82,113 @@ describe("profile show", () => {
     });
 
     const cmd = showCommand();
-    await cmd.parseAsync(["personal"], { from: "user" });
+    await cmd.parseAsync(["personal", "--format", "table"], { from: "user" });
 
-    expect(consoleSpy).toHaveBeenCalledWith("  access-token: ****");
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain("****");
+  });
+
+  it("outputs JSON with all fields when --format json is specified", async () => {
+    loadConfigFileSpy.mockResolvedValue({
+      raw: {
+        oauth: {
+          "client-id": "abcdefghijklmnop",
+          "client-secret": "secretsecretsecretsecret",
+          "access-token": "tokentokentokentoken",
+          "refresh-token": "refreshrefreshrefresh",
+          "token-expires-at": "2099-12-31T23:59:59Z",
+        },
+        "api-version": "202601",
+      },
+      path: "/mock/home/.linkedctl/work.yaml",
+    });
+
+    const cmd = showCommand();
+    await cmd.parseAsync(["work", "--format", "json"], { from: "user" });
+
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    const parsed = JSON.parse(consoleSpy.mock.calls[0]?.[0] as string) as Record<string, unknown>;
+    expect(parsed).toEqual({
+      profile: "work",
+      clientId: "abcd****mnop",
+      clientSecret: "secr****cret",
+      accessToken: "toke****oken",
+      refreshToken: "refr****resh",
+      tokenExpiresAt: "2099-12-31T23:59:59Z",
+      apiVersion: "202601",
+    });
+  });
+
+  it("outputs JSON with nulls for missing fields", async () => {
+    loadConfigFileSpy.mockResolvedValue({
+      raw: {
+        oauth: { "access-token": "abcdefghijklmnop" },
+        "api-version": "202601",
+      },
+      path: "/mock/home/.linkedctl/personal.yaml",
+    });
+
+    const cmd = showCommand();
+    await cmd.parseAsync(["personal", "--format", "json"], { from: "user" });
+
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    const parsed = JSON.parse(consoleSpy.mock.calls[0]?.[0] as string) as Record<string, unknown>;
+    expect(parsed).toEqual({
+      profile: "personal",
+      clientId: null,
+      clientSecret: null,
+      accessToken: "abcd****mnop",
+      refreshToken: null,
+      tokenExpiresAt: null,
+      apiVersion: "202601",
+    });
+  });
+
+  it("outputs JSON with all nulls when no oauth is configured", async () => {
+    loadConfigFileSpy.mockResolvedValue({
+      raw: {
+        "api-version": "202601",
+      },
+      path: "/mock/home/.linkedctl/minimal.yaml",
+    });
+
+    const cmd = showCommand();
+    await cmd.parseAsync(["minimal", "--format", "json"], { from: "user" });
+
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    const parsed = JSON.parse(consoleSpy.mock.calls[0]?.[0] as string) as Record<string, unknown>;
+    expect(parsed).toEqual({
+      profile: "minimal",
+      clientId: null,
+      clientSecret: null,
+      accessToken: null,
+      refreshToken: null,
+      tokenExpiresAt: null,
+      apiVersion: "202601",
+    });
   });
 
   it("throws when profile does not exist", async () => {
     loadConfigFileSpy.mockResolvedValue({ raw: undefined, path: undefined });
 
     const cmd = showCommand();
-    await expect(cmd.parseAsync(["nonexistent"], { from: "user" })).rejects.toThrow(/not found/);
+    await expect(cmd.parseAsync(["nonexistent", "--format", "table"], { from: "user" })).rejects.toThrow(/not found/);
   });
 
   it("throws for invalid profile name", async () => {
     const cmd = showCommand();
-    await expect(cmd.parseAsync(["../evil"], { from: "user" })).rejects.toThrow(/Invalid profile name/);
+    await expect(cmd.parseAsync(["../evil", "--format", "table"], { from: "user" })).rejects.toThrow(
+      /Invalid profile name/,
+    );
+  });
+
+  it("rejects invalid --format value", async () => {
+    const cmd = showCommand();
+    cmd.exitOverride();
+
+    await expect(cmd.parseAsync(["personal", "--format", "xml"], { from: "user" })).rejects.toThrow(
+      /Allowed choices are json, table/,
+    );
   });
 });

--- a/packages/cli/src/commands/profile/show.ts
+++ b/packages/cli/src/commands/profile/show.ts
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { loadConfigFile, validateConfig, isValidProfileName } from "@linkedctl/core";
+import type { OutputFormat } from "../../output/index.js";
+import { resolveFormat, formatOutput } from "../../output/index.js";
 
 function redactSecret(value: string): string {
   if (value.length <= 8) {
@@ -15,8 +17,9 @@ export function showCommand(): Command {
   const cmd = new Command("show");
   cmd.description("Show profile details (secrets redacted)");
   cmd.argument("<name>", "profile name");
+  cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
 
-  cmd.action(async (name: string) => {
+  cmd.action(async (name: string, opts: Record<string, unknown>, actionCmd: Command) => {
     if (!isValidProfileName(name)) {
       throw new Error(`Invalid profile name "${name}". Names must not contain path separators or be empty.`);
     }
@@ -27,29 +30,30 @@ export function showCommand(): Command {
     }
 
     const { config } = validateConfig(raw);
+    const rootOpts = actionCmd.optsWithGlobals();
+    const globalJson = rootOpts["json"] === true;
+    const format = resolveFormat(opts["format"] as OutputFormat | undefined, process.stdout, globalJson);
 
-    console.log(`Profile: ${name}`);
-
-    if (config.oauth !== undefined) {
-      if (config.oauth.clientId !== undefined) {
-        console.log(`  client-id: ${redactSecret(config.oauth.clientId)}`);
-      }
-      if (config.oauth.clientSecret !== undefined) {
-        console.log(`  client-secret: ${redactSecret(config.oauth.clientSecret)}`);
-      }
-      if (config.oauth.accessToken !== undefined) {
-        console.log(`  access-token: ${redactSecret(config.oauth.accessToken)}`);
-      }
-      if (config.oauth.refreshToken !== undefined) {
-        console.log(`  refresh-token: ${redactSecret(config.oauth.refreshToken)}`);
-      }
-      if (config.oauth.tokenExpiresAt !== undefined) {
-        console.log(`  token-expires-at: ${config.oauth.tokenExpiresAt}`);
-      }
-    }
-
-    if (config.apiVersion !== undefined) {
-      console.log(`  api-version: ${config.apiVersion}`);
+    if (format === "json") {
+      const data: Record<string, string | null> = {
+        profile: name,
+        clientId: config.oauth?.clientId !== undefined ? redactSecret(config.oauth.clientId) : null,
+        clientSecret: config.oauth?.clientSecret !== undefined ? redactSecret(config.oauth.clientSecret) : null,
+        accessToken: config.oauth?.accessToken !== undefined ? redactSecret(config.oauth.accessToken) : null,
+        refreshToken: config.oauth?.refreshToken !== undefined ? redactSecret(config.oauth.refreshToken) : null,
+        tokenExpiresAt: config.oauth?.tokenExpiresAt ?? null,
+        apiVersion: config.apiVersion ?? null,
+      };
+      console.log(formatOutput(data, format));
+    } else {
+      const data: Record<string, string> = { profile: name };
+      if (config.oauth?.clientId !== undefined) data["client-id"] = redactSecret(config.oauth.clientId);
+      if (config.oauth?.clientSecret !== undefined) data["client-secret"] = redactSecret(config.oauth.clientSecret);
+      if (config.oauth?.accessToken !== undefined) data["access-token"] = redactSecret(config.oauth.accessToken);
+      if (config.oauth?.refreshToken !== undefined) data["refresh-token"] = redactSecret(config.oauth.refreshToken);
+      if (config.oauth?.tokenExpiresAt !== undefined) data["token-expires-at"] = config.oauth.tokenExpiresAt;
+      if (config.apiVersion !== undefined) data["api-version"] = config.apiVersion;
+      console.log(formatOutput(data, format));
     }
   });
 


### PR DESCRIPTION
## Summary

- Migrate `profile show` from custom `console.log()` formatting to `formatOutput()` with `--format json|table` support
- JSON output: camelCase keys, all fields present (null for missing), predictable schema for machine consumption
- Table output: kebab-case keys, only present fields, matching the original display style
- Supports global `--json` flag and piped-context auto-detection (non-TTY → JSON)

Closes #105

## Test plan

- [x] JSON format outputs all fields with camelCase keys and nulls for missing values
- [x] Table format outputs only present fields with kebab-case keys
- [x] Short secrets are fully redacted (`****`)
- [x] Invalid `--format` value is rejected
- [x] Error cases preserved (invalid profile name, profile not found)
- [x] All 237 existing tests pass
- [x] Typecheck, lint, and formatting pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)