### PR TITLE
(feat) add reactions support

### DIFF
--- a/packages/cli/src/commands/reaction/create.test.ts
+++ b/packages/cli/src/commands/reaction/create.test.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { createProgram } from "../../program.js";
+
+vi.mock("@linkedctl/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@linkedctl/core")>();
+  return {
+    ...actual,
+    resolveConfig: vi.fn().mockResolvedValue({
+      config: {
+        oauth: { accessToken: "test-token" },
+        apiVersion: "202601",
+      },
+      warnings: [],
+    }),
+    getCurrentPersonUrn: vi.fn().mockResolvedValue("urn:li:person:person123"),
+    createReaction: vi.fn().mockResolvedValue("urn:li:reaction:test123"),
+  };
+});
+
+const coreMock = await import("@linkedctl/core");
+
+describe("reaction create", () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.mocked(coreMock.resolveConfig).mockResolvedValue({
+      config: {
+        oauth: { accessToken: "test-token" },
+        apiVersion: "202601",
+      },
+      warnings: [],
+    });
+    vi.mocked(coreMock.createReaction).mockResolvedValue("urn:li:reaction:test123");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates a LIKE reaction by default", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "reaction", "create", "urn:li:share:abc123"]);
+
+    expect(coreMock.createReaction).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        entity: "urn:li:share:abc123",
+        reactionType: "LIKE",
+      }),
+    );
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+
+  it("creates a reaction with specified type", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "reaction", "create", "urn:li:share:abc123", "--type", "PRAISE"]);
+
+    expect(coreMock.createReaction).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        entity: "urn:li:share:abc123",
+        reactionType: "PRAISE",
+      }),
+    );
+  });
+
+  it("outputs JSON when --format json is specified", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "reaction", "create", "urn:li:share:abc123", "--format", "json"]);
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(JSON.parse(output)).toEqual({ urn: "urn:li:reaction:test123" });
+  });
+
+  it("resolves config with profile from global options", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "--profile", "work", "reaction", "create", "urn:li:share:abc123"]);
+
+    expect(coreMock.resolveConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profile: "work",
+        requiredScopes: ["openid", "profile", "email", "w_member_social"],
+      }),
+    );
+  });
+
+  it("rejects invalid --type value", async () => {
+    const program = createProgram();
+    for (const cmd of program.commands) {
+      cmd.exitOverride();
+      for (const sub of cmd.commands) sub.exitOverride();
+    }
+
+    await expect(
+      program.parseAsync(["node", "linkedctl", "reaction", "create", "urn:li:share:abc123", "--type", "INVALID"]),
+    ).rejects.toThrow(/Allowed choices are/);
+  });
+
+  it("wraps API errors with actionable message", async () => {
+    const { LinkedInApiError } = await import("@linkedctl/core");
+    vi.mocked(coreMock.createReaction).mockRejectedValueOnce(new LinkedInApiError("Forbidden", 403));
+
+    const program = createProgram();
+    program.exitOverride();
+
+    await expect(
+      program.parseAsync(["node", "linkedctl", "reaction", "create", "urn:li:share:abc123"]),
+    ).rejects.toThrow(/Failed to create reaction/);
+  });
+});

--- a/packages/cli/src/commands/reaction/create.ts
+++ b/packages/cli/src/commands/reaction/create.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { Command, Option } from "commander";
+import { resolveConfig, LinkedInClient, createReaction, LinkedInApiError, REACTION_TYPES } from "@linkedctl/core";
+import type { ReactionType } from "@linkedctl/core";
+import { resolveFormat, formatOutput } from "../../output/index.js";
+import type { OutputFormat } from "../../output/index.js";
+
+interface CreateOpts {
+  type?: string | undefined;
+  format?: string | undefined;
+}
+
+export async function createReactionAction(entityUrn: string, opts: CreateOpts, cmd: Command): Promise<void> {
+  const globals = cmd.optsWithGlobals<{ profile?: string | undefined; json?: boolean | undefined }>();
+
+  const { config } = await resolveConfig({
+    profile: globals.profile,
+    requiredScopes: ["openid", "profile", "email", "w_member_social"],
+  });
+  const accessToken = config.oauth?.accessToken ?? "";
+  const apiVersion = config.apiVersion ?? "";
+  const client = new LinkedInClient({ accessToken, apiVersion });
+
+  const reactionType = (opts.type ?? "LIKE") as ReactionType;
+
+  try {
+    const reactionUrn = await createReaction(client, {
+      entity: entityUrn,
+      reactionType,
+    });
+
+    const format = resolveFormat(opts.format as OutputFormat | undefined, process.stdout, globals.json === true);
+    const output = formatOutput({ urn: reactionUrn }, format);
+    console.log(output);
+  } catch (error) {
+    if (error instanceof LinkedInApiError) {
+      throw new Error(`Failed to create reaction: ${error.message}`);
+    }
+    throw error;
+  }
+}
+
+export function createReactionCommand(): Command {
+  const cmd = new Command("create");
+  cmd.description("Add a reaction to a LinkedIn post");
+  cmd.argument("<entity-urn>", "entity URN to react to (e.g. urn:li:share:abc123)");
+  cmd.addOption(new Option("--type <type>", "reaction type").choices([...REACTION_TYPES]).default("LIKE"));
+  cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
+
+  cmd.addHelpText(
+    "after",
+    `
+Examples:
+  linkedctl reaction create urn:li:share:abc123
+  linkedctl reaction create urn:li:share:abc123 --type PRAISE
+  linkedctl reaction create urn:li:share:abc123 --type ENTERTAINMENT --format json`,
+  );
+
+  cmd.action(async (entityUrn: string, opts: CreateOpts, actionCmd: Command) => {
+    await createReactionAction(entityUrn, opts, actionCmd);
+  });
+
+  return cmd;
+}

