### PR TITLE
(feat) add combined upload+post flow

### DIFF
--- a/packages/cli/src/commands/post/create.test.ts
+++ b/packages/cli/src/commands/post/create.test.ts
@@ -22,6 +22,9 @@ vi.mock("@linkedctl/core", async (importOriginal) => {
     getCurrentPersonUrn: vi.fn().mockResolvedValue("urn:li:person:person123"),
     createTextPost: vi.fn().mockResolvedValue("urn:li:share:111222333"),
     createPost: vi.fn().mockResolvedValue("urn:li:share:111222333"),
+    uploadImage: vi.fn().mockResolvedValue("urn:li:image:UPLOADED1"),
+    uploadVideo: vi.fn().mockResolvedValue("urn:li:video:UPLOADED1"),
+    uploadDocument: vi.fn().mockResolvedValue("urn:li:document:UPLOADED1"),
   };
 });
 
@@ -42,6 +45,9 @@ describe("post create", () => {
     });
     vi.mocked(coreMock.createPost).mockResolvedValue("urn:li:share:111222333");
     vi.mocked(coreMock.getCurrentPersonUrn).mockResolvedValue("urn:li:person:person123");
+    vi.mocked(coreMock.uploadImage).mockResolvedValue("urn:li:image:UPLOADED1");
+    vi.mocked(coreMock.uploadVideo).mockResolvedValue("urn:li:video:UPLOADED1");
+    vi.mocked(coreMock.uploadDocument).mockResolvedValue("urn:li:document:UPLOADED1");
   });
 
   afterEach(() => {
@@ -561,6 +567,264 @@ describe("post create", () => {
         expect.objectContaining({
           text: "Plain text",
           content: undefined,
+        }),
+      );
+    });
+  });
+
+  describe("file upload options", () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await mkdtemp(join(tmpdir(), "linkedctl-test-"));
+    });
+
+    afterEach(async () => {
+      await rm(tempDir, { recursive: true, force: true });
+    });
+
+    it("uploads an image file and creates a post with --image-file", async () => {
+      const filePath = join(tempDir, "photo.jpg");
+      await writeFile(filePath, "fake-image-data");
+
+      const program = createProgram();
+      await program.parseAsync([
+        "node",
+        "linkedctl",
+        "post",
+        "create",
+        "--text",
+        "Photo post",
+        "--image-file",
+        filePath,
+      ]);
+
+      expect(coreMock.uploadImage).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          owner: "urn:li:person:person123",
+          contentType: "image/jpeg",
+        }),
+      );
+      expect(coreMock.createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          text: "Photo post",
+          content: { media: { id: "urn:li:image:UPLOADED1" } },
+        }),
+      );
+    });
+
+    it("uploads a PNG image file with --image-file", async () => {
+      const filePath = join(tempDir, "banner.png");
+      await writeFile(filePath, "fake-png-data");
+
+      const program = createProgram();
+      await program.parseAsync(["node", "linkedctl", "post", "create", "--text", "PNG post", "--image-file", filePath]);
+
+      expect(coreMock.uploadImage).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          contentType: "image/png",
+        }),
+      );
+    });
+
+    it("rejects unsupported image format with --image-file", async () => {
+      const filePath = join(tempDir, "photo.bmp");
+      await writeFile(filePath, "fake-bmp-data");
+
+      const program = createProgram();
+      program.exitOverride();
+
+      await expect(
+        program.parseAsync(["node", "linkedctl", "post", "create", "--text", "BMP post", "--image-file", filePath]),
+      ).rejects.toThrow(/Unsupported image format/);
+    });
+
+    it("uploads a video file and creates a post with --video-file", async () => {
+      const filePath = join(tempDir, "clip.mp4");
+      await writeFile(filePath, "fake-video-data");
+
+      const program = createProgram();
+      await program.parseAsync([
+        "node",
+        "linkedctl",
+        "post",
+        "create",
+        "--text",
+        "Video post",
+        "--video-file",
+        filePath,
+      ]);
+
+      expect(coreMock.uploadVideo).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          owner: "urn:li:person:person123",
+        }),
+      );
+      expect(coreMock.createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          text: "Video post",
+          content: { media: { id: "urn:li:video:UPLOADED1" } },
+        }),
+      );
+    });
+
+    it("uploads a document file and creates a post with --document-file", async () => {
+      const filePath = join(tempDir, "deck.pdf");
+      await writeFile(filePath, "fake-pdf-data");
+
+      const program = createProgram();
+      await program.parseAsync([
+        "node",
+        "linkedctl",
+        "post",
+        "create",
+        "--text",
+        "Document post",
+        "--document-file",
+        filePath,
+      ]);
+
+      expect(coreMock.uploadDocument).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          owner: "urn:li:person:person123",
+        }),
+      );
+      expect(coreMock.createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          text: "Document post",
+          content: { media: { id: "urn:li:document:UPLOADED1" } },
+        }),
+      );
+    });
+
+    it("rejects unsupported document format with --document-file", async () => {
+      const filePath = join(tempDir, "file.txt");
+      await writeFile(filePath, "text content");
+
+      const program = createProgram();
+      program.exitOverride();
+
+      await expect(
+        program.parseAsync(["node", "linkedctl", "post", "create", "--text", "Text post", "--document-file", filePath]),
+      ).rejects.toThrow(/Unsupported file type/);
+    });
+
+    it("uploads multiple image files and creates a multi-image post with --image-files", async () => {
+      const filePath1 = join(tempDir, "a.jpg");
+      const filePath2 = join(tempDir, "b.png");
+      await writeFile(filePath1, "fake-jpg-data");
+      await writeFile(filePath2, "fake-png-data");
+
+      vi.mocked(coreMock.uploadImage)
+        .mockResolvedValueOnce("urn:li:image:UP1")
+        .mockResolvedValueOnce("urn:li:image:UP2");
+
+      const program = createProgram();
+      await program.parseAsync([
+        "node",
+        "linkedctl",
+        "post",
+        "create",
+        "--text",
+        "Gallery post",
+        "--image-files",
+        `${filePath1},${filePath2}`,
+      ]);
+
+      expect(coreMock.uploadImage).toHaveBeenCalledTimes(2);
+      expect(coreMock.createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          text: "Gallery post",
+          content: {
+            multiImage: {
+              images: [{ id: "urn:li:image:UP1" }, { id: "urn:li:image:UP2" }],
+            },
+          },
+        }),
+      );
+    });
+
+    it("rejects --image-files with fewer than 2 paths", async () => {
+      const filePath = join(tempDir, "single.jpg");
+      await writeFile(filePath, "fake-data");
+
+      const program = createProgram();
+      program.exitOverride();
+
+      await expect(
+        program.parseAsync(["node", "linkedctl", "post", "create", "--text", "Single", "--image-files", filePath]),
+      ).rejects.toThrow(/at least 2/);
+    });
+
+    it("rejects combining --image-file with --image URN", async () => {
+      const filePath = join(tempDir, "photo.jpg");
+      await writeFile(filePath, "fake-data");
+
+      const program = createProgram();
+      program.exitOverride();
+
+      await expect(
+        program.parseAsync([
+          "node",
+          "linkedctl",
+          "post",
+          "create",
+          "--text",
+          "Both",
+          "--image-file",
+          filePath,
+          "--image",
+          "urn:li:image:X",
+        ]),
+      ).rejects.toThrow(/Only one media option/);
+    });
+
+    it("rejects combining --video-file with --document-file", async () => {
+      const videoPath = join(tempDir, "clip.mp4");
+      const docPath = join(tempDir, "deck.pdf");
+      await writeFile(videoPath, "fake-video");
+      await writeFile(docPath, "fake-doc");
+
+      const program = createProgram();
+      program.exitOverride();
+
+      await expect(
+        program.parseAsync([
+          "node",
+          "linkedctl",
+          "post",
+          "create",
+          "--text",
+          "Both",
+          "--video-file",
+          videoPath,
+          "--document-file",
+          docPath,
+        ]),
+      ).rejects.toThrow(/Only one media option/);
+    });
+
+    it("uses --image-file on post shorthand", async () => {
+      const filePath = join(tempDir, "photo.jpg");
+      await writeFile(filePath, "fake-image-data");
+
+      const program = createProgram();
+      await program.parseAsync(["node", "linkedctl", "post", "--text", "Shorthand upload", "--image-file", filePath]);
+
+      expect(coreMock.uploadImage).toHaveBeenCalled();
+      expect(coreMock.createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          text: "Shorthand upload",
+          content: { media: { id: "urn:li:image:UPLOADED1" } },
         }),
       );
     });

