### PR TITLE
(feat) add draft posts

### DIFF
--- a/packages/cli/src/commands/post/create.test.ts
+++ b/packages/cli/src/commands/post/create.test.ts
@@ -286,6 +286,71 @@ describe("post create", () => {
     );
   });
 
+  describe("--draft", () => {
+    it("creates a draft post with --draft on post create", async () => {
+      const program = createProgram();
+      await program.parseAsync(["node", "linkedctl", "post", "create", "--text", "Draft post", "--draft"]);
+
+      expect(coreMock.createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          text: "Draft post",
+          lifecycleState: "DRAFT",
+        }),
+      );
+    });
+
+    it("creates a draft post with --draft on post shorthand", async () => {
+      const program = createProgram();
+      await program.parseAsync(["node", "linkedctl", "post", "--text", "Draft shorthand", "--draft"]);
+
+      expect(coreMock.createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          text: "Draft shorthand",
+          lifecycleState: "DRAFT",
+        }),
+      );
+    });
+
+    it("defaults to PUBLISHED when --draft is not specified", async () => {
+      const program = createProgram();
+      await program.parseAsync(["node", "linkedctl", "post", "create", "--text", "Published post"]);
+
+      expect(coreMock.createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          text: "Published post",
+          lifecycleState: "PUBLISHED",
+        }),
+      );
+    });
+
+    it("creates a draft post with media attachment", async () => {
+      const program = createProgram();
+      await program.parseAsync([
+        "node",
+        "linkedctl",
+        "post",
+        "create",
+        "--text",
+        "Draft with image",
+        "--draft",
+        "--image",
+        "urn:li:image:C5608AQ123",
+      ]);
+
+      expect(coreMock.createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          text: "Draft with image",
+          lifecycleState: "DRAFT",
+          content: { media: { id: "urn:li:image:C5608AQ123" } },
+        }),
+      );
+    });
+  });
+
   describe("--text-file", () => {
     let tempDir: string;
 

--- a/packages/cli/src/commands/post/create.ts
+++ b/packages/cli/src/commands/post/create.ts
@@ -18,7 +18,7 @@ import {
   DOCUMENT_EXTENSIONS,
   DOCUMENT_MAX_SIZE_BYTES,
 } from "@linkedctl/core";
-import type { PostVisibility, PostContent } from "@linkedctl/core";
+import type { PostVisibility, PostLifecycleState, PostContent } from "@linkedctl/core";
 import { resolveFormat, formatOutput } from "../../output/index.js";
 import type { OutputFormat } from "../../output/index.js";
 import { readStdin } from "./stdin.js";
@@ -27,6 +27,7 @@ interface CreateOpts {
   text?: string | undefined;
   textFile?: string | undefined;
   visibility?: string | undefined;
+  draft?: boolean | undefined;
   image?: string | undefined;
   video?: string | undefined;
   document?: string | undefined;
@@ -213,6 +214,7 @@ export async function createPostAction(textArg: string | undefined, opts: Create
   const finalContent = content ?? (await resolveFileContent(opts, client, authorUrn));
 
   const visibility = (opts.visibility as PostVisibility | undefined) ?? "PUBLIC";
+  const lifecycleState: PostLifecycleState = opts.draft === true ? "DRAFT" : "PUBLISHED";
 
   try {
     const postUrn = await createPost(client, {
@@ -220,6 +222,7 @@ export async function createPostAction(textArg: string | undefined, opts: Create
       text,
       visibility,
       content: finalContent,
+      lifecycleState,
     });
 
     const format = resolveFormat(opts.format as OutputFormat | undefined, process.stdout, globals.json === true);
@@ -266,6 +269,7 @@ export function createCommand(): Command {
       })
       .default("PUBLIC"),
   );
+  cmd.option("--draft", "save post as draft instead of publishing");
   addMediaOptions(cmd);
   cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
 
@@ -283,6 +287,7 @@ Examples:
   linkedctl post create --text "Video" --video-file clip.mp4
   linkedctl post create --text "Deck" --document-file deck.pdf
   linkedctl post create --text "Gallery" --image-files a.jpg,b.jpg
+  linkedctl post create --draft --text "Work in progress"
   echo "Hello" | linkedctl post create`,
   );
 

--- a/packages/cli/src/commands/post/index.ts
+++ b/packages/cli/src/commands/post/index.ts
@@ -25,6 +25,7 @@ export function postCommand(): Command {
       })
       .default("PUBLIC"),
   );
+  cmd.option("--draft", "save post as draft instead of publishing");
   addMediaOptions(cmd);
   cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
 
@@ -35,6 +36,7 @@ Examples:
   linkedctl post "Hello from LinkedCtl!"
   linkedctl post --text "Hello" --visibility CONNECTIONS
   linkedctl post --text "Check this out" --image urn:li:image:C5608AQ...
+  linkedctl post --draft --text "Work in progress"
   echo "Hello" | linkedctl post`,
   );
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -52,7 +52,14 @@ export type { UploadImageOptions } from "./media/media-service.js";
 export { SUPPORTED_IMAGE_TYPES } from "./media/types.js";
 export { createTextPost, createPost } from "./posts/posts-service.js";
 export type { CreateTextPostOptions, CreatePostOptions } from "./posts/posts-service.js";
-export type { PostVisibility, PostContent, MediaContent, ArticleContent, MultiImageContent } from "./posts/types.js";
+export type {
+  PostVisibility,
+  PostLifecycleState,
+  PostContent,
+  MediaContent,
+  ArticleContent,
+  MultiImageContent,
+} from "./posts/types.js";
 export { initializeVideoUpload, uploadVideoChunk, finalizeVideoUpload, uploadVideo } from "./video/video-service.js";
 export type {
   InitializeVideoUploadRequest,

--- a/packages/core/src/posts/posts-service.test.ts
+++ b/packages/core/src/posts/posts-service.test.ts
@@ -65,6 +65,29 @@ describe("createTextPost", () => {
     const call = vi.mocked(client.create).mock.calls[0];
     expect(call?.[1]).toHaveProperty("visibility", "CONNECTIONS");
   });
+
+  it("defaults lifecycleState to PUBLISHED", async () => {
+    const client = mockClient("urn:li:share:102");
+    await createTextPost(client, {
+      author: "urn:li:person:abc",
+      text: "Default state",
+    });
+
+    const call = vi.mocked(client.create).mock.calls[0];
+    expect(call?.[1]).toHaveProperty("lifecycleState", "PUBLISHED");
+  });
+
+  it("uses DRAFT lifecycleState when specified", async () => {
+    const client = mockClient("urn:li:share:103");
+    await createTextPost(client, {
+      author: "urn:li:person:abc",
+      text: "Draft post",
+      lifecycleState: "DRAFT",
+    });
+
+    const call = vi.mocked(client.create).mock.calls[0];
+    expect(call?.[1]).toHaveProperty("lifecycleState", "DRAFT");
+  });
 });
 
 describe("createPost", () => {
@@ -199,6 +222,43 @@ describe("createPost", () => {
 
     const call = vi.mocked(client.create).mock.calls[0];
     expect(call?.[1]).toHaveProperty("visibility", "CONNECTIONS");
+    expect(call?.[1]).toHaveProperty("content", { media: { id: "urn:li:image:X" } });
+  });
+
+  it("defaults lifecycleState to PUBLISHED", async () => {
+    const client = mockClient("urn:li:share:307");
+    await createPost(client, {
+      author: "urn:li:person:abc",
+      text: "Default state",
+    });
+
+    const call = vi.mocked(client.create).mock.calls[0];
+    expect(call?.[1]).toHaveProperty("lifecycleState", "PUBLISHED");
+  });
+
+  it("uses DRAFT lifecycleState when specified", async () => {
+    const client = mockClient("urn:li:share:308");
+    await createPost(client, {
+      author: "urn:li:person:abc",
+      text: "Draft post",
+      lifecycleState: "DRAFT",
+    });
+
+    const call = vi.mocked(client.create).mock.calls[0];
+    expect(call?.[1]).toHaveProperty("lifecycleState", "DRAFT");
+  });
+
+  it("uses DRAFT lifecycleState with content", async () => {
+    const client = mockClient("urn:li:share:309");
+    await createPost(client, {
+      author: "urn:li:person:abc",
+      text: "Draft with image",
+      content: { media: { id: "urn:li:image:X" } },
+      lifecycleState: "DRAFT",
+    });
+
+    const call = vi.mocked(client.create).mock.calls[0];
+    expect(call?.[1]).toHaveProperty("lifecycleState", "DRAFT");
     expect(call?.[1]).toHaveProperty("content", { media: { id: "urn:li:image:X" } });
   });
 });

--- a/packages/core/src/posts/posts-service.ts
+++ b/packages/core/src/posts/posts-service.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { LinkedInClient } from "../http/linkedin-client.js";
-import type { PostContent, PostVisibility } from "./types.js";
+import type { PostContent, PostLifecycleState, PostVisibility } from "./types.js";
 
 /**
  * Options for creating a text-only LinkedIn post.
@@ -14,6 +14,8 @@ export interface CreateTextPostOptions {
   text: string;
   /** Post visibility. Defaults to `"PUBLIC"`. */
   visibility?: PostVisibility | undefined;
+  /** Post lifecycle state. Defaults to `"PUBLISHED"`. */
+  lifecycleState?: PostLifecycleState | undefined;
 }
 
 /**
@@ -28,6 +30,8 @@ export interface CreatePostOptions {
   visibility?: PostVisibility | undefined;
   /** Optional media content attachment. */
   content?: PostContent | undefined;
+  /** Post lifecycle state. Defaults to `"PUBLISHED"`. */
+  lifecycleState?: PostLifecycleState | undefined;
 }
 
 /**
@@ -50,7 +54,7 @@ export async function createPost(client: LinkedInClient, options: CreatePostOpti
       targetEntities: [],
       thirdPartyDistributionChannels: [],
     },
-    lifecycleState: "PUBLISHED",
+    lifecycleState: options.lifecycleState ?? "PUBLISHED",
     isReshareDisabledByAuthor: false,
   };
 

--- a/packages/core/src/posts/types.ts
+++ b/packages/core/src/posts/types.ts
@@ -7,6 +7,11 @@
 export type PostVisibility = "PUBLIC" | "CONNECTIONS";
 
 /**
+ * Lifecycle state of a LinkedIn post.
+ */
+export type PostLifecycleState = "PUBLISHED" | "DRAFT";
+
+/**
  * A single media attachment (image, video, or document).
  */
 export interface MediaContent {

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -726,6 +726,69 @@ describe("createMcpServer", () => {
       expect(result.isError).toBe(true);
     });
 
+    it("creates a draft post when draft is true", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockResolvedValue("urn:li:person:abc123");
+      vi.mocked(createPost).mockResolvedValue("urn:li:share:draft001");
+
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: {
+          text: "Draft post",
+          draft: true,
+        },
+      });
+
+      expect(createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          text: "Draft post",
+          lifecycleState: "DRAFT",
+        }),
+      );
+      expect(result.content).toEqual([{ type: "text", text: "Post created: urn:li:share:draft001" }]);
+    });
+
+    it("defaults to PUBLISHED when draft is not specified", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockResolvedValue("urn:li:person:abc123");
+      vi.mocked(createPost).mockResolvedValue("urn:li:share:pub001");
+
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: {
+          text: "Published post",
+        },
+      });
+
+      expect(createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          text: "Published post",
+          lifecycleState: "PUBLISHED",
+        }),
+      );
+      expect(result.content).toEqual([{ type: "text", text: "Post created: urn:li:share:pub001" }]);
+    });
+
     it("returns error when combining file and URN media options", async () => {
       const result = await client.callTool({
         name: "post_create",

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -25,7 +25,7 @@ import {
   clearOAuthTokens,
   revokeAccessToken,
 } from "@linkedctl/core";
-import type { PostContent } from "@linkedctl/core";
+import type { PostContent, PostLifecycleState } from "@linkedctl/core";
 
 /**
  * Create and configure the LinkedCtl MCP server with all tools registered.
@@ -92,6 +92,7 @@ export function createMcpServer(): McpServer {
       inputSchema: {
         text: z.string().describe("The text content of the post"),
         visibility: z.enum(["PUBLIC", "CONNECTIONS"]).optional().describe("Post visibility (defaults to PUBLIC)"),
+        draft: z.boolean().optional().describe("Save as draft instead of publishing (defaults to false)"),
         image: z.string().optional().describe("Image URN to attach (e.g. urn:li:image:C5608AQ...)"),
         video: z.string().optional().describe("Video URN to attach (e.g. urn:li:video:D5608AQ...)"),
         document: z.string().optional().describe("Document URN to attach (e.g. urn:li:document:D123...)"),
@@ -248,12 +249,14 @@ export function createMcpServer(): McpServer {
       }
 
       const visibility = args.visibility ?? "PUBLIC";
+      const lifecycleState: PostLifecycleState = args.draft === true ? "DRAFT" : "PUBLISHED";
 
       const postUrn = await createPost(client, {
         author: authorUrn,
         text: args.text,
         visibility,
         content: postContent,
+        lifecycleState,
       });
 
       return {


### PR DESCRIPTION
## Summary

- Add `--draft` flag to `post create` CLI command and `post` shorthand to create posts with `DRAFT` lifecycle state instead of `PUBLISHED`
- Add `draft` boolean parameter to the `post_create` MCP tool
- Add `PostLifecycleState` type and `lifecycleState` option to core `CreatePostOptions`/`CreateTextPostOptions`

Closes #19

## Test plan

- [x] Core: `createPost` defaults to `PUBLISHED` lifecycle state
- [x] Core: `createPost` uses `DRAFT` when `lifecycleState: "DRAFT"` specified
- [x] Core: `createTextPost` supports `lifecycleState` option
- [x] CLI: `--draft` flag sets lifecycle state to `DRAFT` on `post create`
- [x] CLI: `--draft` flag works on `post` shorthand
- [x] CLI: defaults to `PUBLISHED` when `--draft` is omitted
- [x] CLI: `--draft` works with media attachments
- [x] MCP: `draft: true` sets lifecycle state to `DRAFT`
- [x] MCP: defaults to `PUBLISHED` when `draft` is not specified
- [x] All 482 tests pass, typecheck/lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)