--- a/packages/cli/src/commands/reaction/delete.test.ts
+++ b/packages/cli/src/commands/reaction/delete.test.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { createProgram } from "../../program.js";
+
+vi.mock("@linkedctl/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@linkedctl/core")>();
+  return {
+    ...actual,
+    resolveConfig: vi.fn().mockResolvedValue({
+      config: {
+        oauth: { accessToken: "test-token" },
+        apiVersion: "202601",
+      },
+      warnings: [],
+    }),
+    getCurrentPersonUrn: vi.fn().mockResolvedValue("urn:li:person:person123"),
+    deleteReaction: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+const coreMock = await import("@linkedctl/core");
+
+describe("reaction delete", () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.mocked(coreMock.resolveConfig).mockResolvedValue({
+      config: {
+        oauth: { accessToken: "test-token" },
+        apiVersion: "202601",
+      },
+      warnings: [],
+    });
+    vi.mocked(coreMock.getCurrentPersonUrn).mockResolvedValue("urn:li:person:person123");
+    vi.mocked(coreMock.deleteReaction).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("deletes the user's reaction from a post", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "reaction", "delete", "urn:li:share:abc123"]);
+
+    expect(coreMock.deleteReaction).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        entity: "urn:li:share:abc123",
+        actor: "urn:li:person:person123",
+      }),
+    );
+  });
+
+  it("outputs confirmation message", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "reaction", "delete", "urn:li:share:abc123"]);
+
+    expect(consoleSpy).toHaveBeenCalledWith("Reaction deleted");
+  });
+
+  it("resolves config with profile from global options", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "--profile", "work", "reaction", "delete", "urn:li:share:abc123"]);
+
+    expect(coreMock.resolveConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profile: "work",
+        requiredScopes: ["openid", "profile", "email", "w_member_social"],
+      }),
+    );
+  });
+
+  it("wraps API errors with actionable message", async () => {
+    const { LinkedInApiError } = await import("@linkedctl/core");
+    vi.mocked(coreMock.deleteReaction).mockRejectedValueOnce(new LinkedInApiError("Not Found", 404));
+
+    const program = createProgram();
+    program.exitOverride();
+
+    await expect(
+      program.parseAsync(["node", "linkedctl", "reaction", "delete", "urn:li:share:abc123"]),
+    ).rejects.toThrow(/Failed to delete reaction/);
+  });
+});

--- a/packages/cli/src/commands/reaction/delete.ts
+++ b/packages/cli/src/commands/reaction/delete.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { Command } from "commander";
+import { resolveConfig, LinkedInClient, getCurrentPersonUrn, deleteReaction, LinkedInApiError } from "@linkedctl/core";
+
+export async function deleteReactionAction(entityUrn: string, cmd: Command): Promise<void> {
+  const globals = cmd.optsWithGlobals<{ profile?: string | undefined }>();
+
+  const { config } = await resolveConfig({
+    profile: globals.profile,
+    requiredScopes: ["openid", "profile", "email", "w_member_social"],
+  });
+  const accessToken = config.oauth?.accessToken ?? "";
+  const apiVersion = config.apiVersion ?? "";
+  const client = new LinkedInClient({ accessToken, apiVersion });
+
+  const actorUrn = await getCurrentPersonUrn(client);
+
+  try {
+    await deleteReaction(client, { entity: entityUrn, actor: actorUrn });
+    console.log("Reaction deleted");
+  } catch (error) {
+    if (error instanceof LinkedInApiError) {
+      throw new Error(`Failed to delete reaction: ${error.message}`);
+    }
+    throw error;
+  }
+}
+
+export function deleteReactionCommand(): Command {
+  const cmd = new Command("delete");
+  cmd.description("Remove your reaction from a LinkedIn post");
+  cmd.argument("<entity-urn>", "entity URN to remove reaction from (e.g. urn:li:share:abc123)");
+
+  cmd.addHelpText(
+    "after",
+    `
+Examples:
+  linkedctl reaction delete urn:li:share:abc123`,
+  );
+
+  cmd.action(async (entityUrn: string, _opts: Record<string, unknown>, actionCmd: Command) => {
+    await deleteReactionAction(entityUrn, actionCmd);
+  });
+
+  return cmd;
+}

