### PR TITLE
(feat) add organization lookup

### DIFF
--- a/packages/cli/src/commands/org/followers.test.ts
+++ b/packages/cli/src/commands/org/followers.test.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { createProgram } from "../../program.js";
+
+vi.mock("@linkedctl/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@linkedctl/core")>();
+  return {
+    ...actual,
+    resolveConfig: vi.fn().mockResolvedValue({
+      config: {
+        oauth: { accessToken: "test-token" },
+        apiVersion: "202601",
+      },
+      warnings: [],
+    }),
+    getOrganizationFollowerCount: vi.fn().mockResolvedValue(5000),
+  };
+});
+
+const coreMock = await import("@linkedctl/core");
+
+describe("org followers", () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches follower count for an organization", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "org", "followers", "12345"]);
+
+    expect(coreMock.getOrganizationFollowerCount).toHaveBeenCalledWith(expect.anything(), "urn:li:organization:12345");
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+
+  it("outputs JSON when --format json is specified", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "org", "followers", "12345", "--format", "json"]);
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(output) as Record<string, unknown>;
+    expect(parsed).toHaveProperty("organization", "urn:li:organization:12345");
+    expect(parsed).toHaveProperty("followerCount", 5000);
+  });
+
+  it("resolves config with profile from global options", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "--profile", "work", "org", "followers", "12345"]);
+
+    expect(coreMock.resolveConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profile: "work",
+      }),
+    );
+  });
+
+  it("wraps API errors with actionable message", async () => {
+    const { LinkedInApiError } = await import("@linkedctl/core");
+    vi.mocked(coreMock.getOrganizationFollowerCount).mockRejectedValueOnce(new LinkedInApiError("Not Found", 404));
+
+    const program = createProgram();
+    program.exitOverride();
+
+    await expect(program.parseAsync(["node", "linkedctl", "org", "followers", "99999"])).rejects.toThrow(
+      /Failed to get follower count/,
+    );
+  });
+});

--- a/packages/cli/src/commands/org/followers.ts
+++ b/packages/cli/src/commands/org/followers.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { Command, Option } from "commander";
+import { resolveConfig, LinkedInClient, getOrganizationFollowerCount, LinkedInApiError } from "@linkedctl/core";
+import type { OutputFormat } from "../../output/index.js";
+import { resolveFormat, formatOutput } from "../../output/index.js";
+
+export function followersCommand(): Command {
+  const cmd = new Command("followers");
+  cmd.description("Get the follower count for an organization");
+  cmd.argument("<id>", "organization ID (numeric, e.g. 12345)");
+  cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
+
+  cmd.action(async (id: string, opts: Record<string, unknown>, actionCmd: Command) => {
+    const globals = actionCmd.optsWithGlobals<{ profile?: string | undefined; json?: boolean | undefined }>();
+
+    const { config } = await resolveConfig({
+      profile: globals.profile,
+      requiredScopes: ["openid", "profile", "email", "w_member_social"],
+    });
+    const accessToken = config.oauth?.accessToken ?? "";
+    const apiVersion = config.apiVersion ?? "";
+    const client = new LinkedInClient({ accessToken, apiVersion });
+
+    try {
+      const organizationUrn = `urn:li:organization:${id}`;
+      const followerCount = await getOrganizationFollowerCount(client, organizationUrn);
+
+      const format = resolveFormat(opts["format"] as OutputFormat | undefined, process.stdout, globals.json === true);
+      const output = formatOutput({ organization: organizationUrn, followerCount }, format);
+      console.log(output);
+    } catch (error) {
+      if (error instanceof LinkedInApiError) {
+        throw new Error(`Failed to get follower count: ${error.message}`);
+      }
+      throw error;
+    }
+  });
+
+  return cmd;
+}