--- a/packages/cli/src/commands/post/create.ts
+++ b/packages/cli/src/commands/post/create.ts
@@ -1,10 +1,23 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { readFile } from "node:fs/promises";
+import { readFile, stat } from "node:fs/promises";
+import { extname } from "node:path";
 
 import { Command, InvalidArgumentError, Option } from "commander";
-import { resolveConfig, LinkedInClient, getCurrentPersonUrn, createPost, LinkedInApiError } from "@linkedctl/core";
+import {
+  resolveConfig,
+  LinkedInClient,
+  getCurrentPersonUrn,
+  createPost,
+  LinkedInApiError,
+  uploadImage,
+  uploadVideo,
+  uploadDocument,
+  SUPPORTED_IMAGE_TYPES,
+  DOCUMENT_EXTENSIONS,
+  DOCUMENT_MAX_SIZE_BYTES,
+} from "@linkedctl/core";
 import type { PostVisibility, PostContent } from "@linkedctl/core";
 import { resolveFormat, formatOutput } from "../../output/index.js";
 import type { OutputFormat } from "../../output/index.js";
@@ -19,6 +32,10 @@ interface CreateOpts {
   document?: string | undefined;
   articleUrl?: string | undefined;
   images?: string | undefined;
+  imageFile?: string | undefined;
+  videoFile?: string | undefined;
+  documentFile?: string | undefined;
+  imageFiles?: string | undefined;
   format?: string | undefined;
 }
 