--- a/packages/cli/src/commands/reaction/index.ts
+++ b/packages/cli/src/commands/reaction/index.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { Command } from "commander";
+import { createReactionCommand } from "./create.js";
+import { listReactionsCommand } from "./list.js";
+import { deleteReactionCommand } from "./delete.js";
+
+export function reactionCommand(): Command {
+  const cmd = new Command("reaction");
+  cmd.description("Manage LinkedIn reactions");
+
+  cmd.enablePositionalOptions();
+
+  cmd.addCommand(createReactionCommand());
+  cmd.addCommand(listReactionsCommand());
+  cmd.addCommand(deleteReactionCommand());
+
+  return cmd;
+}

--- a/packages/cli/src/commands/reaction/list.test.ts
+++ b/packages/cli/src/commands/reaction/list.test.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { createProgram } from "../../program.js";
+
+vi.mock("@linkedctl/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@linkedctl/core")>();
+  return {
+    ...actual,
+    resolveConfig: vi.fn().mockResolvedValue({
+      config: {
+        oauth: { accessToken: "test-token" },
+        apiVersion: "202601",
+      },
+      warnings: [],
+    }),
+    getCurrentPersonUrn: vi.fn().mockResolvedValue("urn:li:person:person123"),
+    listReactions: vi.fn().mockResolvedValue([]),
+  };
+});
+
+const coreMock = await import("@linkedctl/core");
+
+describe("reaction list", () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.mocked(coreMock.resolveConfig).mockResolvedValue({
+      config: {
+        oauth: { accessToken: "test-token" },
+        apiVersion: "202601",
+      },
+      warnings: [],
+    });
+    vi.mocked(coreMock.listReactions).mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("lists reactions for a post", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "reaction", "list", "urn:li:share:abc123"]);
+
+    expect(coreMock.listReactions).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        entity: "urn:li:share:abc123",
+      }),
+    );
+  });
+
+  it("outputs reactions as JSON when --format json is specified", async () => {
+    vi.mocked(coreMock.listReactions).mockResolvedValue([
+      {
+        actor: "urn:li:person:user1",
+        entity: "urn:li:share:abc123",
+        reactionType: "LIKE",
+        createdAt: 1700000000000,
+      },
+    ]);
+
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "reaction", "list", "urn:li:share:abc123", "--format", "json"]);
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(output) as Array<Record<string, unknown>>;
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]).toHaveProperty("actor", "urn:li:person:user1");
+    expect(parsed[0]).toHaveProperty("type", "LIKE");
+  });
+
+  it("resolves config with profile from global options", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "--profile", "work", "reaction", "list", "urn:li:share:abc123"]);
+
+    expect(coreMock.resolveConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profile: "work",
+        requiredScopes: ["openid", "profile", "email", "w_member_social"],
+      }),
+    );
+  });
+
+  it("wraps API errors with actionable message", async () => {
+    const { LinkedInApiError } = await import("@linkedctl/core");
+    vi.mocked(coreMock.listReactions).mockRejectedValueOnce(new LinkedInApiError("Forbidden", 403));
+
+    const program = createProgram();
+    program.exitOverride();
+
+    await expect(program.parseAsync(["node", "linkedctl", "reaction", "list", "urn:li:share:abc123"])).rejects.toThrow(
+      /Failed to list reactions/,
+    );
+  });
+});

--- a/packages/cli/src/commands/reaction/list.ts
+++ b/packages/cli/src/commands/reaction/list.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { Command, Option } from "commander";
+import { resolveConfig, LinkedInClient, listReactions, LinkedInApiError } from "@linkedctl/core";
+import { resolveFormat, formatOutput } from "../../output/index.js";
+import type { OutputFormat } from "../../output/index.js";
+
+interface ListOpts {
+  format?: string | undefined;
+}
+
+export async function listReactionsAction(entityUrn: string, opts: ListOpts, cmd: Command): Promise<void> {
+  const globals = cmd.optsWithGlobals<{ profile?: string | undefined; json?: boolean | undefined }>();
+
+  const { config } = await resolveConfig({
+    profile: globals.profile,
+    requiredScopes: ["openid", "profile", "email", "w_member_social"],
+  });
+  const accessToken = config.oauth?.accessToken ?? "";
+  const apiVersion = config.apiVersion ?? "";
+  const client = new LinkedInClient({ accessToken, apiVersion });
+
+  try {
+    const reactions = await listReactions(client, { entity: entityUrn });
+
+    const format = resolveFormat(opts.format as OutputFormat | undefined, process.stdout, globals.json === true);
+    const output = formatOutput(
+      reactions.map((r) => ({
+        actor: r.actor,
+        type: r.reactionType,
+        createdAt: new Date(r.createdAt).toISOString(),
+      })),
+      format,
+    );
+    console.log(output);
+  } catch (error) {
+    if (error instanceof LinkedInApiError) {
+      throw new Error(`Failed to list reactions: ${error.message}`);
+    }
+    throw error;
+  }
+}
+
+export function listReactionsCommand(): Command {
+  const cmd = new Command("list");
+  cmd.description("List reactions on a LinkedIn post");
+  cmd.argument("<entity-urn>", "entity URN to list reactions for (e.g. urn:li:share:abc123)");
+  cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
+
+  cmd.addHelpText(
+    "after",
+    `
+Examples:
+  linkedctl reaction list urn:li:share:abc123
+  linkedctl reaction list urn:li:share:abc123 --format json`,
+  );
+
+  cmd.action(async (entityUrn: string, opts: ListOpts, actionCmd: Command) => {
+    await listReactionsAction(entityUrn, opts, actionCmd);
+  });
+
+  return cmd;
+}

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -7,6 +7,7 @@ import { completionCommand } from "./commands/completion.js";
 import { mediaCommand } from "./commands/media/index.js";
 import { postCommand } from "./commands/post/index.js";
 import { profileCommand } from "./commands/profile/index.js";
