### PR TITLE
(fix) remove redundant H1 title from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 ![LinkedCtl: The Complete CLI & MCP for LinkedIn](https://raw.githubusercontent.com/linkedctl/.github/main/profile/assets/social-preview.png)
 
-# LinkedCtl
-
 [![CI](https://img.shields.io/github/check-runs/alexey-pelykh/linkedctl/main)](https://github.com/alexey-pelykh/linkedctl/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/alexey-pelykh/linkedctl)](https://www.gnu.org/licenses/agpl-3.0.txt)
 


### PR DESCRIPTION
## Summary

- Remove the `# LinkedCtl` heading from README.md — the hero image already displays the project name
- Fixes the GitHub Pages landing page where pandoc's `--shift-heading-level-by=-1` rendered the H1 as a stray plain-text paragraph below the hero image

## Test plan

- [ ] Verify the GitHub Pages landing page no longer shows "LinkedCtl" as plain text below the hero image
- [ ] Verify the README renders correctly on GitHub (hero image → badges → description)

🤖 Generated with [Claude Code](https://claude.com/claude-code)