### PR TITLE
(feat) add poll posts

### DIFF
--- a/packages/cli/src/commands/post/create.test.ts
+++ b/packages/cli/src/commands/post/create.test.ts
@@ -599,7 +599,7 @@ describe("post create", () => {
           "--video",
           "urn:li:video:Y",
         ]),
-      ).rejects.toThrow(/Only one media option/);
+      ).rejects.toThrow(/Only one content option/);
     });
 
     it("creates a post with --image on post shorthand", async () => {
@@ -849,7 +849,7 @@ describe("post create", () => {
           "--image",
           "urn:li:image:X",
         ]),
-      ).rejects.toThrow(/Only one media option/);
+      ).rejects.toThrow(/Only one content option/);
     });
 
     it("rejects combining --video-file with --document-file", async () => {
@@ -874,7 +874,7 @@ describe("post create", () => {
           "--document-file",
           docPath,
         ]),
-      ).rejects.toThrow(/Only one media option/);
+      ).rejects.toThrow(/Only one content option/);
     });
 
     it("uses --image-file on post shorthand", async () => {
@@ -890,6 +890,207 @@ describe("post create", () => {
         expect.objectContaining({
           text: "Shorthand upload",
           content: { media: { id: "urn:li:image:UPLOADED1" } },
+        }),
+      );
+    });
+  });
+
+  describe("poll options", () => {
+    it("creates a poll post with --poll and --option flags", async () => {
+      const program = createProgram();
+      await program.parseAsync([
+        "node",
+        "linkedctl",
+        "post",
+        "create",
+        "--text",
+        "Vote now!",
+        "--poll",
+        "Favorite language?",
+        "--option",
+        "TypeScript",
+        "--option",
+        "Python",
+      ]);
+
+      expect(coreMock.createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          text: "Vote now!",
+          content: {
+            poll: {
+              question: "Favorite language?",
+              options: [{ text: "TypeScript" }, { text: "Python" }],
+              settings: { duration: "THREE_DAYS" },
+            },
+          },
+        }),
+      );
+    });
+
+    it("creates a poll post with custom duration", async () => {
+      const program = createProgram();
+      await program.parseAsync([
+        "node",
+        "linkedctl",
+        "post",
+        "create",
+        "--text",
+        "Vote!",
+        "--poll",
+        "Best framework?",
+        "--option",
+        "React",
+        "--option",
+        "Vue",
+        "--option",
+        "Angular",
+        "--poll-duration",
+        "ONE_WEEK",
+      ]);
+
+      expect(coreMock.createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          content: {
+            poll: {
+              question: "Best framework?",
+              options: [{ text: "React" }, { text: "Vue" }, { text: "Angular" }],
+              settings: { duration: "ONE_WEEK" },
+            },
+          },
+        }),
+      );
+    });
+
+    it("rejects --poll with fewer than 2 options", async () => {
+      const program = createProgram();
+      program.exitOverride();
+
+      await expect(
+        program.parseAsync([
+          "node",
+          "linkedctl",
+          "post",
+          "create",
+          "--text",
+          "Vote!",
+          "--poll",
+          "Question?",
+          "--option",
+          "Only one",
+        ]),
+      ).rejects.toThrow(/at least 2/);
+    });
+
+    it("rejects --poll with more than 4 options", async () => {
+      const program = createProgram();
+      program.exitOverride();
+
+      await expect(
+        program.parseAsync([
+          "node",
+          "linkedctl",
+          "post",
+          "create",
+          "--text",
+          "Vote!",
+          "--poll",
+          "Question?",
+          "--option",
+          "A",
+          "--option",
+          "B",
+          "--option",
+          "C",
+          "--option",
+          "D",
+          "--option",
+          "E",
+        ]),
+      ).rejects.toThrow(/at most 4/);
+    });
+
+    it("rejects combining --poll with --image", async () => {
+      const program = createProgram();
+      program.exitOverride();
+
+      await expect(
+        program.parseAsync([
+          "node",
+          "linkedctl",
+          "post",
+          "create",
+          "--text",
+          "Both",
+          "--poll",
+          "Question?",
+          "--option",
+          "A",
+          "--option",
+          "B",
+          "--image",
+          "urn:li:image:X",
+        ]),
+      ).rejects.toThrow(/Only one content option/);
+    });
+
+    it("creates a poll post on post shorthand", async () => {
+      const program = createProgram();
+      await program.parseAsync([
+        "node",
+        "linkedctl",
+        "post",
+        "--text",
+        "Quick poll",
+        "--poll",
+        "Yes or no?",
+        "--option",
+        "Yes",
+        "--option",
+        "No",
+      ]);
+
+      expect(coreMock.createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          text: "Quick poll",
+          content: {
+            poll: {
+              question: "Yes or no?",
+              options: [{ text: "Yes" }, { text: "No" }],
+              settings: { duration: "THREE_DAYS" },
+            },
+          },
+        }),
+      );
+    });
+
+    it("defaults poll duration to THREE_DAYS", async () => {
+      const program = createProgram();
+      await program.parseAsync([
+        "node",
+        "linkedctl",
+        "post",
+        "create",
+        "--text",
+        "Poll",
+        "--poll",
+        "Q?",
+        "--option",
+        "A",
+        "--option",
+        "B",
+      ]);
+
+      expect(coreMock.createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          content: expect.objectContaining({
+            poll: expect.objectContaining({
+              settings: { duration: "THREE_DAYS" },
+            }),
+          }),
         }),
       );
     });