+import { reactionCommand } from "./commands/reaction/index.js";
 import { whoamiCommand } from "./commands/whoami.js";
 
 /**
@@ -37,6 +38,7 @@ export function createProgram(version?: string): Command {
   program.addCommand(mediaCommand());
   program.addCommand(postCommand());
   program.addCommand(profileCommand());
+  program.addCommand(reactionCommand());
   program.addCommand(whoamiCommand());
 
   program.exitOverride();

--- a/packages/core/src/http/linkedin-client.ts
+++ b/packages/core/src/http/linkedin-client.ts
@@ -90,6 +90,13 @@ export class LinkedInClient {
   }
 
   /**
+   * Delete a resource via DELETE (standard LinkedIn REST.li delete pattern).
+   */
+  async delete(path: string): Promise<void> {
+    await this.sendRequest(path, { method: "DELETE" });
+  }
+
+  /**
    * Upload binary data via PUT to an absolute URL.
    *
    * Used for LinkedIn media uploads where the upload URL is provided by

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -71,3 +71,12 @@ export type {
 export { uploadDocument } from "./documents/documents-service.js";
 export { DOCUMENT_EXTENSIONS, DOCUMENT_MAX_SIZE_BYTES } from "./documents/types.js";
 export type { UploadDocumentOptions, InitializeDocumentUploadResponse } from "./documents/types.js";
+export { createReaction, listReactions, deleteReaction } from "./reactions/reactions-service.js";
+export { REACTION_TYPES } from "./reactions/types.js";
+export type {
+  ReactionType,
+  Reaction,
+  CreateReactionOptions,
+  ListReactionsOptions,
+  DeleteReactionOptions,
+} from "./reactions/types.js";

--- a/packages/core/src/reactions/reactions-service.test.ts
+++ b/packages/core/src/reactions/reactions-service.test.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, expect, it, vi } from "vitest";
+import { createReaction, listReactions, deleteReaction } from "./reactions-service.js";
+import type { LinkedInClient } from "../http/linkedin-client.js";
+
+function mockClient(overrides?: Partial<LinkedInClient>): LinkedInClient {
+  return {
+    create: vi.fn().mockResolvedValue("urn:li:reaction:123"),
+    request: vi.fn().mockResolvedValue({ elements: [] }),
+    delete: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as LinkedInClient;
+}
+
+describe("createReaction", () => {
+  it("calls client.create with correct path and body", async () => {
+    const client = mockClient();
+    await createReaction(client, { entity: "urn:li:share:abc123" });
+
+    expect(client.create).toHaveBeenCalledWith("/rest/reactions", {
+      root: "urn:li:share:abc123",
+      reactionType: "LIKE",
+    });
+  });
+
+  it("defaults reactionType to LIKE", async () => {
+    const client = mockClient();
+    await createReaction(client, { entity: "urn:li:share:abc123" });
+
+    const call = vi.mocked(client.create).mock.calls[0];
+    expect(call?.[1]).toHaveProperty("reactionType", "LIKE");
+  });
+
+  it("uses specified reactionType", async () => {
+    const client = mockClient();
+    await createReaction(client, { entity: "urn:li:share:abc123", reactionType: "PRAISE" });
+
+    expect(client.create).toHaveBeenCalledWith("/rest/reactions", {
+      root: "urn:li:share:abc123",
+      reactionType: "PRAISE",
+    });
+  });
+
+  it("returns the reaction URN from create", async () => {
+    const client = mockClient({ create: vi.fn().mockResolvedValue("urn:li:reaction:456") });
+    const urn = await createReaction(client, { entity: "urn:li:share:abc123" });
+
+    expect(urn).toBe("urn:li:reaction:456");
+  });
+});
+
+describe("listReactions", () => {
+  it("calls client.request with correct path and query parameters", async () => {
+    const client = mockClient();
+    await listReactions(client, { entity: "urn:li:share:abc123" });
+
+    expect(client.request).toHaveBeenCalledWith(expect.stringContaining("/rest/reactions?"));
+    const url = vi.mocked(client.request).mock.calls[0]?.[0] as string;
+    expect(url).toContain("q=entity");
+    expect(url).toContain("entity=urn%3Ali%3Ashare%3Aabc123");
+  });
+
+  it("includes count and start when specified", async () => {
+    const client = mockClient();
+    await listReactions(client, { entity: "urn:li:share:abc123", count: 10, start: 20 });
+
+    const url = vi.mocked(client.request).mock.calls[0]?.[0] as string;
+    expect(url).toContain("count=10");
+    expect(url).toContain("start=20");
+  });
+
+  it("maps response elements to Reaction objects", async () => {
+    const client = mockClient({
+      request: vi.fn().mockResolvedValue({
+        elements: [
+          {
+            actor: "urn:li:person:user1",
+            object: "urn:li:share:abc123",
+            reactionType: "LIKE",
+            created: { time: 1700000000000 },
+          },
+          {
+            actor: "urn:li:person:user2",
+            object: "urn:li:share:abc123",
+            reactionType: "PRAISE",
+            created: { time: 1700000001000 },
+          },
+        ],
+      }),
+    });
+
+    const reactions = await listReactions(client, { entity: "urn:li:share:abc123" });
+
+    expect(reactions).toEqual([
+      {
+        actor: "urn:li:person:user1",
+        entity: "urn:li:share:abc123",
+        reactionType: "LIKE",
+        createdAt: 1700000000000,
+      },
+      {
+        actor: "urn:li:person:user2",
+        entity: "urn:li:share:abc123",
+        reactionType: "PRAISE",
+        createdAt: 1700000001000,
+      },
+    ]);
+  });
+
+  it("returns empty array when no reactions exist", async () => {
+    const client = mockClient({ request: vi.fn().mockResolvedValue({ elements: [] }) });
+    const reactions = await listReactions(client, { entity: "urn:li:share:abc123" });
+
+    expect(reactions).toEqual([]);
+  });
+});
+
+describe("deleteReaction", () => {
+  it("calls client.delete with REST.li compound key path", async () => {
+    const client = mockClient();
+    await deleteReaction(client, {
+      actor: "urn:li:person:user1",
+      entity: "urn:li:share:abc123",
+    });
+
+    expect(client.delete).toHaveBeenCalledWith(
+      "/rest/reactions/(actor:urn%3Ali%3Aperson%3Auser1,entity:urn%3Ali%3Ashare%3Aabc123)",
+    );
+  });
+
+  it("percent-encodes URN colons in compound key", async () => {
+    const client = mockClient();
+    await deleteReaction(client, {
+      actor: "urn:li:person:abc",
+      entity: "urn:li:share:xyz",
+    });
+
+    const path = vi.mocked(client.delete).mock.calls[0]?.[0] as string;
+    expect(path).not.toContain("urn:li:");
+    expect(path).toContain("urn%3Ali%3Aperson%3Aabc");
+    expect(path).toContain("urn%3Ali%3Ashare%3Axyz");
+  });
+});

--- a/packages/core/src/reactions/reactions-service.ts
+++ b/packages/core/src/reactions/reactions-service.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { LinkedInClient } from "../http/linkedin-client.js";
+import type {
+  CreateReactionOptions,
+  DeleteReactionOptions,
+  ListReactionsOptions,
+  Reaction,
+  ReactionType,
+} from "./types.js";
+
+interface ReactionsResponse {
+  elements: Array<{
+    actor: string;
+    object: string;
+    reactionType: ReactionType;
+    created: { time: number };
+  }>;
+}
+
+/**
+ * Encode a URN for use inside a REST.li compound key by percent-encoding colons.
+ */
+function encodeUrnForKey(urn: string): string {
+  return urn.replaceAll(":", "%3A");
+}
+
+/**
+ * Create a reaction on a LinkedIn entity.
+ */
+export async function createReaction(client: LinkedInClient, options: CreateReactionOptions): Promise<string> {
+  const body = {
+    root: options.entity,
+    reactionType: options.reactionType ?? "LIKE",
+  };
+
+  return client.create("/rest/reactions", body);
+}
+
+/**
+ * List reactions on a LinkedIn entity.
+ */
+export async function listReactions(client: LinkedInClient, options: ListReactionsOptions): Promise<Reaction[]> {
+  const params = new URLSearchParams({ q: "entity", entity: options.entity });
+  if (options.count !== undefined) {
+    params.set("count", String(options.count));
+  }
+  if (options.start !== undefined) {
+    params.set("start", String(options.start));
+  }
+
+  const response = await client.request<ReactionsResponse>(`/rest/reactions?${params.toString()}`);
+  return response.elements.map((element) => ({
+    actor: element.actor,
+    entity: element.object,
+    reactionType: element.reactionType,
+    createdAt: element.created.time,
+  }));
+}
+
+/**
+ * Delete a reaction from a LinkedIn entity.
+ */
+export async function deleteReaction(client: LinkedInClient, options: DeleteReactionOptions): Promise<void> {
+  const actorKey = encodeUrnForKey(options.actor);
+  const entityKey = encodeUrnForKey(options.entity);
+  const path = `/rest/reactions/(actor:${actorKey},entity:${entityKey})`;
+
+  await client.delete(path);
+}