--- a/packages/cli/src/commands/org/get.test.ts
+++ b/packages/cli/src/commands/org/get.test.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { createProgram } from "../../program.js";
+
+vi.mock("@linkedctl/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@linkedctl/core")>();
+  return {
+    ...actual,
+    resolveConfig: vi.fn().mockResolvedValue({
+      config: {
+        oauth: { accessToken: "test-token" },
+        apiVersion: "202601",
+      },
+      warnings: [],
+    }),
+    getOrganization: vi.fn().mockResolvedValue({
+      id: 12345,
+      localizedName: "Acme Corp",
+      localizedDescription: "A great company",
+      vanityName: "acme-corp",
+    }),
+  };
+});
+
+const coreMock = await import("@linkedctl/core");
+
+describe("org get", () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches an organization by ID", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "org", "get", "12345"]);
+
+    expect(coreMock.getOrganization).toHaveBeenCalledWith(expect.anything(), "12345");
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+
+  it("outputs JSON when --format json is specified", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "org", "get", "12345", "--format", "json"]);
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(output) as Record<string, unknown>;
+    expect(parsed).toHaveProperty("id", 12345);
+    expect(parsed).toHaveProperty("localizedName", "Acme Corp");
+  });
+
+  it("resolves config with profile from global options", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "--profile", "work", "org", "get", "12345"]);
+
+    expect(coreMock.resolveConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profile: "work",
+      }),
+    );
+  });
+
+  it("wraps API errors with actionable message", async () => {
+    const { LinkedInApiError } = await import("@linkedctl/core");
+    vi.mocked(coreMock.getOrganization).mockRejectedValueOnce(new LinkedInApiError("Not Found", 404));
+
+    const program = createProgram();
+    program.exitOverride();
+
+    await expect(program.parseAsync(["node", "linkedctl", "org", "get", "99999"])).rejects.toThrow(
+      /Failed to get organization/,
+    );
+  });
+});

--- a/packages/cli/src/commands/org/get.ts
+++ b/packages/cli/src/commands/org/get.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { Command, Option } from "commander";
+import { resolveConfig, LinkedInClient, getOrganization, LinkedInApiError } from "@linkedctl/core";
+import type { OutputFormat } from "../../output/index.js";
+import { resolveFormat, formatOutput } from "../../output/index.js";
+
+export function getCommand(): Command {
+  const cmd = new Command("get");
+  cmd.description("Get organization details by ID");
+  cmd.argument("<id>", "organization ID (numeric, e.g. 12345)");
+  cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
+
+  cmd.action(async (id: string, opts: Record<string, unknown>, actionCmd: Command) => {
+    const globals = actionCmd.optsWithGlobals<{ profile?: string | undefined; json?: boolean | undefined }>();
+
+    const { config } = await resolveConfig({
+      profile: globals.profile,
+      requiredScopes: ["openid", "profile", "email", "w_member_social"],
+    });
+    const accessToken = config.oauth?.accessToken ?? "";
+    const apiVersion = config.apiVersion ?? "";
+    const client = new LinkedInClient({ accessToken, apiVersion });
+
+    try {
+      const org = await getOrganization(client, id);
+
+      const format = resolveFormat(opts["format"] as OutputFormat | undefined, process.stdout, globals.json === true);
+      const output = formatOutput(org, format);
+      console.log(output);
+    } catch (error) {
+      if (error instanceof LinkedInApiError) {
+        throw new Error(`Failed to get organization: ${error.message}`);
+      }
+      throw error;
+    }
+  });
+
+  return cmd;
+}

--- a/packages/cli/src/commands/org/index.ts
+++ b/packages/cli/src/commands/org/index.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { Command } from "commander";
+import { getCommand } from "./get.js";
+import { listCommand } from "./list.js";
+import { followersCommand } from "./followers.js";
+
+export function orgCommand(): Command {
+  const cmd = new Command("org");
+  cmd.description("Manage LinkedIn organizations");
+
+  cmd.addHelpText(
+    "after",
+    `
+Examples:
+  linkedctl org list
+  linkedctl org get 12345
+  linkedctl org followers 12345`,
+  );
+
+  cmd.addCommand(listCommand());
+  cmd.addCommand(getCommand());
+  cmd.addCommand(followersCommand());
+
+  return cmd;
+}