@@ -61,15 +78,27 @@ async function resolveText(
 }
 
 /**
- * Resolve media content from mutually exclusive CLI options.
+ * Resolve media content from mutually exclusive CLI options (URN-based).
+ *
+ * Also validates mutual exclusivity against file-based options.
  */
 function resolveContent(opts: CreateOpts): PostContent | undefined {
-  const mediaFlags = [opts.image, opts.video, opts.document, opts.articleUrl, opts.images].filter(
-    (v) => v !== undefined,
-  );
+  const mediaFlags = [
+    opts.image,
+    opts.video,
+    opts.document,
+    opts.articleUrl,
+    opts.images,
+    opts.imageFile,
+    opts.videoFile,
+    opts.documentFile,
+    opts.imageFiles,
+  ].filter((v) => v !== undefined);
 
   if (mediaFlags.length > 1) {
-    throw new Error("Only one media option may be specified: --image, --video, --document, --article-url, or --images");
+    throw new Error(
+      "Only one media option may be specified: --image, --video, --document, --article-url, --images, --image-file, --video-file, --document-file, or --image-files",
+    );
   }
 
   if (opts.image !== undefined) {
@@ -95,6 +124,74 @@ function resolveContent(opts: CreateOpts): PostContent | undefined {
 }
 
 /**
+ * Resolve media content from file-based CLI options by uploading files first.
+ */
+async function resolveFileContent(
+  opts: CreateOpts,
+  client: LinkedInClient,
+  ownerUrn: string,
+): Promise<PostContent | undefined> {
+  if (opts.imageFile !== undefined) {
+    const ext = extname(opts.imageFile).toLowerCase();
+    const contentType = SUPPORTED_IMAGE_TYPES.get(ext);
+    if (contentType === undefined) {
+      const supported = [...SUPPORTED_IMAGE_TYPES.keys()].join(", ");
+      throw new Error(`Unsupported image format "${ext}". Supported formats: ${supported}`);
+    }
+    const data = new Uint8Array(await readFile(opts.imageFile));
+    const urn = await uploadImage(client, { owner: ownerUrn, data, contentType });
+    return { media: { id: urn } };
+  }
+
+  if (opts.videoFile !== undefined) {
+    const fileStat = await stat(opts.videoFile);
+    if (!fileStat.isFile()) {
+      throw new Error(`Not a file: ${opts.videoFile}`);
+    }
+    const data = await readFile(opts.videoFile);
+    const urn = await uploadVideo(client, { owner: ownerUrn, data });
+    return { media: { id: urn } };
+  }
+
+  if (opts.documentFile !== undefined) {
+    const ext = extname(opts.documentFile).toLowerCase();
+    if (!DOCUMENT_EXTENSIONS.includes(ext as (typeof DOCUMENT_EXTENSIONS)[number])) {
+      throw new Error(`Unsupported file type "${ext}". Supported types: ${DOCUMENT_EXTENSIONS.join(", ")}`);
+    }
+    const fileStat = await stat(opts.documentFile);
+    if (fileStat.size > DOCUMENT_MAX_SIZE_BYTES) {
+      const sizeMB = Math.round(fileStat.size / (1024 * 1024));
+      throw new Error(`File is ${sizeMB} MB, which exceeds the 100 MB limit.`);
+    }
+    const data = new Uint8Array(await readFile(opts.documentFile));
+    const urn = await uploadDocument(client, { owner: ownerUrn, data });
+    return { media: { id: urn } };
+  }
+
+  if (opts.imageFiles !== undefined) {
+    const paths = opts.imageFiles.split(",").map((s) => s.trim());
+    if (paths.length < 2) {
+      throw new Error("--image-files requires at least 2 comma-separated file paths");
+    }
+    const urns: string[] = [];
+    for (const filePath of paths) {
+      const ext = extname(filePath).toLowerCase();
+      const contentType = SUPPORTED_IMAGE_TYPES.get(ext);
+      if (contentType === undefined) {
+        const supported = [...SUPPORTED_IMAGE_TYPES.keys()].join(", ");
+        throw new Error(`Unsupported image format "${ext}" for file "${filePath}". Supported formats: ${supported}`);
+      }
+      const data = new Uint8Array(await readFile(filePath));
+      const urn = await uploadImage(client, { owner: ownerUrn, data, contentType });
+      urns.push(urn);
+    }
+    return { multiImage: { images: urns.map((id) => ({ id })) } };
+  }
+
+  return undefined;
+}
+
+/**
  * Shared action handler for creating a post.
  */
 export async function createPostAction(textArg: string | undefined, opts: CreateOpts, cmd: Command): Promise<void> {
@@ -113,6 +210,8 @@ export async function createPostAction(textArg: string | undefined, opts: Create
 
   const authorUrn = await getCurrentPersonUrn(client);
 
+  const finalContent = content ?? (await resolveFileContent(opts, client, authorUrn));
+
   const visibility = (opts.visibility as PostVisibility | undefined) ?? "PUBLIC";
 
   try {
@@ -120,7 +219,7 @@ export async function createPostAction(textArg: string | undefined, opts: Create
       author: authorUrn,
       text,
       visibility,
-      content,
+      content: finalContent,
     });
 
     const format = resolveFormat(opts.format as OutputFormat | undefined, process.stdout, globals.json === true);
@@ -143,6 +242,10 @@ export function addMediaOptions(cmd: Command): void {
   cmd.option("--document <urn>", "attach a document by URN");
   cmd.option("--article-url <url>", "attach an article link");
   cmd.option("--images <urns>", "attach multiple images (comma-separated URNs, minimum 2)");
+  cmd.option("--image-file <path>", "upload a local image file and attach it");
+  cmd.option("--video-file <path>", "upload a local video file and attach it");
+  cmd.option("--document-file <path>", "upload a local document file and attach it");
+  cmd.option("--image-files <paths>", "upload multiple local image files and attach them (comma-separated, minimum 2)");
 }
 
 export function createCommand(): Command {
@@ -176,6 +279,10 @@ Examples:
   linkedctl post create --text "Watch this" --video urn:li:video:D5608AQ...
   linkedctl post create --text "Read more" --article-url https://example.com/article
   linkedctl post create --text "Gallery" --images urn:li:image:A1,urn:li:image:A2
+  linkedctl post create --text "Photo" --image-file photo.jpg
+  linkedctl post create --text "Video" --video-file clip.mp4
+  linkedctl post create --text "Deck" --document-file deck.pdf
+  linkedctl post create --text "Gallery" --image-files a.jpg,b.jpg
   echo "Hello" | linkedctl post create`,
   );
 

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -25,7 +25,15 @@ vi.mock("@linkedctl/core", () => ({
   getUserInfo: vi.fn(),
   createTextPost: vi.fn(),
   createPost: vi.fn(),
+  uploadImage: vi.fn(),
+  uploadVideo: vi.fn(),
   uploadDocument: vi.fn(),
+  SUPPORTED_IMAGE_TYPES: new Map([
+    [".jpg", "image/jpeg"],
+    [".jpeg", "image/jpeg"],
+    [".png", "image/png"],
+    [".gif", "image/gif"],
+  ]),
   DOCUMENT_EXTENSIONS: [".pdf", ".docx", ".pptx", ".doc", ".ppt"],
   DOCUMENT_MAX_SIZE_BYTES: 100 * 1024 * 1024,
   loadConfigFile: vi.fn(),
@@ -43,6 +51,8 @@ import {
   getCurrentPersonUrn,
   getUserInfo,
   createPost,
+  uploadImage,
+  uploadVideo,
   uploadDocument,
   loadConfigFile,
   validateConfig,
@@ -455,6 +465,281 @@ describe("createMcpServer", () => {
         {
           type: "text",
           text: expect.stringContaining("at least 2"),
+        },
+      ]);
+      expect(result.isError).toBe(true);
+    });
+
+    it("uploads an image file and creates a post with image_file", async () => {
+      vi.mocked(readFile).mockResolvedValue(Buffer.from("fake-image-data"));
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockResolvedValue("urn:li:person:abc123");
+      vi.mocked(uploadImage).mockResolvedValue("urn:li:image:UPLOADED1");
+      vi.mocked(createPost).mockResolvedValue("urn:li:share:imgfile001");
+
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: {
+          text: "Photo from file",
+          image_file: "/path/to/photo.jpg",
+        },
+      });
+
+      expect(uploadImage).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          owner: "urn:li:person:abc123",
+          contentType: "image/jpeg",
+        }),
+      );
+      expect(createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          content: { media: { id: "urn:li:image:UPLOADED1" } },
+        }),
+      );
+      expect(result.content).toEqual([{ type: "text", text: "Post created: urn:li:share:imgfile001" }]);
+    });
+
+    it("returns error for unsupported image format in image_file", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockResolvedValue("urn:li:person:abc123");
+
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: {
+          text: "BMP post",
+          image_file: "/path/to/photo.bmp",
+        },
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: expect.stringContaining("Unsupported image format"),
+        },
+      ]);
+      expect(result.isError).toBe(true);
+    });
+
+    it("uploads a video file and creates a post with video_file", async () => {
+      vi.mocked(stat).mockResolvedValue({ size: 1024, isFile: () => true } as ReturnType<
+        typeof import("node:fs/promises").stat
+      > extends Promise<infer T>
+        ? T
+        : never);
+      vi.mocked(readFile).mockResolvedValue(Buffer.from("fake-video-data"));
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockResolvedValue("urn:li:person:abc123");
+      vi.mocked(uploadVideo).mockResolvedValue("urn:li:video:UPLOADED1");
+      vi.mocked(createPost).mockResolvedValue("urn:li:share:vidfile001");
+
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: {
+          text: "Video from file",
+          video_file: "/path/to/clip.mp4",
+        },
+      });
+
+      expect(uploadVideo).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          owner: "urn:li:person:abc123",
+        }),
+      );
+      expect(createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          content: { media: { id: "urn:li:video:UPLOADED1" } },
+        }),
+      );
+      expect(result.content).toEqual([{ type: "text", text: "Post created: urn:li:share:vidfile001" }]);
+    });
+
+    it("uploads a document file and creates a post with document_file", async () => {
+      vi.mocked(stat).mockResolvedValue({ size: 1024 } as ReturnType<
+        typeof import("node:fs/promises").stat
+      > extends Promise<infer T>
+        ? T
+        : never);
+      vi.mocked(readFile).mockResolvedValue(Buffer.from("fake-pdf-data"));
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockResolvedValue("urn:li:person:abc123");
+      vi.mocked(uploadDocument).mockResolvedValue("urn:li:document:UPLOADED1");
+      vi.mocked(createPost).mockResolvedValue("urn:li:share:docfile001");
+
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: {
+          text: "Document from file",
+          document_file: "/path/to/deck.pdf",
+        },
+      });
+
+      expect(uploadDocument).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          owner: "urn:li:person:abc123",
+        }),
+      );
+      expect(createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          content: { media: { id: "urn:li:document:UPLOADED1" } },
+        }),
+      );
+      expect(result.content).toEqual([{ type: "text", text: "Post created: urn:li:share:docfile001" }]);
+    });
+
+    it("returns error for unsupported document format in document_file", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockResolvedValue("urn:li:person:abc123");
+
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: {
+          text: "TXT post",
+          document_file: "/path/to/file.txt",
+        },
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: expect.stringContaining("Unsupported file type"),
+        },
+      ]);
+      expect(result.isError).toBe(true);
+    });
+
+    it("uploads multiple image files and creates a multi-image post with image_files", async () => {
+      vi.mocked(readFile).mockResolvedValue(Buffer.from("fake-image-data"));
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockResolvedValue("urn:li:person:abc123");
+      vi.mocked(uploadImage).mockResolvedValueOnce("urn:li:image:UP1").mockResolvedValueOnce("urn:li:image:UP2");
+      vi.mocked(createPost).mockResolvedValue("urn:li:share:multifile001");
+
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: {
+          text: "Gallery from files",
+          image_files: ["/path/to/a.jpg", "/path/to/b.png"],
+        },
+      });
+
+      expect(uploadImage).toHaveBeenCalledTimes(2);
+      expect(createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          content: {
+            multiImage: {
+              images: [{ id: "urn:li:image:UP1" }, { id: "urn:li:image:UP2" }],
+            },
+          },
+        }),
+      );
+      expect(result.content).toEqual([{ type: "text", text: "Post created: urn:li:share:multifile001" }]);
+    });
+
+    it("returns error when image_files has fewer than 2 items", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockResolvedValue("urn:li:person:abc123");
+
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: {
+          text: "Single file",
+          image_files: ["/path/to/a.jpg"],
+        },
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: expect.stringContaining("at least 2"),
+        },
+      ]);
+      expect(result.isError).toBe(true);
+    });
+
+    it("returns error when combining file and URN media options", async () => {
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: {
+          text: "Conflicting",
+          image: "urn:li:image:X",
+          image_file: "/path/to/photo.jpg",
+        },
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: expect.stringContaining("Only one media option"),
         },
       ]);
       expect(result.isError).toBe(true);

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -13,7 +13,10 @@ import {
   getCurrentPersonUrn,
   getUserInfo,
   createPost,
+  uploadImage,
+  uploadVideo,
   uploadDocument,
+  SUPPORTED_IMAGE_TYPES,
   DOCUMENT_EXTENSIONS,
   DOCUMENT_MAX_SIZE_BYTES,
   loadConfigFile,
@@ -85,7 +88,7 @@ export function createMcpServer(): McpServer {
     {
       title: "Create Post",
       description:
-        "Create a post on LinkedIn with optional media attachment (image, video, document, article URL, or multi-image)",
+        "Create a post on LinkedIn with optional media attachment. Supports URNs for pre-uploaded media or local file paths for combined upload+post.",
       inputSchema: {
         text: z.string().describe("The text content of the post"),
         visibility: z.enum(["PUBLIC", "CONNECTIONS"]).optional().describe("Post visibility (defaults to PUBLIC)"),
@@ -94,19 +97,34 @@ export function createMcpServer(): McpServer {
         document: z.string().optional().describe("Document URN to attach (e.g. urn:li:document:D123...)"),
         article_url: z.string().optional().describe("Article URL to attach"),
         images: z.array(z.string()).optional().describe("Array of image URNs for multi-image post (minimum 2)"),
+        image_file: z.string().optional().describe("Path to a local image file to upload and attach"),
+        video_file: z.string().optional().describe("Path to a local video file to upload and attach"),
+        document_file: z.string().optional().describe("Path to a local document file to upload and attach"),
+        image_files: z
+          .array(z.string())
+          .optional()
+          .describe("Array of local image file paths to upload and attach (minimum 2)"),
         profile: z.string().optional().describe("Profile name to use from config file"),
       },
     },
     async (args) => {
-      const mediaFlags = [args.image, args.video, args.document, args.article_url, args.images].filter(
-        (v) => v !== undefined,
-      );
+      const mediaFlags = [
+        args.image,
+        args.video,
+        args.document,
+        args.article_url,
+        args.images,
+        args.image_file,
+        args.video_file,
+        args.document_file,
+        args.image_files,
+      ].filter((v) => v !== undefined);
       if (mediaFlags.length > 1) {
         return {
           content: [
             {
               type: "text" as const,
-              text: "Only one media option may be specified: image, video, document, article_url, or images",
+              text: "Only one media option may be specified: image, video, document, article_url, images, image_file, video_file, document_file, or image_files",
             },
           ],
           isError: true,
@@ -142,6 +160,93 @@ export function createMcpServer(): McpServer {
       const client = new LinkedInClient({ accessToken, apiVersion });
 
       const authorUrn = await getCurrentPersonUrn(client);
+
+      // Handle file-based uploads if no URN-based content was resolved
+      if (postContent === undefined) {
+        if (args.image_file !== undefined) {
+          const ext = extname(args.image_file).toLowerCase();
+          const contentType = SUPPORTED_IMAGE_TYPES.get(ext);
+          if (contentType === undefined) {
+            const supported = [...SUPPORTED_IMAGE_TYPES.keys()].join(", ");
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: `Unsupported image format "${ext}". Supported formats: ${supported}`,
+                },
+              ],
+              isError: true,
+            };
+          }
+          const data = new Uint8Array(await readFile(args.image_file));
+          const urn = await uploadImage(client, { owner: authorUrn, data, contentType });
+          postContent = { media: { id: urn } };
+        } else if (args.video_file !== undefined) {
+          const fileStat = await stat(args.video_file);
+          if (!fileStat.isFile()) {
+            return {
+              content: [{ type: "text" as const, text: `Not a file: ${args.video_file}` }],
+              isError: true,
+            };
+          }
+          const data = await readFile(args.video_file);
+          const urn = await uploadVideo(client, { owner: authorUrn, data });
+          postContent = { media: { id: urn } };
+        } else if (args.document_file !== undefined) {
+          const ext = extname(args.document_file).toLowerCase();
+          if (!DOCUMENT_EXTENSIONS.includes(ext as (typeof DOCUMENT_EXTENSIONS)[number])) {
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: `Unsupported file type "${ext}". Supported types: ${DOCUMENT_EXTENSIONS.join(", ")}`,
+                },
+              ],
+              isError: true,
+            };
+          }
+          const fileStat = await stat(args.document_file);
+          if (fileStat.size > DOCUMENT_MAX_SIZE_BYTES) {
+            const sizeMB = Math.round(fileStat.size / (1024 * 1024));
+            return {
+              content: [{ type: "text" as const, text: `File is ${sizeMB} MB, which exceeds the 100 MB limit.` }],
+              isError: true,
+            };
+          }
+          const data = new Uint8Array(await readFile(args.document_file));
+          const urn = await uploadDocument(client, { owner: authorUrn, data });
+          postContent = { media: { id: urn } };
+        } else if (args.image_files !== undefined) {
+          if (args.image_files.length < 2) {
+            return {
+              content: [{ type: "text" as const, text: "Multi-image file posts require at least 2 image file paths" }],
+              isError: true,
+            };
+          }
+          const urns: string[] = [];
+          for (const filePath of args.image_files) {
+            const ext = extname(filePath).toLowerCase();
+            const contentType = SUPPORTED_IMAGE_TYPES.get(ext);
+            if (contentType === undefined) {
+              const supported = [...SUPPORTED_IMAGE_TYPES.keys()].join(", ");
+              return {
+                content: [
+                  {
+                    type: "text" as const,
+                    text: `Unsupported image format "${ext}" for file "${filePath}". Supported formats: ${supported}`,
+                  },
+                ],
+                isError: true,
+              };
+            }
+            const data = new Uint8Array(await readFile(filePath));
+            const urn = await uploadImage(client, { owner: authorUrn, data, contentType });
+            urns.push(urn);
+          }
+          postContent = { multiImage: { images: urns.map((id) => ({ id })) } };
+        }
+      }
+
       const visibility = args.visibility ?? "PUBLIC";
 
       const postUrn = await createPost(client, {


### PR DESCRIPTION
## Summary

- Add `--image-file`, `--video-file`, `--document-file`, `--image-files` CLI options to `post create` that upload a local file and create the post in one command
- Add corresponding `image_file`, `video_file`, `document_file`, `image_files` parameters to the MCP `post_create` tool
- All new options are mutually exclusive with existing URN-based media options
- Full validation: image format checks, document type/size limits, minimum 2 files for multi-image

Closes #14

## Test plan

- [x] CLI: `--image-file` uploads image and creates post with resulting URN
- [x] CLI: `--video-file` uploads video and creates post with resulting URN
- [x] CLI: `--document-file` uploads document and creates post with resulting URN
- [x] CLI: `--image-files` uploads multiple images and creates multi-image post
- [x] CLI: Rejects unsupported formats, fewer than 2 files for multi-image
- [x] CLI: Rejects combining file and URN options
- [x] CLI: Works with post shorthand (`linkedctl post --image-file`)
- [x] MCP: All four file-based parameters work end-to-end
- [x] MCP: Validation errors returned as `isError: true`
- [x] Build, typecheck, lint, format all pass
- [x] All 257 CLI tests, 34 MCP tests, 180 core tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)