--- a/packages/core/src/reactions/types.ts
+++ b/packages/core/src/reactions/types.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * Supported LinkedIn reaction types.
+ */
+export type ReactionType = "LIKE" | "PRAISE" | "EMPATHY" | "INTEREST" | "APPRECIATION" | "ENTERTAINMENT";
+
+/**
+ * All valid reaction type values.
+ */
+export const REACTION_TYPES: readonly ReactionType[] = [
+  "LIKE",
+  "PRAISE",
+  "EMPATHY",
+  "INTEREST",
+  "APPRECIATION",
+  "ENTERTAINMENT",
+] as const;
+
+/**
+ * A reaction on a LinkedIn entity.
+ */
+export interface Reaction {
+  /** The person who reacted. */
+  actor: string;
+  /** The entity that was reacted to. */
+  entity: string;
+  /** The type of reaction. */
+  reactionType: ReactionType;
+  /** Timestamp when the reaction was created (milliseconds since epoch). */
+  createdAt: number;
+}
+
+/**
+ * Options for creating a reaction.
+ */
+export interface CreateReactionOptions {
+  /** The entity URN to react to (e.g. `urn:li:share:abc123`). */
+  entity: string;
+  /** The type of reaction. Defaults to `"LIKE"`. */
+  reactionType?: ReactionType | undefined;
+}
+
+/**
+ * Options for listing reactions on an entity.
+ */
+export interface ListReactionsOptions {
+  /** The entity URN to list reactions for. */
+  entity: string;
+  /** Number of results to return. */
+  count?: number | undefined;
+  /** Starting index for pagination. */
+  start?: number | undefined;
+}
+
+/**
+ * Options for deleting a reaction.
+ */
+export interface DeleteReactionOptions {
+  /** The entity URN the reaction is on. */
+  entity: string;
+  /** The actor URN whose reaction to delete. */
+  actor: string;
+}

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -28,6 +28,9 @@ vi.mock("@linkedctl/core", () => ({
   uploadImage: vi.fn(),
   uploadVideo: vi.fn(),
   uploadDocument: vi.fn(),
+  createReaction: vi.fn(),
+  listReactions: vi.fn(),
+  deleteReaction: vi.fn(),
   SUPPORTED_IMAGE_TYPES: new Map([
     [".jpg", "image/jpeg"],
     [".jpeg", "image/jpeg"],
@@ -36,6 +39,7 @@ vi.mock("@linkedctl/core", () => ({
   ]),
   DOCUMENT_EXTENSIONS: [".pdf", ".docx", ".pptx", ".doc", ".ppt"],
   DOCUMENT_MAX_SIZE_BYTES: 100 * 1024 * 1024,
+  REACTION_TYPES: ["LIKE", "PRAISE", "EMPATHY", "INTEREST", "APPRECIATION", "ENTERTAINMENT"],
   loadConfigFile: vi.fn(),
   validateConfig: vi.fn(),
   getTokenExpiry: vi.fn(),
@@ -54,6 +58,9 @@ import {
   uploadImage,
   uploadVideo,
   uploadDocument,
+  createReaction,
+  listReactions,
+  deleteReaction,
   loadConfigFile,
   validateConfig,
   getTokenExpiry,
@@ -93,6 +100,9 @@ describe("createMcpServer", () => {
     expect(toolNames).toContain("whoami");
     expect(toolNames).toContain("post_create");
     expect(toolNames).toContain("document_upload");
+    expect(toolNames).toContain("reaction_create");
+    expect(toolNames).toContain("reaction_list");
+    expect(toolNames).toContain("reaction_delete");
     expect(toolNames).toContain("auth_status");
     expect(toolNames).toContain("auth_revoke");
   });
@@ -1191,6 +1201,215 @@ describe("createMcpServer", () => {
           text: expect.stringContaining("No complete credentials for server-side revocation"),
         },
       ]);
+    });
+  });
+
+  describe("reaction_create", () => {
+    it("creates a LIKE reaction by default and returns the URN", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(createReaction).mockResolvedValue("urn:li:reaction:r123");
+
+      const result = await client.callTool({
+        name: "reaction_create",
+        arguments: { entity_urn: "urn:li:share:abc123" },
+      });
+
+      expect(resolveConfig).toHaveBeenCalledWith({
+        profile: undefined,
+        requiredScopes: ["openid", "profile", "email", "w_member_social"],
+      });
+      expect(createReaction).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          entity: "urn:li:share:abc123",
+          reactionType: "LIKE",
+        }),
+      );
+      expect(result.content).toEqual([{ type: "text", text: "Reaction created: urn:li:reaction:r123" }]);
+    });
+
+    it("creates a reaction with specified type", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(createReaction).mockResolvedValue("urn:li:reaction:r456");
+
+      const result = await client.callTool({
+        name: "reaction_create",
+        arguments: { entity_urn: "urn:li:share:abc123", reaction_type: "PRAISE" },
+      });
+
+      expect(createReaction).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          reactionType: "PRAISE",
+        }),
+      );
+      expect(result.content).toEqual([{ type: "text", text: "Reaction created: urn:li:reaction:r456" }]);
+    });
+
+    it("returns error with re-auth guidance for expired token", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "expired-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(createReaction).mockRejectedValue(new LinkedInAuthError("HTTP 401: Unauthorized"));
+
+      const result = await client.callTool({
+        name: "reaction_create",
+        arguments: { entity_urn: "urn:li:share:abc123" },
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: expect.stringContaining('Run "linkedctl auth login" to re-authenticate'),
+        },
+      ]);
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe("reaction_list", () => {
+    it("lists reactions on a post", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(listReactions).mockResolvedValue([
+        {
+          actor: "urn:li:person:user1",
+          entity: "urn:li:share:abc123",
+          reactionType: "LIKE",
+          createdAt: 1700000000000,
+        },
+      ]);
+
+      const result = await client.callTool({
+        name: "reaction_list",
+        arguments: { entity_urn: "urn:li:share:abc123" },
+      });
+
+      expect(listReactions).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          entity: "urn:li:share:abc123",
+        }),
+      );
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: expect.stringContaining("LIKE by urn:li:person:user1"),
+        },
+      ]);
+    });
+
+    it("returns message when no reactions found", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(listReactions).mockResolvedValue([]);
+
+      const result = await client.callTool({
+        name: "reaction_list",
+        arguments: { entity_urn: "urn:li:share:abc123" },
+      });
+
+      expect(result.content).toEqual([{ type: "text", text: "No reactions found" }]);
+    });
+  });
+
+  describe("reaction_delete", () => {
+    it("deletes the user's reaction from a post", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockResolvedValue("urn:li:person:abc123");
+      vi.mocked(deleteReaction).mockResolvedValue(undefined);
+
+      const result = await client.callTool({
+        name: "reaction_delete",
+        arguments: { entity_urn: "urn:li:share:abc123" },
+      });
+
+      expect(deleteReaction).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          entity: "urn:li:share:abc123",
+          actor: "urn:li:person:abc123",
+        }),
+      );
+      expect(result.content).toEqual([{ type: "text", text: "Reaction deleted" }]);
+    });
+
+    it("returns error with re-auth guidance for expired token", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "expired-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockResolvedValue("urn:li:person:abc123");
+      vi.mocked(deleteReaction).mockRejectedValue(new LinkedInAuthError("HTTP 401: Unauthorized"));
+
+      const result = await client.callTool({
+        name: "reaction_delete",
+        arguments: { entity_urn: "urn:li:share:abc123" },
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: expect.stringContaining('Run "linkedctl auth login" to re-authenticate'),
+        },
+      ]);
+      expect(result.isError).toBe(true);
     });
   });
 });

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -16,16 +16,20 @@ import {
   uploadImage,
   uploadVideo,
   uploadDocument,
+  createReaction,
+  listReactions,
+  deleteReaction,
   SUPPORTED_IMAGE_TYPES,
   DOCUMENT_EXTENSIONS,
   DOCUMENT_MAX_SIZE_BYTES,
+  REACTION_TYPES,
   loadConfigFile,
   validateConfig,
   getTokenExpiry,
   clearOAuthTokens,
   revokeAccessToken,
 } from "@linkedctl/core";
