### PR TITLE
(feat) add rich content posts

### DIFF
--- a/packages/cli/src/commands/post/create.test.ts
+++ b/packages/cli/src/commands/post/create.test.ts
@@ -21,6 +21,7 @@ vi.mock("@linkedctl/core", async (importOriginal) => {
     }),
     getCurrentPersonUrn: vi.fn().mockResolvedValue("urn:li:person:person123"),
     createTextPost: vi.fn().mockResolvedValue("urn:li:share:111222333"),
+    createPost: vi.fn().mockResolvedValue("urn:li:share:111222333"),
   };
 });
 
@@ -39,7 +40,7 @@ describe("post create", () => {
       },
       warnings: [],
     });
-    vi.mocked(coreMock.createTextPost).mockResolvedValue("urn:li:share:111222333");
+    vi.mocked(coreMock.createPost).mockResolvedValue("urn:li:share:111222333");
     vi.mocked(coreMock.getCurrentPersonUrn).mockResolvedValue("urn:li:person:person123");
   });
 
@@ -51,7 +52,7 @@ describe("post create", () => {
     const program = createProgram();
     await program.parseAsync(["node", "linkedctl", "post", "create", "--text", "Hello LinkedIn"]);
 
-    expect(coreMock.createTextPost).toHaveBeenCalledWith(
+    expect(coreMock.createPost).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         author: "urn:li:person:person123",
@@ -66,7 +67,7 @@ describe("post create", () => {
     const program = createProgram();
     await program.parseAsync(["node", "linkedctl", "post", "Hello from shorthand"]);
 
-    expect(coreMock.createTextPost).toHaveBeenCalledWith(
+    expect(coreMock.createPost).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         text: "Hello from shorthand",
@@ -78,7 +79,7 @@ describe("post create", () => {
     const program = createProgram();
     await program.parseAsync(["node", "linkedctl", "post", "--text", "Hello from text option"]);
 
-    expect(coreMock.createTextPost).toHaveBeenCalledWith(
+    expect(coreMock.createPost).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         text: "Hello from text option",
@@ -90,7 +91,7 @@ describe("post create", () => {
     const program = createProgram();
     await program.parseAsync(["node", "linkedctl", "post", "positional", "--text", "from option"]);
 
-    expect(coreMock.createTextPost).toHaveBeenCalledWith(
+    expect(coreMock.createPost).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         text: "from option",
@@ -102,7 +103,7 @@ describe("post create", () => {
     const program = createProgram();
     await program.parseAsync(["node", "linkedctl", "post", "--text", "Private", "--visibility", "CONNECTIONS"]);
 
-    expect(coreMock.createTextPost).toHaveBeenCalledWith(
+    expect(coreMock.createPost).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         visibility: "CONNECTIONS",
@@ -123,7 +124,7 @@ describe("post create", () => {
       "CONNECTIONS",
     ]);
 
-    expect(coreMock.createTextPost).toHaveBeenCalledWith(
+    expect(coreMock.createPost).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         visibility: "CONNECTIONS",
@@ -135,7 +136,7 @@ describe("post create", () => {
     const program = createProgram();
     await program.parseAsync(["node", "linkedctl", "post", "create", "--text", "Public post"]);
 
-    expect(coreMock.createTextPost).toHaveBeenCalledWith(
+    expect(coreMock.createPost).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         visibility: "PUBLIC",
@@ -175,7 +176,7 @@ describe("post create", () => {
     const program = createProgram();
     await program.parseAsync(["node", "linkedctl", "post", "create", "--text", "Hello", "--visibility", "connections"]);
 
-    expect(coreMock.createTextPost).toHaveBeenCalledWith(
+    expect(coreMock.createPost).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         visibility: "CONNECTIONS",
@@ -187,7 +188,7 @@ describe("post create", () => {
     const program = createProgram();
     await program.parseAsync(["node", "linkedctl", "post", "create", "--text", "Hello", "--visibility", "Public"]);
 
-    expect(coreMock.createTextPost).toHaveBeenCalledWith(
+    expect(coreMock.createPost).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         visibility: "PUBLIC",
@@ -199,7 +200,7 @@ describe("post create", () => {
     const program = createProgram();
     await program.parseAsync(["node", "linkedctl", "post", "--text", "Hello", "--visibility", "public"]);
 
-    expect(coreMock.createTextPost).toHaveBeenCalledWith(
+    expect(coreMock.createPost).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         visibility: "PUBLIC",
@@ -247,7 +248,7 @@ describe("post create", () => {
     const program = createProgram();
     await program.parseAsync(["node", "linkedctl", "post", "create", "Hello positional"]);
 
-    expect(coreMock.createTextPost).toHaveBeenCalledWith(
+    expect(coreMock.createPost).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         text: "Hello positional",
@@ -259,7 +260,7 @@ describe("post create", () => {
     const program = createProgram();
     await program.parseAsync(["node", "linkedctl", "post", "create", "positional", "--text", "from option"]);
 
-    expect(coreMock.createTextPost).toHaveBeenCalledWith(
+    expect(coreMock.createPost).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         text: "from option",
@@ -269,7 +270,7 @@ describe("post create", () => {
 
   it("wraps API errors with actionable message", async () => {
     const { LinkedInApiError } = await import("@linkedctl/core");
-    vi.mocked(coreMock.createTextPost).mockRejectedValueOnce(new LinkedInApiError("Forbidden", 403));
+    vi.mocked(coreMock.createPost).mockRejectedValueOnce(new LinkedInApiError("Forbidden", 403));
 
     const program = createProgram();
     program.exitOverride();
@@ -297,7 +298,7 @@ describe("post create", () => {
       const program = createProgram();
       await program.parseAsync(["node", "linkedctl", "post", "create", "--text-file", filePath]);
 
-      expect(coreMock.createTextPost).toHaveBeenCalledWith(
+      expect(coreMock.createPost).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
           text: "Hello from file",
@@ -312,7 +313,7 @@ describe("post create", () => {
       const program = createProgram();
       await program.parseAsync(["node", "linkedctl", "post", "--text-file", filePath]);
 
-      expect(coreMock.createTextPost).toHaveBeenCalledWith(
+      expect(coreMock.createPost).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
           text: "Hello from file shorthand",
@@ -327,7 +328,7 @@ describe("post create", () => {
       const program = createProgram();
       await program.parseAsync(["node", "linkedctl", "post", "create", "--text-file", filePath]);
 
-      expect(coreMock.createTextPost).toHaveBeenCalledWith(
+      expect(coreMock.createPost).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
           text: "Hello trimmed",
@@ -351,7 +352,7 @@ describe("post create", () => {
         filePath,
       ]);
 
-      expect(coreMock.createTextPost).toHaveBeenCalledWith(
+      expect(coreMock.createPost).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
           text: "from option",
@@ -366,7 +367,7 @@ describe("post create", () => {
       const program = createProgram();
       await program.parseAsync(["node", "linkedctl", "post", "--text", "from option", "--text-file", filePath]);
 
-      expect(coreMock.createTextPost).toHaveBeenCalledWith(
+      expect(coreMock.createPost).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
           text: "from option",
@@ -383,6 +384,185 @@ describe("post create", () => {
       await expect(
         program.parseAsync(["node", "linkedctl", "post", "create", "--text-file", filePath]),
       ).rejects.toThrow(/ENOENT/);
+    });
+  });
+
+  describe("media options", () => {
+    it("creates a post with --image option", async () => {
+      const program = createProgram();
+      await program.parseAsync([
+        "node",
+        "linkedctl",
+        "post",
+        "create",
+        "--text",
+        "Check this",
+        "--image",
+        "urn:li:image:C5608AQ123",
+      ]);
+
+      expect(coreMock.createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          text: "Check this",
+          content: { media: { id: "urn:li:image:C5608AQ123" } },
+        }),
+      );
+    });
+
+    it("creates a post with --video option", async () => {
+      const program = createProgram();
+      await program.parseAsync([
+        "node",
+        "linkedctl",
+        "post",
+        "create",
+        "--text",
+        "Watch this",
+        "--video",
+        "urn:li:video:D5608AQ456",
+      ]);
+
+      expect(coreMock.createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          text: "Watch this",
+          content: { media: { id: "urn:li:video:D5608AQ456" } },
+        }),
+      );
+    });
+
+    it("creates a post with --document option", async () => {
+      const program = createProgram();
+      await program.parseAsync([
+        "node",
+        "linkedctl",
+        "post",
+        "create",
+        "--text",
+        "Read this",
+        "--document",
+        "urn:li:document:D789",
+      ]);
+
+      expect(coreMock.createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          text: "Read this",
+          content: { media: { id: "urn:li:document:D789" } },
+        }),
+      );
+    });
+
+    it("creates a post with --article-url option", async () => {
+      const program = createProgram();
+      await program.parseAsync([
+        "node",
+        "linkedctl",
+        "post",
+        "create",
+        "--text",
+        "Great read",
+        "--article-url",
+        "https://example.com/article",
+      ]);
+
+      expect(coreMock.createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          text: "Great read",
+          content: { article: { source: "https://example.com/article" } },
+        }),
+      );
+    });
+
+    it("creates a post with --images option (multi-image)", async () => {
+      const program = createProgram();
+      await program.parseAsync([
+        "node",
+        "linkedctl",
+        "post",
+        "create",
+        "--text",
+        "Gallery",
+        "--images",
+        "urn:li:image:A1,urn:li:image:A2,urn:li:image:A3",
+      ]);
+
+      expect(coreMock.createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          text: "Gallery",
+          content: {
+            multiImage: {
+              images: [{ id: "urn:li:image:A1" }, { id: "urn:li:image:A2" }, { id: "urn:li:image:A3" }],
+            },
+          },
+        }),
+      );
+    });
+
+    it("rejects --images with fewer than 2 URNs", async () => {
+      const program = createProgram();
+      program.exitOverride();
+
+      await expect(
+        program.parseAsync(["node", "linkedctl", "post", "create", "--text", "Single", "--images", "urn:li:image:A1"]),
+      ).rejects.toThrow(/at least 2/);
+    });
+
+    it("rejects multiple media options", async () => {
+      const program = createProgram();
+      program.exitOverride();
+
+      await expect(
+        program.parseAsync([
+          "node",
+          "linkedctl",
+          "post",
+          "create",
+          "--text",
+          "Both",
+          "--image",
+          "urn:li:image:X",
+          "--video",
+          "urn:li:video:Y",
+        ]),
+      ).rejects.toThrow(/Only one media option/);
+    });
+
+    it("creates a post with --image on post shorthand", async () => {
+      const program = createProgram();
+      await program.parseAsync([
+        "node",
+        "linkedctl",
+        "post",
+        "--text",
+        "Shorthand image",
+        "--image",
+        "urn:li:image:S1",
+      ]);
+
+      expect(coreMock.createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          text: "Shorthand image",
+          content: { media: { id: "urn:li:image:S1" } },
+        }),
+      );
+    });
+
+    it("passes no content when no media option is given", async () => {
+      const program = createProgram();
+      await program.parseAsync(["node", "linkedctl", "post", "create", "--text", "Plain text"]);
+
+      expect(coreMock.createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          text: "Plain text",
+          content: undefined,
+        }),
+      );
     });
   });
 });

--- a/packages/cli/src/commands/post/create.ts
+++ b/packages/cli/src/commands/post/create.ts
@@ -4,8 +4,8 @@
 import { readFile } from "node:fs/promises";
 
 import { Command, InvalidArgumentError, Option } from "commander";
-import { resolveConfig, LinkedInClient, getCurrentPersonUrn, createTextPost, LinkedInApiError } from "@linkedctl/core";
-import type { PostVisibility } from "@linkedctl/core";
+import { resolveConfig, LinkedInClient, getCurrentPersonUrn, createPost, LinkedInApiError } from "@linkedctl/core";
+import type { PostVisibility, PostContent } from "@linkedctl/core";
 import { resolveFormat, formatOutput } from "../../output/index.js";
 import type { OutputFormat } from "../../output/index.js";
 import { readStdin } from "./stdin.js";
@@ -14,6 +14,11 @@ interface CreateOpts {
   text?: string | undefined;
   textFile?: string | undefined;
   visibility?: string | undefined;
+  image?: string | undefined;
+  video?: string | undefined;
+  document?: string | undefined;
+  articleUrl?: string | undefined;
+  images?: string | undefined;
   format?: string | undefined;
 }
 
@@ -56,10 +61,45 @@ async function resolveText(
 }
 
 /**
- * Shared action handler for creating a text post.
+ * Resolve media content from mutually exclusive CLI options.
+ */
+function resolveContent(opts: CreateOpts): PostContent | undefined {
+  const mediaFlags = [opts.image, opts.video, opts.document, opts.articleUrl, opts.images].filter(
+    (v) => v !== undefined,
+  );
+
+  if (mediaFlags.length > 1) {
+    throw new Error("Only one media option may be specified: --image, --video, --document, --article-url, or --images");
+  }
+
+  if (opts.image !== undefined) {
+    return { media: { id: opts.image } };
+  }
+  if (opts.video !== undefined) {
+    return { media: { id: opts.video } };
+  }
+  if (opts.document !== undefined) {
+    return { media: { id: opts.document } };
+  }
+  if (opts.articleUrl !== undefined) {
+    return { article: { source: opts.articleUrl } };
+  }
+  if (opts.images !== undefined) {
+    const ids = opts.images.split(",").map((s) => s.trim());
+    if (ids.length < 2) {
+      throw new Error("--images requires at least 2 comma-separated image URNs");
+    }
+    return { multiImage: { images: ids.map((id) => ({ id })) } };
+  }
+  return undefined;
+}
+
+/**
+ * Shared action handler for creating a post.
  */
 export async function createPostAction(textArg: string | undefined, opts: CreateOpts, cmd: Command): Promise<void> {
   const text = await resolveText(opts.text, opts.textFile, textArg);
+  const content = resolveContent(opts);
   const globals = cmd.optsWithGlobals<{ profile?: string | undefined; json?: boolean | undefined }>();
 
   const { config } = await resolveConfig({
@@ -76,10 +116,11 @@ export async function createPostAction(textArg: string | undefined, opts: Create
   const visibility = (opts.visibility as PostVisibility | undefined) ?? "PUBLIC";
 
   try {
-    const postUrn = await createTextPost(client, {
+    const postUrn = await createPost(client, {
       author: authorUrn,
       text,
       visibility,
+      content,
     });
 
     const format = resolveFormat(opts.format as OutputFormat | undefined, process.stdout, globals.json === true);
@@ -93,9 +134,20 @@ export async function createPostAction(textArg: string | undefined, opts: Create
   }
 }
 
+/**
+ * Add media options shared between `post create` and `post` shorthand.
+ */
+export function addMediaOptions(cmd: Command): void {
+  cmd.option("--image <urn>", "attach an image by URN");
+  cmd.option("--video <urn>", "attach a video by URN");
+  cmd.option("--document <urn>", "attach a document by URN");
+  cmd.option("--article-url <url>", "attach an article link");
+  cmd.option("--images <urns>", "attach multiple images (comma-separated URNs, minimum 2)");
+}
+
 export function createCommand(): Command {
   const cmd = new Command("create");
-  cmd.description("Create a text post on LinkedIn (text: --text > --text-file > positional > stdin)");
+  cmd.description("Create a post on LinkedIn (text: --text > --text-file > positional > stdin)");
   cmd.argument("[text]", "text content of the post");
   cmd.option("--text <text>", "text content of the post (takes precedence over --text-file and positional argument)");
   cmd.option("--text-file <path>", "read post text from a UTF-8 file");
@@ -111,6 +163,7 @@ export function createCommand(): Command {
       })
       .default("PUBLIC"),
   );
+  addMediaOptions(cmd);
   cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
 
   cmd.addHelpText(
@@ -119,6 +172,10 @@ export function createCommand(): Command {
 Examples:
   linkedctl post create "Hello from LinkedCtl!"
   linkedctl post create --text "Hello" --visibility CONNECTIONS
+  linkedctl post create --text "Check this out" --image urn:li:image:C5608AQ...
+  linkedctl post create --text "Watch this" --video urn:li:video:D5608AQ...
+  linkedctl post create --text "Read more" --article-url https://example.com/article
+  linkedctl post create --text "Gallery" --images urn:li:image:A1,urn:li:image:A2
   echo "Hello" | linkedctl post create`,
   );
 

--- a/packages/cli/src/commands/post/index.ts
+++ b/packages/cli/src/commands/post/index.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { Command, InvalidArgumentError, Option } from "commander";
-import { createCommand, createPostAction } from "./create.js";
+import { addMediaOptions, createCommand, createPostAction } from "./create.js";
 
 export function postCommand(): Command {
   const cmd = new Command("post");
@@ -25,6 +25,7 @@ export function postCommand(): Command {
       })
       .default("PUBLIC"),
   );
+  addMediaOptions(cmd);
   cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
 
   cmd.addHelpText(
@@ -33,6 +34,7 @@ export function postCommand(): Command {
 Examples:
   linkedctl post "Hello from LinkedCtl!"
   linkedctl post --text "Hello" --visibility CONNECTIONS
+  linkedctl post --text "Check this out" --image urn:li:image:C5608AQ...
   echo "Hello" | linkedctl post`,
   );
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -50,9 +50,9 @@ export { getCurrentPersonUrn } from "./userinfo/userinfo-service.js";
 export { uploadImage } from "./media/media-service.js";
 export type { UploadImageOptions } from "./media/media-service.js";
 export { SUPPORTED_IMAGE_TYPES } from "./media/types.js";
-export { createTextPost } from "./posts/posts-service.js";
-export type { CreateTextPostOptions } from "./posts/posts-service.js";
-export type { PostVisibility } from "./posts/types.js";
+export { createTextPost, createPost } from "./posts/posts-service.js";
+export type { CreateTextPostOptions, CreatePostOptions } from "./posts/posts-service.js";
+export type { PostVisibility, PostContent, MediaContent, ArticleContent, MultiImageContent } from "./posts/types.js";
 export { initializeVideoUpload, uploadVideoChunk, finalizeVideoUpload, uploadVideo } from "./video/video-service.js";
 export type {
   InitializeVideoUploadRequest,

--- a/packages/core/src/posts/posts-service.test.ts
+++ b/packages/core/src/posts/posts-service.test.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, expect, it, vi } from "vitest";
-import { createTextPost } from "./posts-service.js";
+import { createTextPost, createPost } from "./posts-service.js";
 import type { LinkedInClient } from "../http/linkedin-client.js";
 
 function mockClient(urn: string): LinkedInClient {
@@ -64,5 +64,141 @@ describe("createTextPost", () => {
 
     const call = vi.mocked(client.create).mock.calls[0];
     expect(call?.[1]).toHaveProperty("visibility", "CONNECTIONS");
+  });
+});
+
+describe("createPost", () => {
+  it("creates a text-only post when no content is provided", async () => {
+    const client = mockClient("urn:li:share:200");
+    await createPost(client, {
+      author: "urn:li:person:abc",
+      text: "Text only",
+    });
+
+    expect(client.create).toHaveBeenCalledWith("/rest/posts", {
+      author: "urn:li:person:abc",
+      commentary: "Text only",
+      visibility: "PUBLIC",
+      distribution: {
+        feedDistribution: "MAIN_FEED",
+        targetEntities: [],
+        thirdPartyDistributionChannels: [],
+      },
+      lifecycleState: "PUBLISHED",
+      isReshareDisabledByAuthor: false,
+    });
+  });
+
+  it("does not include content key when content is undefined", async () => {
+    const client = mockClient("urn:li:share:201");
+    await createPost(client, {
+      author: "urn:li:person:abc",
+      text: "No content",
+      content: undefined,
+    });
+
+    const call = vi.mocked(client.create).mock.calls[0];
+    expect(call?.[1]).not.toHaveProperty("content");
+  });
+
+  it("includes media content for image post", async () => {
+    const client = mockClient("urn:li:share:300");
+    await createPost(client, {
+      author: "urn:li:person:abc",
+      text: "Check this image",
+      content: { media: { id: "urn:li:image:C5608AQ123" } },
+    });
+
+    const call = vi.mocked(client.create).mock.calls[0];
+    expect(call?.[1]).toHaveProperty("content", {
+      media: { id: "urn:li:image:C5608AQ123" },
+    });
+  });
+
+  it("includes media content for video post", async () => {
+    const client = mockClient("urn:li:share:301");
+    await createPost(client, {
+      author: "urn:li:person:abc",
+      text: "Watch this video",
+      content: { media: { id: "urn:li:video:D5608AQ456" } },
+    });
+
+    const call = vi.mocked(client.create).mock.calls[0];
+    expect(call?.[1]).toHaveProperty("content", {
+      media: { id: "urn:li:video:D5608AQ456" },
+    });
+  });
+
+  it("includes media content for document post", async () => {
+    const client = mockClient("urn:li:share:302");
+    await createPost(client, {
+      author: "urn:li:person:abc",
+      text: "Read this document",
+      content: { media: { id: "urn:li:document:D789" } },
+    });
+
+    const call = vi.mocked(client.create).mock.calls[0];
+    expect(call?.[1]).toHaveProperty("content", {
+      media: { id: "urn:li:document:D789" },
+    });
+  });
+
+  it("includes article content for article post", async () => {
+    const client = mockClient("urn:li:share:303");
+    await createPost(client, {
+      author: "urn:li:person:abc",
+      text: "Great article",
+      content: { article: { source: "https://example.com/article" } },
+    });
+
+    const call = vi.mocked(client.create).mock.calls[0];
+    expect(call?.[1]).toHaveProperty("content", {
+      article: { source: "https://example.com/article" },
+    });
+  });
+
+  it("includes multiImage content for multi-image post", async () => {
+    const client = mockClient("urn:li:share:304");
+    await createPost(client, {
+      author: "urn:li:person:abc",
+      text: "Photo gallery",
+      content: {
+        multiImage: {
+          images: [{ id: "urn:li:image:A1" }, { id: "urn:li:image:A2" }, { id: "urn:li:image:A3" }],
+        },
+      },
+    });
+
+    const call = vi.mocked(client.create).mock.calls[0];
+    expect(call?.[1]).toHaveProperty("content", {
+      multiImage: {
+        images: [{ id: "urn:li:image:A1" }, { id: "urn:li:image:A2" }, { id: "urn:li:image:A3" }],
+      },
+    });
+  });
+
+  it("returns the post URN", async () => {
+    const client = mockClient("urn:li:share:305");
+    const urn = await createPost(client, {
+      author: "urn:li:person:abc",
+      text: "With image",
+      content: { media: { id: "urn:li:image:X" } },
+    });
+
+    expect(urn).toBe("urn:li:share:305");
+  });
+
+  it("uses specified visibility with content", async () => {
+    const client = mockClient("urn:li:share:306");
+    await createPost(client, {
+      author: "urn:li:person:abc",
+      text: "Private image post",
+      visibility: "CONNECTIONS",
+      content: { media: { id: "urn:li:image:X" } },
+    });
+
+    const call = vi.mocked(client.create).mock.calls[0];
+    expect(call?.[1]).toHaveProperty("visibility", "CONNECTIONS");
+    expect(call?.[1]).toHaveProperty("content", { media: { id: "urn:li:image:X" } });
   });
 });

--- a/packages/core/src/posts/posts-service.ts
+++ b/packages/core/src/posts/posts-service.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { LinkedInClient } from "../http/linkedin-client.js";
-import type { PostVisibility } from "./types.js";
+import type { PostContent, PostVisibility } from "./types.js";
 
 /**
  * Options for creating a text-only LinkedIn post.
@@ -17,10 +17,31 @@ export interface CreateTextPostOptions {
 }
 
 /**
+ * Options for creating a LinkedIn post with optional media content.
+ */
+export interface CreatePostOptions {
+  /** Author URN (e.g. `urn:li:person:abc123`). */
+  author: string;
+  /** The post text content. */
+  text: string;
+  /** Post visibility. Defaults to `"PUBLIC"`. */
+  visibility?: PostVisibility | undefined;
+  /** Optional media content attachment. */
+  content?: PostContent | undefined;
+}
+
+/**
  * Create a text-only post on LinkedIn and return the post URN.
  */
 export async function createTextPost(client: LinkedInClient, options: CreateTextPostOptions): Promise<string> {
-  const body = {
+  return createPost(client, options);
+}
+
+/**
+ * Create a post on LinkedIn with optional media content and return the post URN.
+ */
+export async function createPost(client: LinkedInClient, options: CreatePostOptions): Promise<string> {
+  const body: Record<string, unknown> = {
     author: options.author,
     commentary: options.text,
     visibility: options.visibility ?? "PUBLIC",
@@ -32,6 +53,10 @@ export async function createTextPost(client: LinkedInClient, options: CreateText
     lifecycleState: "PUBLISHED",
     isReshareDisabledByAuthor: false,
   };
+
+  if (options.content !== undefined) {
+    body.content = options.content;
+  }
 
   return client.create("/rest/posts", body);
 }

--- a/packages/core/src/posts/types.ts
+++ b/packages/core/src/posts/types.ts
@@ -5,3 +5,36 @@
  * Supported visibility settings for a LinkedIn post.
  */
 export type PostVisibility = "PUBLIC" | "CONNECTIONS";
+
+/**
+ * A single media attachment (image, video, or document).
+ */
+export interface MediaContent {
+  /** Media asset URN (e.g. `urn:li:image:...`, `urn:li:video:...`, `urn:li:document:...`). */
+  id: string;
+}
+
+/**
+ * An article link attachment.
+ */
+export interface ArticleContent {
+  /** The article URL. */
+  source: string;
+  /** Optional article title. */
+  title?: string | undefined;
+  /** Optional article description. */
+  description?: string | undefined;
+}
+
+/**
+ * A multi-image attachment.
+ */
+export interface MultiImageContent {
+  /** Array of image URNs (minimum 2). */
+  images: Array<{ id: string }>;
+}
+
+/**
+ * Content attachment for a LinkedIn post.
+ */
+export type PostContent = { media: MediaContent } | { article: ArticleContent } | { multiImage: MultiImageContent };

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -24,6 +24,7 @@ vi.mock("@linkedctl/core", () => ({
   getCurrentPersonUrn: vi.fn(),
   getUserInfo: vi.fn(),
   createTextPost: vi.fn(),
+  createPost: vi.fn(),
   uploadDocument: vi.fn(),
   DOCUMENT_EXTENSIONS: [".pdf", ".docx", ".pptx", ".doc", ".ppt"],
   DOCUMENT_MAX_SIZE_BYTES: 100 * 1024 * 1024,
@@ -41,7 +42,7 @@ import {
   LinkedInAuthError,
   getCurrentPersonUrn,
   getUserInfo,
-  createTextPost,
+  createPost,
   uploadDocument,
   loadConfigFile,
   validateConfig,
@@ -192,7 +193,7 @@ describe("createMcpServer", () => {
   });
 
   describe("post_create", () => {
-    it("creates a post and returns the URN", async () => {
+    it("creates a text-only post and returns the URN", async () => {
       vi.mocked(resolveConfig).mockResolvedValue({
         config: {
           oauth: { accessToken: "test-token" },
@@ -204,7 +205,7 @@ describe("createMcpServer", () => {
         return Object.create(null);
       } as unknown as typeof LinkedInClient);
       vi.mocked(getCurrentPersonUrn).mockResolvedValue("urn:li:person:abc123");
-      vi.mocked(createTextPost).mockResolvedValue("urn:li:share:post456");
+      vi.mocked(createPost).mockResolvedValue("urn:li:share:post456");
 
       const result = await client.callTool({
         name: "post_create",
@@ -215,12 +216,13 @@ describe("createMcpServer", () => {
         profile: undefined,
         requiredScopes: ["openid", "profile", "email", "w_member_social"],
       });
-      expect(createTextPost).toHaveBeenCalledWith(
+      expect(createPost).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
           author: "urn:li:person:abc123",
           text: "Hello LinkedIn",
           visibility: "PUBLIC",
+          content: undefined,
         }),
       );
       expect(result.content).toEqual([{ type: "text", text: "Post created: urn:li:share:post456" }]);
@@ -238,7 +240,7 @@ describe("createMcpServer", () => {
         return Object.create(null);
       } as unknown as typeof LinkedInClient);
       vi.mocked(getCurrentPersonUrn).mockResolvedValue("urn:li:person:abc123");
-      vi.mocked(createTextPost).mockResolvedValue("urn:li:share:post789");
+      vi.mocked(createPost).mockResolvedValue("urn:li:share:post789");
 
       const result = await client.callTool({
         name: "post_create",
@@ -253,13 +255,209 @@ describe("createMcpServer", () => {
         profile: "work",
         requiredScopes: ["openid", "profile", "email", "w_member_social"],
       });
-      expect(createTextPost).toHaveBeenCalledWith(
+      expect(createPost).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
           visibility: "CONNECTIONS",
         }),
       );
       expect(result.content).toEqual([{ type: "text", text: "Post created: urn:li:share:post789" }]);
+    });
+
+    it("creates a post with image attachment", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockResolvedValue("urn:li:person:abc123");
+      vi.mocked(createPost).mockResolvedValue("urn:li:share:img001");
+
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: {
+          text: "Check this image",
+          image: "urn:li:image:C5608AQ123",
+        },
+      });
+
+      expect(createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          content: { media: { id: "urn:li:image:C5608AQ123" } },
+        }),
+      );
+      expect(result.content).toEqual([{ type: "text", text: "Post created: urn:li:share:img001" }]);
+    });
+
+    it("creates a post with video attachment", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockResolvedValue("urn:li:person:abc123");
+      vi.mocked(createPost).mockResolvedValue("urn:li:share:vid001");
+
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: {
+          text: "Watch this video",
+          video: "urn:li:video:D5608AQ456",
+        },
+      });
+
+      expect(createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          content: { media: { id: "urn:li:video:D5608AQ456" } },
+        }),
+      );
+      expect(result.content).toEqual([{ type: "text", text: "Post created: urn:li:share:vid001" }]);
+    });
+
+    it("creates a post with document attachment", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockResolvedValue("urn:li:person:abc123");
+      vi.mocked(createPost).mockResolvedValue("urn:li:share:doc001");
+
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: {
+          text: "Read this document",
+          document: "urn:li:document:D789",
+        },
+      });
+
+      expect(createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          content: { media: { id: "urn:li:document:D789" } },
+        }),
+      );
+      expect(result.content).toEqual([{ type: "text", text: "Post created: urn:li:share:doc001" }]);
+    });
+
+    it("creates a post with article URL attachment", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockResolvedValue("urn:li:person:abc123");
+      vi.mocked(createPost).mockResolvedValue("urn:li:share:art001");
+
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: {
+          text: "Great article",
+          article_url: "https://example.com/article",
+        },
+      });
+
+      expect(createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          content: { article: { source: "https://example.com/article" } },
+        }),
+      );
+      expect(result.content).toEqual([{ type: "text", text: "Post created: urn:li:share:art001" }]);
+    });
+
+    it("creates a multi-image post", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockResolvedValue("urn:li:person:abc123");
+      vi.mocked(createPost).mockResolvedValue("urn:li:share:multi001");
+
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: {
+          text: "Photo gallery",
+          images: ["urn:li:image:A1", "urn:li:image:A2", "urn:li:image:A3"],
+        },
+      });
+
+      expect(createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          content: {
+            multiImage: {
+              images: [{ id: "urn:li:image:A1" }, { id: "urn:li:image:A2" }, { id: "urn:li:image:A3" }],
+            },
+          },
+        }),
+      );
+      expect(result.content).toEqual([{ type: "text", text: "Post created: urn:li:share:multi001" }]);
+    });
+
+    it("returns error when multiple media options are specified", async () => {
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: {
+          text: "Conflicting",
+          image: "urn:li:image:X",
+          video: "urn:li:video:Y",
+        },
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: expect.stringContaining("Only one media option"),
+        },
+      ]);
+      expect(result.isError).toBe(true);
+    });
+
+    it("returns error when images array has fewer than 2 items", async () => {
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: {
+          text: "Single image in array",
+          images: ["urn:li:image:A1"],
+        },
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: expect.stringContaining("at least 2"),
+        },
+      ]);
+      expect(result.isError).toBe(true);
     });
   });
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -12,7 +12,7 @@ import {
   LinkedInAuthError,
   getCurrentPersonUrn,
   getUserInfo,
-  createTextPost,
+  createPost,
   uploadDocument,
   DOCUMENT_EXTENSIONS,
   DOCUMENT_MAX_SIZE_BYTES,
@@ -22,6 +22,7 @@ import {
   clearOAuthTokens,
   revokeAccessToken,
 } from "@linkedctl/core";
+import type { PostContent } from "@linkedctl/core";
 
 /**
  * Create and configure the LinkedCtl MCP server with all tools registered.
@@ -83,14 +84,54 @@ export function createMcpServer(): McpServer {
     "post_create",
     {
       title: "Create Post",
-      description: "Create a text post on LinkedIn",
+      description:
+        "Create a post on LinkedIn with optional media attachment (image, video, document, article URL, or multi-image)",
       inputSchema: {
         text: z.string().describe("The text content of the post"),
         visibility: z.enum(["PUBLIC", "CONNECTIONS"]).optional().describe("Post visibility (defaults to PUBLIC)"),
+        image: z.string().optional().describe("Image URN to attach (e.g. urn:li:image:C5608AQ...)"),
+        video: z.string().optional().describe("Video URN to attach (e.g. urn:li:video:D5608AQ...)"),
+        document: z.string().optional().describe("Document URN to attach (e.g. urn:li:document:D123...)"),
+        article_url: z.string().optional().describe("Article URL to attach"),
+        images: z.array(z.string()).optional().describe("Array of image URNs for multi-image post (minimum 2)"),
         profile: z.string().optional().describe("Profile name to use from config file"),
       },
     },
     async (args) => {
+      const mediaFlags = [args.image, args.video, args.document, args.article_url, args.images].filter(
+        (v) => v !== undefined,
+      );
+      if (mediaFlags.length > 1) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Only one media option may be specified: image, video, document, article_url, or images",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      let postContent: PostContent | undefined;
+      if (args.image !== undefined) {
+        postContent = { media: { id: args.image } };
+      } else if (args.video !== undefined) {
+        postContent = { media: { id: args.video } };
+      } else if (args.document !== undefined) {
+        postContent = { media: { id: args.document } };
+      } else if (args.article_url !== undefined) {
+        postContent = { article: { source: args.article_url } };
+      } else if (args.images !== undefined) {
+        if (args.images.length < 2) {
+          return {
+            content: [{ type: "text" as const, text: "Multi-image posts require at least 2 image URNs" }],
+            isError: true,
+          };
+        }
+        postContent = { multiImage: { images: args.images.map((id) => ({ id })) } };
+      }
+
       const { config } = await resolveConfig({
         profile: args.profile,
         requiredScopes: ["openid", "profile", "email", "w_member_social"],
@@ -103,10 +144,11 @@ export function createMcpServer(): McpServer {
       const authorUrn = await getCurrentPersonUrn(client);
       const visibility = args.visibility ?? "PUBLIC";
 
-      const postUrn = await createTextPost(client, {
+      const postUrn = await createPost(client, {
         author: authorUrn,
         text: args.text,
         visibility,
+        content: postContent,
       });
 
       return {


### PR DESCRIPTION
## Summary

- Add media attachment support to `post create` and `post` shorthand: `--image <urn>`, `--video <urn>`, `--document <urn>`, `--article-url <url>`, `--images <urn1>,<urn2>`
- Extend core `createPost()` function to accept optional `PostContent` (media, article, multiImage)
- Update MCP `post_create` tool with `image`, `video`, `document`, `article_url`, and `images` parameters
- Options are mutually exclusive; `--images` requires at least 2 URNs

Closes #13

## Test plan

- [x] Core: 9 new tests for `createPost` covering image, video, document, article, multi-image, visibility with content, and no-content cases
- [x] CLI: 8 new tests for media options (each media type, multi-image, mutual exclusivity, minimum URNs, shorthand support)
- [x] MCP: 7 new tests for media parameters (each type, mutual exclusivity, minimum images validation)
- [x] All existing tests continue to pass (180 core + 242 CLI + 26 MCP)
- [x] Build, typecheck, lint, and format all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)