--- a/packages/cli/src/commands/post/create.ts
+++ b/packages/cli/src/commands/post/create.ts
@@ -18,7 +18,7 @@ import {
   DOCUMENT_EXTENSIONS,
   DOCUMENT_MAX_SIZE_BYTES,
 } from "@linkedctl/core";
-import type { PostVisibility, PostLifecycleState, PostContent } from "@linkedctl/core";
+import type { PostVisibility, PostLifecycleState, PostContent, PollDuration } from "@linkedctl/core";
 import { resolveFormat, formatOutput } from "../../output/index.js";
 import type { OutputFormat } from "../../output/index.js";
 import { readStdin } from "./stdin.js";
@@ -37,6 +37,9 @@ interface CreateOpts {
   videoFile?: string | undefined;
   documentFile?: string | undefined;
   imageFiles?: string | undefined;
+  poll?: string | undefined;
+  option?: string[] | undefined;
+  pollDuration?: string | undefined;
   format?: string | undefined;
 }
 
@@ -81,10 +84,10 @@ async function resolveText(
 /**
  * Resolve media content from mutually exclusive CLI options (URN-based).
  *
- * Also validates mutual exclusivity against file-based options.
+ * Also validates mutual exclusivity against file-based and poll options.
  */
 function resolveContent(opts: CreateOpts): PostContent | undefined {
-  const mediaFlags = [
+  const contentFlags = [
     opts.image,
     opts.video,
     opts.document,
@@ -94,11 +97,12 @@ function resolveContent(opts: CreateOpts): PostContent | undefined {
     opts.videoFile,
     opts.documentFile,
     opts.imageFiles,
+    opts.poll,
   ].filter((v) => v !== undefined);
 
-  if (mediaFlags.length > 1) {
+  if (contentFlags.length > 1) {
     throw new Error(
-      "Only one media option may be specified: --image, --video, --document, --article-url, --images, --image-file, --video-file, --document-file, or --image-files",
+      "Only one content option may be specified: --image, --video, --document, --article-url, --images, --image-file, --video-file, --document-file, --image-files, or --poll",
     );
   }
 
@@ -120,6 +124,23 @@ function resolveContent(opts: CreateOpts): PostContent | undefined {
       throw new Error("--images requires at least 2 comma-separated image URNs");
     }
     return { multiImage: { images: ids.map((id) => ({ id })) } };
+  }
+  if (opts.poll !== undefined) {
+    const options = opts.option ?? [];
+    if (options.length < 2) {
+      throw new Error("--poll requires at least 2 --option values");
+    }
+    if (options.length > 4) {
+      throw new Error("--poll allows at most 4 --option values");
+    }
+    const duration = (opts.pollDuration as PollDuration | undefined) ?? "THREE_DAYS";
+    return {
+      poll: {
+        question: opts.poll,
+        options: options.map((text) => ({ text })),
+        settings: { duration },
+      },
+    };
   }
   return undefined;
 }
@@ -251,6 +272,23 @@ export function addMediaOptions(cmd: Command): void {
   cmd.option("--image-files <paths>", "upload multiple local image files and attach them (comma-separated, minimum 2)");
 }
 
+/**
+ * Add poll options shared between `post create` and `post` shorthand.
+ */
+export function addPollOptions(cmd: Command): void {
+  cmd.option("--poll <question>", "create a poll with the given question");
+  cmd.option("--option <text>", "add a poll answer option (repeat for each option, 2-4 required)", collectOption);
+  cmd.addOption(
+    new Option("--poll-duration <duration>", "poll duration (defaults to THREE_DAYS)")
+      .choices(["ONE_DAY", "THREE_DAYS", "ONE_WEEK", "TWO_WEEKS"])
+      .default("THREE_DAYS"),
+  );
+}
+
+function collectOption(value: string, previous: string[] | undefined): string[] {
+  return [...(previous ?? []), value];
+}
+
 export function createCommand(): Command {
   const cmd = new Command("create");
   cmd.description("Create a post on LinkedIn (text: --text > --text-file > positional > stdin)");
@@ -271,6 +309,7 @@ export function createCommand(): Command {
   );
   cmd.option("--draft", "save post as draft instead of publishing");
   addMediaOptions(cmd);
+  addPollOptions(cmd);
   cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
 
   cmd.addHelpText(
@@ -288,6 +327,7 @@ Examples:
   linkedctl post create --text "Deck" --document-file deck.pdf
   linkedctl post create --text "Gallery" --image-files a.jpg,b.jpg
   linkedctl post create --draft --text "Work in progress"
+  linkedctl post create --text "Vote!" --poll "Favorite language?" --option "TypeScript" --option "Python"
   echo "Hello" | linkedctl post create`,
   );
 

--- a/packages/cli/src/commands/post/index.ts
+++ b/packages/cli/src/commands/post/index.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { Command, InvalidArgumentError, Option } from "commander";
-import { addMediaOptions, createCommand, createPostAction } from "./create.js";
+import { addMediaOptions, addPollOptions, createCommand, createPostAction } from "./create.js";
 
 export function postCommand(): Command {
   const cmd = new Command("post");
@@ -27,6 +27,7 @@ export function postCommand(): Command {
   );
   cmd.option("--draft", "save post as draft instead of publishing");
   addMediaOptions(cmd);
+  addPollOptions(cmd);
   cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
 
   cmd.addHelpText(
@@ -37,6 +38,7 @@ Examples:
   linkedctl post --text "Hello" --visibility CONNECTIONS
   linkedctl post --text "Check this out" --image urn:li:image:C5608AQ...
   linkedctl post --draft --text "Work in progress"
+  linkedctl post --text "Vote!" --poll "Favorite?" --option "A" --option "B"
   echo "Hello" | linkedctl post`,
   );
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -59,6 +59,8 @@ export type {
   MediaContent,
   ArticleContent,
   MultiImageContent,
+  PollDuration,
+  PollContent,
 } from "./posts/types.js";
 export { initializeVideoUpload, uploadVideoChunk, finalizeVideoUpload, uploadVideo } from "./video/video-service.js";
 export type {

--- a/packages/core/src/posts/posts-service.test.ts
+++ b/packages/core/src/posts/posts-service.test.ts
@@ -261,4 +261,52 @@ describe("createPost", () => {
     expect(call?.[1]).toHaveProperty("lifecycleState", "DRAFT");
     expect(call?.[1]).toHaveProperty("content", { media: { id: "urn:li:image:X" } });
   });
+
+  it("includes poll content for poll post", async () => {
+    const client = mockClient("urn:li:share:400");
+    await createPost(client, {
+      author: "urn:li:person:abc",
+      text: "What do you think?",
+      content: {
+        poll: {
+          question: "Favorite language?",
+          options: [{ text: "TypeScript" }, { text: "Python" }],
+          settings: { duration: "THREE_DAYS" },
+        },
+      },
+    });
+
+    const call = vi.mocked(client.create).mock.calls[0];
+    expect(call?.[1]).toHaveProperty("content", {
+      poll: {
+        question: "Favorite language?",
+        options: [{ text: "TypeScript" }, { text: "Python" }],
+        settings: { duration: "THREE_DAYS" },
+      },
+    });
+  });
+
+  it("includes poll content with four options", async () => {
+    const client = mockClient("urn:li:share:401");
+    await createPost(client, {
+      author: "urn:li:person:abc",
+      text: "Pick one",
+      content: {
+        poll: {
+          question: "Best framework?",
+          options: [{ text: "React" }, { text: "Vue" }, { text: "Angular" }, { text: "Svelte" }],
+          settings: { duration: "ONE_WEEK" },
+        },
+      },
+    });
+
+    const call = vi.mocked(client.create).mock.calls[0];
+    expect(call?.[1]).toHaveProperty("content", {
+      poll: {
+        question: "Best framework?",
+        options: [{ text: "React" }, { text: "Vue" }, { text: "Angular" }, { text: "Svelte" }],
+        settings: { duration: "ONE_WEEK" },
+      },
+    });
+  });
 });

--- a/packages/core/src/posts/types.ts
+++ b/packages/core/src/posts/types.ts
@@ -40,6 +40,30 @@ export interface MultiImageContent {
 }
 
 /**
+ * Supported poll duration settings.
+ */
+export type PollDuration = "ONE_DAY" | "THREE_DAYS" | "ONE_WEEK" | "TWO_WEEKS";
+
+/**
+ * A poll attachment.
+ */
+export interface PollContent {
+  /** The poll question. */
+  question: string;
+  /** Poll answer options (minimum 2, maximum 4). */
+  options: Array<{ text: string }>;
+  /** Poll settings. */
+  settings: {
+    /** How long the poll stays open. Defaults to `"THREE_DAYS"`. */
+    duration: PollDuration;
+  };
+}
+
+/**
  * Content attachment for a LinkedIn post.
  */
-export type PostContent = { media: MediaContent } | { article: ArticleContent } | { multiImage: MultiImageContent };
+export type PostContent =
+  | { media: MediaContent }
+  | { article: ArticleContent }
+  | { multiImage: MultiImageContent }
+  | { poll: PollContent };

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -468,7 +468,7 @@ describe("createMcpServer", () => {
       expect(result.content).toEqual([
         {
           type: "text",
-          text: expect.stringContaining("Only one media option"),
+          text: expect.stringContaining("Only one content option"),
         },
       ]);
       expect(result.isError).toBe(true);
@@ -824,7 +824,166 @@ describe("createMcpServer", () => {
       expect(result.content).toEqual([
         {
           type: "text",
-          text: expect.stringContaining("Only one media option"),
+          text: expect.stringContaining("Only one content option"),
+        },
+      ]);
+      expect(result.isError).toBe(true);
+    });
+
+    it("creates a poll post", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockResolvedValue("urn:li:person:abc123");
+      vi.mocked(createPost).mockResolvedValue("urn:li:share:poll001");
+
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: {
+          text: "Vote now!",
+          poll: "Favorite language?",
+          poll_options: ["TypeScript", "Python"],
+        },
+      });
+
+      expect(createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          content: {
+            poll: {
+              question: "Favorite language?",
+              options: [{ text: "TypeScript" }, { text: "Python" }],
+              settings: { duration: "THREE_DAYS" },
+            },
+          },
+        }),
+      );
+      expect(result.content).toEqual([{ type: "text", text: "Post created: urn:li:share:poll001" }]);
+    });
+
+    it("creates a poll post with custom duration", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockResolvedValue("urn:li:person:abc123");
+      vi.mocked(createPost).mockResolvedValue("urn:li:share:poll002");
+
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: {
+          text: "Quick poll",
+          poll: "Yes or no?",
+          poll_options: ["Yes", "No"],
+          poll_duration: "ONE_DAY",
+        },
+      });
+
+      expect(createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          content: {
+            poll: {
+              question: "Yes or no?",
+              options: [{ text: "Yes" }, { text: "No" }],
+              settings: { duration: "ONE_DAY" },
+            },
+          },
+        }),
+      );
+      expect(result.content).toEqual([{ type: "text", text: "Post created: urn:li:share:poll002" }]);
+    });
+
+    it("returns error when poll has fewer than 2 options", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockResolvedValue("urn:li:person:abc123");
+
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: {
+          text: "Bad poll",
+          poll: "Question?",
+          poll_options: ["Only one"],
+        },
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: expect.stringContaining("at least 2"),
+        },
+      ]);
+      expect(result.isError).toBe(true);
+    });
+
+    it("returns error when poll has more than 4 options", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockResolvedValue("urn:li:person:abc123");
+
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: {
+          text: "Too many options",
+          poll: "Question?",
+          poll_options: ["A", "B", "C", "D", "E"],
+        },
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: expect.stringContaining("at most 4"),
+        },
+      ]);
+      expect(result.isError).toBe(true);
+    });
+
+    it("returns error when combining poll with image", async () => {
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: {
+          text: "Conflicting",
+          poll: "Question?",
+          poll_options: ["A", "B"],
+          image: "urn:li:image:X",
+        },
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: expect.stringContaining("Only one content option"),
         },
       ]);
       expect(result.isError).toBe(true);

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -113,11 +113,20 @@ export function createMcpServer(): McpServer {
           .array(z.string())
           .optional()
           .describe("Array of local image file paths to upload and attach (minimum 2)"),
+        poll: z.string().optional().describe("Poll question text (creates a poll post)"),
+        poll_options: z
+          .array(z.string())
+          .optional()
+          .describe("Array of poll answer options (minimum 2, maximum 4; required when poll is set)"),
+        poll_duration: z
+          .enum(["ONE_DAY", "THREE_DAYS", "ONE_WEEK", "TWO_WEEKS"])
+          .optional()
+          .describe("How long the poll stays open (defaults to THREE_DAYS)"),
         profile: z.string().optional().describe("Profile name to use from config file"),
       },
     },
     async (args) => {
-      const mediaFlags = [
+      const contentFlags = [
         args.image,
         args.video,
         args.document,
@@ -127,13 +136,14 @@ export function createMcpServer(): McpServer {
         args.video_file,
         args.document_file,
         args.image_files,
+        args.poll,
       ].filter((v) => v !== undefined);
-      if (mediaFlags.length > 1) {
+      if (contentFlags.length > 1) {
         return {
           content: [
             {
               type: "text" as const,
-              text: "Only one media option may be specified: image, video, document, article_url, images, image_file, video_file, document_file, or image_files",
+              text: "Only one content option may be specified: image, video, document, article_url, images, image_file, video_file, document_file, image_files, or poll",
             },
           ],
           isError: true,
@@ -157,6 +167,27 @@ export function createMcpServer(): McpServer {
           };
         }
         postContent = { multiImage: { images: args.images.map((id) => ({ id })) } };
+      } else if (args.poll !== undefined) {
+        const pollOptions = args.poll_options ?? [];
+        if (pollOptions.length < 2) {
+          return {
+            content: [{ type: "text" as const, text: "Poll posts require at least 2 poll_options" }],
+            isError: true,
+          };
+        }
+        if (pollOptions.length > 4) {
+          return {
+            content: [{ type: "text" as const, text: "Poll posts allow at most 4 poll_options" }],
+            isError: true,
+          };
+        }
+        postContent = {
+          poll: {
+            question: args.poll,
+            options: pollOptions.map((text) => ({ text })),
+            settings: { duration: args.poll_duration ?? "THREE_DAYS" },
+          },
+        };
       }
 
       const { config } = await resolveConfig({


### PR DESCRIPTION
## Summary

- Add `PollContent` type with question, options (2-4), and duration settings to `@linkedctl/core`
- Add `--poll`, `--option` (repeatable), and `--poll-duration` CLI flags to `post create` and `post` shorthand commands
- Add `poll`, `poll_options`, and `poll_duration` parameters to MCP `post_create` tool
- Polls are mutually exclusive with media attachments (image, video, document, article, multi-image)
- Default poll duration is `THREE_DAYS`; supported: `ONE_DAY`, `THREE_DAYS`, `ONE_WEEK`, `TWO_WEEKS`

Closes #18

## Test plan

- [x] Core service tests: poll content passed through to LinkedIn API correctly (2 and 4 options)
- [x] CLI tests: poll post creation, custom duration, option count validation (min 2, max 4), mutual exclusivity with media, shorthand support
- [x] MCP tests: poll post creation, custom duration, option count validation, mutual exclusivity
- [x] Build, typecheck, lint, format check all pass
- [x] All 485 tests pass (182 core + 264 CLI + 39 MCP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)