-import type { PostContent, PostLifecycleState } from "@linkedctl/core";
+import type { PostContent, PostLifecycleState, ReactionType } from "@linkedctl/core";
 
 /**
  * Create and configure the LinkedCtl MCP server with all tools registered.
@@ -436,6 +440,149 @@ export function createMcpServer(): McpServer {
       return {
         content: [{ type: "text" as const, text: lines.join("\n") }],
       };
+    },
+  );
+
+  server.registerTool(
+    "reaction_create",
+    {
+      title: "Create Reaction",
+      description:
+        "Add a reaction to a LinkedIn post. Supports LIKE (default), PRAISE, EMPATHY, INTEREST, APPRECIATION, ENTERTAINMENT.",
+      inputSchema: {
+        entity_urn: z.string().describe("Entity URN to react to (e.g. urn:li:share:abc123)"),
+        reaction_type: z
+          .enum(REACTION_TYPES as unknown as [string, ...string[]])
+          .optional()
+          .describe("Type of reaction (defaults to LIKE)"),
+        profile: z.string().optional().describe("Profile name to use from config file"),
+      },
+    },
+    async (args) => {
+      const { config } = await resolveConfig({
+        profile: args.profile,
+        requiredScopes: ["openid", "profile", "email", "w_member_social"],
+      });
+      const accessToken = config.oauth?.accessToken ?? "";
+      const apiVersion = config.apiVersion ?? "";
+      const client = new LinkedInClient({ accessToken, apiVersion });
+
+      try {
+        const reactionUrn = await createReaction(client, {
+          entity: args.entity_urn,
+          reactionType: (args.reaction_type as ReactionType | undefined) ?? "LIKE",
+        });
+
+        return {
+          content: [{ type: "text" as const, text: `Reaction created: ${reactionUrn}` }],
+        };
+      } catch (error: unknown) {
+        if (error instanceof LinkedInAuthError) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Authentication failed: ${error.message}\nRun "linkedctl auth login" to re-authenticate.`,
+              },
+            ],
+            isError: true,
+          };
+        }
+        throw error;
+      }
+    },
+  );
+
+  server.registerTool(
+    "reaction_list",
+    {
+      title: "List Reactions",
+      description: "List reactions on a LinkedIn post",
+      inputSchema: {
+        entity_urn: z.string().describe("Entity URN to list reactions for (e.g. urn:li:share:abc123)"),
+        profile: z.string().optional().describe("Profile name to use from config file"),
+      },
+    },
+    async (args) => {
+      const { config } = await resolveConfig({
+        profile: args.profile,
+        requiredScopes: ["openid", "profile", "email", "w_member_social"],
+      });
+      const accessToken = config.oauth?.accessToken ?? "";
+      const apiVersion = config.apiVersion ?? "";
+      const client = new LinkedInClient({ accessToken, apiVersion });
+
+      try {
+        const reactions = await listReactions(client, { entity: args.entity_urn });
+
+        if (reactions.length === 0) {
+          return {
+            content: [{ type: "text" as const, text: "No reactions found" }],
+          };
+        }
+
+        const lines = reactions.map((r) => `${r.reactionType} by ${r.actor} at ${new Date(r.createdAt).toISOString()}`);
+        return {
+          content: [{ type: "text" as const, text: lines.join("\n") }],
+        };
+      } catch (error: unknown) {
+        if (error instanceof LinkedInAuthError) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Authentication failed: ${error.message}\nRun "linkedctl auth login" to re-authenticate.`,
+              },
+            ],
+            isError: true,
+          };
+        }
+        throw error;
+      }
+    },
+  );
+
+  server.registerTool(
+    "reaction_delete",
+    {
+      title: "Delete Reaction",
+      description: "Remove your reaction from a LinkedIn post",
+      inputSchema: {
+        entity_urn: z.string().describe("Entity URN to remove reaction from (e.g. urn:li:share:abc123)"),
+        profile: z.string().optional().describe("Profile name to use from config file"),
+      },
+    },
+    async (args) => {
+      const { config } = await resolveConfig({
+        profile: args.profile,
+        requiredScopes: ["openid", "profile", "email", "w_member_social"],
+      });
+      const accessToken = config.oauth?.accessToken ?? "";
+      const apiVersion = config.apiVersion ?? "";
+      const client = new LinkedInClient({ accessToken, apiVersion });
+
+      const actorUrn = await getCurrentPersonUrn(client);
+
+      try {
+        await deleteReaction(client, { entity: args.entity_urn, actor: actorUrn });
+
+        return {
+          content: [{ type: "text" as const, text: "Reaction deleted" }],
+        };
+      } catch (error: unknown) {
+        if (error instanceof LinkedInAuthError) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Authentication failed: ${error.message}\nRun "linkedctl auth login" to re-authenticate.`,
+              },
+            ],
+            isError: true,
+          };
+        }
+        throw error;
+      }
     },
   );
 


### PR DESCRIPTION
## Summary

- Add `linkedctl reaction create <urn>` to create a reaction (LIKE default, all 6 types supported)
- Add `linkedctl reaction list <urn>` to list reactions on a post
- Add `linkedctl reaction delete <urn>` to remove the user's reaction
- Add MCP tools: `reaction_create`, `reaction_list`, `reaction_delete`
- Add `delete()` method to `LinkedInClient` for REST.li DELETE operations

## Implementation

**Core (`@linkedctl/core`)**:
- `reactions/types.ts`: `ReactionType`, `Reaction`, `REACTION_TYPES`, option interfaces
- `reactions/reactions-service.ts`: `createReaction`, `listReactions`, `deleteReaction` with REST.li compound key encoding for delete
- `http/linkedin-client.ts`: Added `delete()` method

**CLI (`@linkedctl/cli`)**:
- `commands/reaction/`: `create`, `list`, `delete` subcommands with format output support
- Registered as `linkedctl reaction` in program

**MCP (`@linkedctl/mcp`)**:
- `reaction_create`, `reaction_list`, `reaction_delete` tools with auth error handling

## Test plan

- [x] Core: reactions service unit tests (create/list/delete, URN encoding, response mapping)
- [x] CLI: command tests for all 3 subcommands (args, options, profile, errors)
- [x] MCP: tool tests for all 3 reaction tools (CRUD, auth errors)
- [x] All existing tests pass (502 total)
- [x] Build, typecheck, format, lint all pass

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)