--- a/packages/cli/src/commands/org/list.test.ts
+++ b/packages/cli/src/commands/org/list.test.ts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { createProgram } from "../../program.js";
+
+vi.mock("@linkedctl/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@linkedctl/core")>();
+  return {
+    ...actual,
+    resolveConfig: vi.fn().mockResolvedValue({
+      config: {
+        oauth: { accessToken: "test-token" },
+        apiVersion: "202601",
+      },
+      warnings: [],
+    }),
+    listOrganizations: vi.fn().mockResolvedValue({
+      elements: [
+        { organization: "urn:li:organization:123", role: "ADMINISTRATOR", state: "APPROVED" },
+        { organization: "urn:li:organization:456", role: "ADMINISTRATOR", state: "APPROVED" },
+      ],
+      paging: { count: 10, start: 0, total: 2 },
+    }),
+  };
+});
+
+const coreMock = await import("@linkedctl/core");
+
+describe("org list", () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("lists administered organizations", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "org", "list"]);
+
+    expect(coreMock.listOrganizations).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        count: 10,
+        start: 0,
+      }),
+    );
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+
+  it("passes custom count and start options", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "org", "list", "--count", "5", "--start", "10"]);
+
+    expect(coreMock.listOrganizations).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        count: 5,
+        start: 10,
+      }),
+    );
+  });
+
+  it("outputs JSON when --format json is specified", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "org", "list", "--format", "json"]);
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(output) as Record<string, unknown>;
+    expect(parsed).toHaveProperty("elements");
+    expect(parsed).toHaveProperty("paging");
+  });
+
+  it("shows message when no organizations found in table mode", async () => {
+    vi.mocked(coreMock.listOrganizations).mockResolvedValueOnce({
+      elements: [],
+      paging: { count: 10, start: 0 },
+    });
+
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "org", "list", "--format", "table"]);
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(output).toBe("No organizations found.");
+  });
+
+  it("wraps API errors with actionable message", async () => {
+    const { LinkedInApiError } = await import("@linkedctl/core");
+    vi.mocked(coreMock.listOrganizations).mockRejectedValueOnce(new LinkedInApiError("Forbidden", 403));
+
+    const program = createProgram();
+    program.exitOverride();
+
+    await expect(program.parseAsync(["node", "linkedctl", "org", "list"])).rejects.toThrow(
+      /Failed to list organizations/,
+    );
+  });
+});

--- a/packages/cli/src/commands/org/list.ts
+++ b/packages/cli/src/commands/org/list.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { Command, Option } from "commander";
+import { resolveConfig, LinkedInClient, listOrganizations, LinkedInApiError } from "@linkedctl/core";
+import type { OutputFormat } from "../../output/index.js";
+import { resolveFormat, formatOutput } from "../../output/index.js";
+
+export function listCommand(): Command {
+  const cmd = new Command("list");
+  cmd.description("List organizations you administer");
+  cmd.option("--count <count>", "number of results to return (default 10, max 100)", "10");
+  cmd.option("--start <start>", "starting index for pagination (default 0)", "0");
+  cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
+
+  cmd.action(async (opts: Record<string, unknown>, actionCmd: Command) => {
+    const globals = actionCmd.optsWithGlobals<{ profile?: string | undefined; json?: boolean | undefined }>();
+
+    const { config } = await resolveConfig({
+      profile: globals.profile,
+      requiredScopes: ["openid", "profile", "email", "w_member_social"],
+    });
+    const accessToken = config.oauth?.accessToken ?? "";
+    const apiVersion = config.apiVersion ?? "";
+    const client = new LinkedInClient({ accessToken, apiVersion });
+
+    try {
+      const count = parseInt(opts["count"] as string, 10);
+      const start = parseInt(opts["start"] as string, 10);
+
+      const response = await listOrganizations(client, { count, start });
+
+      const format = resolveFormat(opts["format"] as OutputFormat | undefined, process.stdout, globals.json === true);
+
+      if (format === "json") {
+        console.log(formatOutput(response, format));
+      } else {
+        if (response.elements.length === 0) {
+          console.log("No organizations found.");
+          return;
+        }
+        const rows = response.elements.map((acl) => ({
+          organization: acl.organization,
+          role: acl.role,
+          state: acl.state,
+        }));
+        console.log(formatOutput(rows, format));
+      }
+    } catch (error) {
+      if (error instanceof LinkedInApiError) {
+        throw new Error(`Failed to list organizations: ${error.message}`);
+      }
+      throw error;
+    }
+  });
+
+  return cmd;
+}

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -6,6 +6,7 @@ import { authCommand } from "./commands/auth/index.js";
 import { commentCommand } from "./commands/comment/index.js";
 import { completionCommand } from "./commands/completion.js";
 import { mediaCommand } from "./commands/media/index.js";
+import { orgCommand } from "./commands/org/index.js";
 import { postCommand } from "./commands/post/index.js";
 import { profileCommand } from "./commands/profile/index.js";
 import { reactionCommand } from "./commands/reaction/index.js";
@@ -38,6 +39,7 @@ export function createProgram(version?: string): Command {
   program.addCommand(commentCommand());
   program.addCommand(completionCommand(program));
   program.addCommand(mediaCommand());
+  program.addCommand(orgCommand());
   program.addCommand(postCommand());
   program.addCommand(profileCommand());
   program.addCommand(reactionCommand());

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -81,6 +81,20 @@ export type {
 export { uploadDocument } from "./documents/documents-service.js";
 export { DOCUMENT_EXTENSIONS, DOCUMENT_MAX_SIZE_BYTES } from "./documents/types.js";
 export type { UploadDocumentOptions, InitializeDocumentUploadResponse } from "./documents/types.js";
+export {
+  listOrganizations,
+  getOrganization,
+  getOrganizationFollowerCount,
+} from "./organizations/organizations-service.js";
+export type { ListOrganizationsOptions } from "./organizations/organizations-service.js";
+export type {
+  OrganizationRole,
+  OrganizationRoleAssigneeState,
+  OrganizationAcl,
+  OrganizationAclListResponse,
+  OrganizationData,
+  OrganizationFollowerCountResponse,
+} from "./organizations/types.js";
 export { createReaction, listReactions, deleteReaction } from "./reactions/reactions-service.js";
 export { REACTION_TYPES } from "./reactions/types.js";
 export type {

--- a/packages/core/src/organizations/organizations-service.test.ts
+++ b/packages/core/src/organizations/organizations-service.test.ts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, expect, it, vi } from "vitest";
+import { listOrganizations, getOrganization, getOrganizationFollowerCount } from "./organizations-service.js";
+import type { LinkedInClient } from "../http/linkedin-client.js";
+import type { OrganizationAclListResponse, OrganizationData, OrganizationFollowerCountResponse } from "./types.js";
+
+function mockClient(): LinkedInClient {
+  return {
+    request: vi.fn(),
+  } as unknown as LinkedInClient;
+}
+
+describe("listOrganizations", () => {
+  it("calls client.request with default pagination", async () => {
+    const response: OrganizationAclListResponse = {
+      elements: [{ organization: "urn:li:organization:123", role: "ADMINISTRATOR", state: "APPROVED" }],
+      paging: { count: 10, start: 0, total: 1 },
+    };
+    const client = mockClient();
+    vi.mocked(client.request).mockResolvedValue(response);
+
+    const result = await listOrganizations(client);
+
+    expect(client.request).toHaveBeenCalledWith(
+      "/rest/organizationAcls?q=roleAssignee&role=ADMINISTRATOR&state=APPROVED&count=10&start=0",
+    );
+    expect(result).toEqual(response);
+  });
+
+  it("uses custom count and start values", async () => {
+    const response: OrganizationAclListResponse = {
+      elements: [],
+      paging: { count: 5, start: 10 },
+    };
+    const client = mockClient();
+    vi.mocked(client.request).mockResolvedValue(response);
+
+    await listOrganizations(client, { count: 5, start: 10 });
+
+    expect(client.request).toHaveBeenCalledWith(
+      "/rest/organizationAcls?q=roleAssignee&role=ADMINISTRATOR&state=APPROVED&count=5&start=10",
+    );
+  });
+
+  it("defaults to count=10 and start=0 when options are undefined", async () => {
+    const response: OrganizationAclListResponse = {
+      elements: [],
+      paging: { count: 10, start: 0 },
+    };
+    const client = mockClient();
+    vi.mocked(client.request).mockResolvedValue(response);
+
+    await listOrganizations(client, undefined);
+
+    expect(client.request).toHaveBeenCalledWith(
+      "/rest/organizationAcls?q=roleAssignee&role=ADMINISTRATOR&state=APPROVED&count=10&start=0",
+    );
+  });
+});
+
+describe("getOrganization", () => {
+  it("calls client.request with organization ID", async () => {
+    const orgData: OrganizationData = {
+      id: 12345,
+      localizedName: "Acme Corp",
+      localizedDescription: "A great company",
+      vanityName: "acme-corp",
+    };
+    const client = mockClient();
+    vi.mocked(client.request).mockResolvedValue(orgData);
+
+    const result = await getOrganization(client, "12345");
+
+    expect(client.request).toHaveBeenCalledWith("/rest/organizations/12345");
+    expect(result).toEqual(orgData);
+  });
+
+  it("URL-encodes the organization ID", async () => {
+    const orgData: OrganizationData = {
+      id: 123,
+      localizedName: "Test Org",
+    };
+    const client = mockClient();
+    vi.mocked(client.request).mockResolvedValue(orgData);
+
+    await getOrganization(client, "123");
+
+    expect(client.request).toHaveBeenCalledWith("/rest/organizations/123");
+  });
+});
+
+describe("getOrganizationFollowerCount", () => {
+  it("calls client.request with encoded URN and edgeType", async () => {
+    const response: OrganizationFollowerCountResponse = { firstDegreeSize: 5000 };
+    const client = mockClient();
+    vi.mocked(client.request).mockResolvedValue(response);
+
+    const count = await getOrganizationFollowerCount(client, "urn:li:organization:12345");
+
+    expect(client.request).toHaveBeenCalledWith(
+      "/rest/networkSizes/urn%3Ali%3Aorganization%3A12345?edgeType=COMPANY_FOLLOWED_BY_MEMBER",
+    );
+    expect(count).toBe(5000);
+  });
+
+  it("returns 0 when organization has no followers", async () => {
+    const response: OrganizationFollowerCountResponse = { firstDegreeSize: 0 };
+    const client = mockClient();
+    vi.mocked(client.request).mockResolvedValue(response);
+
+    const count = await getOrganizationFollowerCount(client, "urn:li:organization:99999");
+
+    expect(count).toBe(0);
+  });
+});

--- a/packages/core/src/organizations/organizations-service.ts
+++ b/packages/core/src/organizations/organizations-service.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { LinkedInClient } from "../http/linkedin-client.js";
+import type { OrganizationAclListResponse, OrganizationData, OrganizationFollowerCountResponse } from "./types.js";
+
+/**
+ * Options for listing organizations administered by the current user.
+ */
+export interface ListOrganizationsOptions {
+  /** Number of results to return (default 10, max 100). */
+  count?: number | undefined;
+  /** Starting index for pagination (default 0). */
+  start?: number | undefined;
+}
+
+/**
+ * List organizations the authenticated member administers.
+ */
+export async function listOrganizations(
+  client: LinkedInClient,
+  options?: ListOrganizationsOptions,
+): Promise<OrganizationAclListResponse> {
+  const count = options?.count ?? 10;
+  const start = options?.start ?? 0;
+  return client.request<OrganizationAclListResponse>(
+    `/rest/organizationAcls?q=roleAssignee&role=ADMINISTRATOR&state=APPROVED&count=${String(count)}&start=${String(start)}`,
+  );
+}
+
+/**
+ * Fetch a single organization by ID.
+ */
+export async function getOrganization(client: LinkedInClient, organizationId: string): Promise<OrganizationData> {
+  return client.request<OrganizationData>(`/rest/organizations/${encodeURIComponent(organizationId)}`);
+}
+
+/**
+ * Get the follower count for an organization.
+ */
+export async function getOrganizationFollowerCount(client: LinkedInClient, organizationUrn: string): Promise<number> {
+  const encodedUrn = encodeURIComponent(organizationUrn);
+  const response = await client.request<OrganizationFollowerCountResponse>(
+    `/rest/networkSizes/${encodedUrn}?edgeType=COMPANY_FOLLOWED_BY_MEMBER`,
+  );
+  return response.firstDegreeSize;
+}

--- a/packages/core/src/organizations/types.ts
+++ b/packages/core/src/organizations/types.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * The role an authenticated member holds in an organization.
+ */
+export type OrganizationRole = "ADMINISTRATOR";
+
+/**
+ * The state of a role assignment.
+ */
+export type OrganizationRoleAssigneeState = "APPROVED";
+
+/**
+ * An organization role assignment (ACL entry) as returned by the API.
+ */
+export interface OrganizationAcl {
+  /** Organization URN (e.g. `urn:li:organization:123`). */
+  organization: string;
+  /** Role held by the member. */
+  role: OrganizationRole;
+  /** State of the role assignment. */
+  state: OrganizationRoleAssigneeState;
+}
+
+/**
+ * Paginated response from the organizationAcls endpoint.
+ */
+export interface OrganizationAclListResponse {
+  /** Array of organization ACL entries. */
+  elements: OrganizationAcl[];
+  /** Paging metadata. */
+  paging: {
+    /** Number of results returned. */
+    count: number;
+    /** Starting index. */
+    start: number;
+    /** Total number of results available. */
+    total?: number | undefined;
+  };
+}
+
+/**
+ * An organization as returned by the LinkedIn API.
+ */
+export interface OrganizationData {
+  /** Organization ID (numeric). */
+  id: number;
+  /** Localized organization name. */
+  localizedName: string;
+  /** Localized description. */
+  localizedDescription?: string | undefined;
+  /** Localized website URL. */
+  localizedWebsite?: string | undefined;
+  /** Vanity name (URL slug). */
+  vanityName?: string | undefined;
+  /** Organization logo URN. */
+  logoV2?: { original: string } | undefined;
+}
+
+/**
+ * Follower count response from the networkSizes endpoint.
+ */
+export interface OrganizationFollowerCountResponse {
+  /** First-degree network size (follower count). */
+  firstDegreeSize: number;
+}

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -39,6 +39,9 @@ vi.mock("@linkedctl/core", () => ({
   createReaction: vi.fn(),
   listReactions: vi.fn(),
   deleteReaction: vi.fn(),
+  listOrganizations: vi.fn(),
+  getOrganization: vi.fn(),
+  getOrganizationFollowerCount: vi.fn(),
   SUPPORTED_IMAGE_TYPES: new Map([
     [".jpg", "image/jpeg"],
     [".jpeg", "image/jpeg"],
@@ -77,6 +80,9 @@ import {
   createReaction,
   listReactions,
   deleteReaction,
+  listOrganizations,
+  getOrganization,
+  getOrganizationFollowerCount,
   loadConfigFile,
   validateConfig,
   getTokenExpiry,
@@ -129,6 +135,9 @@ describe("createMcpServer", () => {
     expect(toolNames).toContain("post_delete");
     expect(toolNames).toContain("auth_status");
     expect(toolNames).toContain("auth_revoke");
+    expect(toolNames).toContain("org_list");
+    expect(toolNames).toContain("org_get");
+    expect(toolNames).toContain("org_followers");
   });
 
   describe("whoami", () => {
@@ -2111,6 +2120,89 @@ describe("createMcpServer", () => {
 
       expect(result.isError).toBe(true);
       expect(result.content).toEqual([{ type: "text", text: "Server error" }]);
+    });
+  });
+
+  describe("org_list", () => {
+    it("lists administered organizations", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: { oauth: { accessToken: "tok" }, apiVersion: "202601" },
+        warnings: [],
+      } as never);
+
+      const mockResponse = {
+        elements: [{ organization: "urn:li:organization:123", role: "ADMINISTRATOR", state: "APPROVED" }],
+        paging: { count: 10, start: 0, total: 1 },
+      };
+      vi.mocked(listOrganizations).mockResolvedValue(mockResponse);
+
+      const result = await client.callTool({ name: "org_list", arguments: {} });
+
+      expect(listOrganizations).toHaveBeenCalledWith(expect.anything(), {
+        count: undefined,
+        start: undefined,
+      });
+      const text = (result.content as Array<{ type: string; text: string }>)[0]?.text ?? "";
+      const parsed = JSON.parse(text) as Record<string, unknown>;
+      expect(parsed).toHaveProperty("elements");
+    });
+
+    it("passes count and start parameters", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: { oauth: { accessToken: "tok" }, apiVersion: "202601" },
+        warnings: [],
+      } as never);
+      vi.mocked(listOrganizations).mockResolvedValue({
+        elements: [],
+        paging: { count: 5, start: 10 },
+      });
+
+      await client.callTool({ name: "org_list", arguments: { count: 5, start: 10 } });
+
+      expect(listOrganizations).toHaveBeenCalledWith(expect.anything(), { count: 5, start: 10 });
+    });
+  });
+
+  describe("org_get", () => {
+    it("fetches organization details by ID", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: { oauth: { accessToken: "tok" }, apiVersion: "202601" },
+        warnings: [],
+      } as never);
+
+      const mockOrg = {
+        id: 12345,
+        localizedName: "Acme Corp",
+        localizedDescription: "A great company",
+        vanityName: "acme-corp",
+      };
+      vi.mocked(getOrganization).mockResolvedValue(mockOrg);
+
+      const result = await client.callTool({ name: "org_get", arguments: { id: "12345" } });
+
+      expect(getOrganization).toHaveBeenCalledWith(expect.anything(), "12345");
+      const text = (result.content as Array<{ type: string; text: string }>)[0]?.text ?? "";
+      const parsed = JSON.parse(text) as Record<string, unknown>;
+      expect(parsed).toHaveProperty("localizedName", "Acme Corp");
+    });
+  });
+
+  describe("org_followers", () => {
+    it("returns follower count for an organization", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: { oauth: { accessToken: "tok" }, apiVersion: "202601" },
+        warnings: [],
+      } as never);
+
+      vi.mocked(getOrganizationFollowerCount).mockResolvedValue(5000);
+
+      const result = await client.callTool({ name: "org_followers", arguments: { id: "12345" } });
+
+      expect(getOrganizationFollowerCount).toHaveBeenCalledWith(expect.anything(), "urn:li:organization:12345");
+      const text = (result.content as Array<{ type: string; text: string }>)[0]?.text ?? "";
+      const parsed = JSON.parse(text) as Record<string, unknown>;
+      expect(parsed).toHaveProperty("organization", "urn:li:organization:12345");
+      expect(parsed).toHaveProperty("followerCount", 5000);
     });
   });
 });

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -27,6 +27,9 @@ import {
   createReaction,
   listReactions,
   deleteReaction,
+  listOrganizations,
+  getOrganization,
+  getOrganizationFollowerCount,
   SUPPORTED_IMAGE_TYPES,
   DOCUMENT_EXTENSIONS,
   DOCUMENT_MAX_SIZE_BYTES,
@@ -866,6 +869,97 @@ export function createMcpServer(): McpServer {
 
       return {
         content: [{ type: "text" as const, text: `Post deleted: ${args.urn}` }],
+      };
+    },
+  );
+
+  server.registerTool(
+    "org_list",
+    {
+      title: "List Organizations",
+      description: "List LinkedIn organizations the authenticated user administers",
+      inputSchema: {
+        count: z.number().optional().describe("Number of results to return (default 10, max 100)"),
+        start: z.number().optional().describe("Starting index for pagination (default 0)"),
+        profile: z.string().optional().describe("Profile name to use from config file"),
+      },
+    },
+    async (args) => {
+      const { config } = await resolveConfig({
+        profile: args.profile,
+        requiredScopes: ["openid", "profile", "email", "w_member_social"],
+      });
+      const accessToken = config.oauth?.accessToken ?? "";
+      const apiVersion = config.apiVersion ?? "";
+      const client = new LinkedInClient({ accessToken, apiVersion });
+
+      const response = await listOrganizations(client, {
+        count: args.count,
+        start: args.start,
+      });
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(response, null, 2) }],
+      };
+    },
+  );
+
+  server.registerTool(
+    "org_get",
+    {
+      title: "Get Organization",
+      description: "Fetch a single LinkedIn organization by ID",
+      inputSchema: {
+        id: z.string().describe("Organization ID (numeric, e.g. 12345)"),
+        profile: z.string().optional().describe("Profile name to use from config file"),
+      },
+    },
+    async (args) => {
+      const { config } = await resolveConfig({
+        profile: args.profile,
+        requiredScopes: ["openid", "profile", "email", "w_member_social"],
+      });
+      const accessToken = config.oauth?.accessToken ?? "";
+      const apiVersion = config.apiVersion ?? "";
+      const client = new LinkedInClient({ accessToken, apiVersion });
+
+      const org = await getOrganization(client, args.id);
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(org, null, 2) }],
+      };
+    },
+  );
+
+  server.registerTool(
+    "org_followers",
+    {
+      title: "Get Organization Followers",
+      description: "Get the follower count for a LinkedIn organization",
+      inputSchema: {
+        id: z.string().describe("Organization ID (numeric, e.g. 12345)"),
+        profile: z.string().optional().describe("Profile name to use from config file"),
+      },
+    },
+    async (args) => {
+      const { config } = await resolveConfig({
+        profile: args.profile,
+        requiredScopes: ["openid", "profile", "email", "w_member_social"],
+      });
+      const accessToken = config.oauth?.accessToken ?? "";
+      const apiVersion = config.apiVersion ?? "";
+      const client = new LinkedInClient({ accessToken, apiVersion });
+
+      const organizationUrn = `urn:li:organization:${args.id}`;
+      const followerCount = await getOrganizationFollowerCount(client, organizationUrn);
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({ organization: organizationUrn, followerCount }, null, 2),
+          },
+        ],
       };
     },
   );


### PR DESCRIPTION
## Summary

- Add organization lookup capabilities across all three packages (core, CLI, MCP)
- `linkedctl org list` — lists organizations the authenticated user administers via `organizationAcls` API
- `linkedctl org get <id>` — fetches organization details by numeric ID
- `linkedctl org followers <id>` — returns follower count via `networkSizes` API
- MCP tools: `org_list`, `org_get`, `org_followers`

## Test plan

- [x] Core service unit tests (7 tests): listOrganizations, getOrganization, getOrganizationFollowerCount
- [x] CLI command tests (13 tests): org list, org get, org followers — including JSON output, pagination, profile, and error handling
- [x] MCP tool tests (4 tests): org_list, org_get, org_followers with parameter passing
- [x] Build, typecheck, lint, format check all pass
- [x] All 613 tests pass across all packages

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)