### PR TITLE
(feat) media upload as organization

### DIFF
--- a/packages/cli/src/commands/media/upload-document.test.ts
+++ b/packages/cli/src/commands/media/upload-document.test.ts
@@ -20,6 +20,7 @@ vi.mock("@linkedctl/core", async (importOriginal) => {
       warnings: [],
     }),
     getCurrentPersonUrn: vi.fn().mockResolvedValue("urn:li:person:person123"),
+    getOrganization: vi.fn().mockResolvedValue({ id: 12345, localizedName: "Test Org" }),
     uploadDocument: vi.fn().mockResolvedValue("urn:li:document:D111222333"),
   };
 });
@@ -42,6 +43,7 @@ describe("media upload-document", () => {
     });
     vi.mocked(coreMock.uploadDocument).mockResolvedValue("urn:li:document:D111222333");
     vi.mocked(coreMock.getCurrentPersonUrn).mockResolvedValue("urn:li:person:person123");
+    vi.mocked(coreMock.getOrganization).mockResolvedValue({ id: 12345, localizedName: "Test Org" });
     tempDir = await mkdtemp(join(tmpdir(), "linkedctl-test-"));
   });
 
@@ -193,5 +195,38 @@ describe("media upload-document", () => {
     await program.parseAsync(["node", "linkedctl", "media", "upload-document", filePath]);
 
     expect(coreMock.uploadDocument).toHaveBeenCalled();
+  });
+
+  it("uploads as organization when --as-org is specified", async () => {
+    const filePath = join(tempDir, "deck.pdf");
+    await writeFile(filePath, "fake-pdf");
+
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "media", "upload-document", filePath, "--as-org", "12345"]);
+
+    expect(coreMock.getOrganization).toHaveBeenCalledWith(expect.anything(), "12345");
+    expect(coreMock.uploadDocument).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        owner: "urn:li:organization:12345",
+      }),
+    );
+    expect(coreMock.getCurrentPersonUrn).not.toHaveBeenCalled();
+  });
+
+  it("uses person URN when --as-org is not specified", async () => {
+    const filePath = join(tempDir, "deck.pdf");
+    await writeFile(filePath, "fake-pdf");
+
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "media", "upload-document", filePath]);
+
+    expect(coreMock.getOrganization).not.toHaveBeenCalled();
+    expect(coreMock.uploadDocument).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        owner: "urn:li:person:person123",
+      }),
+    );
   });
 });

--- a/packages/cli/src/commands/media/upload-document.ts
+++ b/packages/cli/src/commands/media/upload-document.ts
@@ -9,6 +9,7 @@ import {
   resolveConfig,
   LinkedInClient,
   getCurrentPersonUrn,
+  getOrganization,
   uploadDocument,
   LinkedInApiError,
   DOCUMENT_EXTENSIONS,
@@ -19,6 +20,7 @@ import type { OutputFormat } from "../../output/index.js";
 
 interface UploadDocumentOpts {
   format?: string | undefined;
+  asOrg?: string | undefined;
 }
 
 export function uploadDocumentCommand(): Command {
@@ -26,13 +28,15 @@ export function uploadDocumentCommand(): Command {
   cmd.description("Upload a document to LinkedIn (PDF, DOCX, PPTX, DOC, PPT; max 100 MB)");
   cmd.argument("<file>", "path to the document file");
   cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
+  cmd.option("--as-org <id>", "upload as an organization (specify org ID)");
 
   cmd.addHelpText(
     "after",
     `
 Examples:
   linkedctl media upload-document deck.pdf
-  linkedctl media upload-document proposal.docx --format json`,
+  linkedctl media upload-document proposal.docx --format json
+  linkedctl media upload-document report.pdf --as-org 12345`,
   );
 
   cmd.action(async (file: string, opts: UploadDocumentOpts, actionCmd: Command) => {
@@ -64,7 +68,13 @@ export async function uploadDocumentAction(file: string, opts: UploadDocumentOpt
   const apiVersion = config.apiVersion ?? "";
   const client = new LinkedInClient({ accessToken, apiVersion });
 
-  const ownerUrn = await getCurrentPersonUrn(client);
+  let ownerUrn: string;
+  if (opts.asOrg !== undefined) {
+    await getOrganization(client, opts.asOrg);
+    ownerUrn = `urn:li:organization:${opts.asOrg}`;
+  } else {
+    ownerUrn = await getCurrentPersonUrn(client);
+  }
 
   const data = new Uint8Array(await readFile(file));
 

--- a/packages/cli/src/commands/media/upload-image.test.ts
+++ b/packages/cli/src/commands/media/upload-image.test.ts
@@ -20,6 +20,7 @@ vi.mock("@linkedctl/core", async (importOriginal) => {
       warnings: [],
     }),
     getCurrentPersonUrn: vi.fn().mockResolvedValue("urn:li:person:person123"),
+    getOrganization: vi.fn().mockResolvedValue({ id: 12345, localizedName: "Test Org" }),
     uploadImage: vi.fn().mockResolvedValue("urn:li:image:abc123"),
   };
 });
@@ -42,6 +43,7 @@ describe("media upload-image", () => {
     });
     vi.mocked(coreMock.uploadImage).mockResolvedValue("urn:li:image:abc123");
     vi.mocked(coreMock.getCurrentPersonUrn).mockResolvedValue("urn:li:person:person123");
+    vi.mocked(coreMock.getOrganization).mockResolvedValue({ id: 12345, localizedName: "Test Org" });
     tempDir = await mkdtemp(join(tmpdir(), "linkedctl-test-"));
   });
 
@@ -178,6 +180,40 @@ describe("media upload-image", () => {
       expect.anything(),
       expect.objectContaining({
         contentType: "image/jpeg",
+      }),
+    );
+  });
+
+  it("uploads as organization when --as-org is specified", async () => {
+    const filePath = join(tempDir, "logo.jpg");
+    await writeFile(filePath, Buffer.from([0xff, 0xd8, 0xff, 0xe0]));
+
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "media", "upload-image", filePath, "--as-org", "12345"]);
+
+    expect(coreMock.getOrganization).toHaveBeenCalledWith(expect.anything(), "12345");
+    expect(coreMock.uploadImage).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        owner: "urn:li:organization:12345",
+        contentType: "image/jpeg",
+      }),
+    );
+    expect(coreMock.getCurrentPersonUrn).not.toHaveBeenCalled();
+  });
+
+  it("uses person URN when --as-org is not specified", async () => {
+    const filePath = join(tempDir, "photo.jpg");
+    await writeFile(filePath, Buffer.from([0xff, 0xd8, 0xff, 0xe0]));
+
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "media", "upload-image", filePath]);
+
+    expect(coreMock.getOrganization).not.toHaveBeenCalled();
+    expect(coreMock.uploadImage).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        owner: "urn:li:person:person123",
       }),
     );
   });

--- a/packages/cli/src/commands/media/upload-image.ts
+++ b/packages/cli/src/commands/media/upload-image.ts
@@ -9,6 +9,7 @@ import {
   resolveConfig,
   LinkedInClient,
   getCurrentPersonUrn,
+  getOrganization,
   uploadImage,
   LinkedInApiError,
   SUPPORTED_IMAGE_TYPES,
@@ -18,6 +19,7 @@ import type { OutputFormat } from "../../output/index.js";
 
 interface UploadImageOpts {
   format?: string | undefined;
+  asOrg?: string | undefined;
 }
 
 export function uploadImageCommand(): Command {
@@ -25,13 +27,15 @@ export function uploadImageCommand(): Command {
   cmd.description("Upload an image to LinkedIn and return the image URN");
   cmd.argument("<file>", "path to image file (JPG, PNG, or GIF)");
   cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
+  cmd.option("--as-org <id>", "upload as an organization (specify org ID)");
 
   cmd.addHelpText(
     "after",
     `
 Examples:
   linkedctl media upload-image photo.jpg
-  linkedctl media upload-image banner.png --format json`,
+  linkedctl media upload-image banner.png --format json
+  linkedctl media upload-image logo.png --as-org 12345`,
   );
 
   cmd.action(async (file: string, opts: UploadImageOpts, actionCmd: Command) => {
@@ -52,7 +56,13 @@ Examples:
     const apiVersion = config.apiVersion ?? "";
     const client = new LinkedInClient({ accessToken, apiVersion });
 
-    const ownerUrn = await getCurrentPersonUrn(client);
+    let ownerUrn: string;
+    if (opts.asOrg !== undefined) {
+      await getOrganization(client, opts.asOrg);
+      ownerUrn = `urn:li:organization:${opts.asOrg}`;
+    } else {
+      ownerUrn = await getCurrentPersonUrn(client);
+    }
     const data = new Uint8Array(await readFile(file));
 
     try {

--- a/packages/cli/src/commands/media/upload-video.test.ts
+++ b/packages/cli/src/commands/media/upload-video.test.ts
@@ -20,6 +20,7 @@ vi.mock("@linkedctl/core", async (importOriginal) => {
       warnings: [],
     }),
     getCurrentPersonUrn: vi.fn().mockResolvedValue("urn:li:person:person123"),
+    getOrganization: vi.fn().mockResolvedValue({ id: 12345, localizedName: "Test Org" }),
     uploadVideo: vi.fn().mockResolvedValue("urn:li:video:V1234567890"),
   };
 });
@@ -44,6 +45,7 @@ describe("media upload-video", () => {
     });
     vi.mocked(coreMock.uploadVideo).mockResolvedValue("urn:li:video:V1234567890");
     vi.mocked(coreMock.getCurrentPersonUrn).mockResolvedValue("urn:li:person:person123");
+    vi.mocked(coreMock.getOrganization).mockResolvedValue({ id: 12345, localizedName: "Test Org" });
     tempDir = await mkdtemp(join(tmpdir(), "linkedctl-test-"));
   });
 
@@ -143,5 +145,38 @@ describe("media upload-video", () => {
     await expect(
       program.parseAsync(["node", "linkedctl", "media", "upload-video", filePath, "--format", "xml"]),
     ).rejects.toThrow(/Allowed choices are json, table/);
+  });
+
+  it("uploads as organization when --as-org is specified", async () => {
+    const filePath = join(tempDir, "clip.mp4");
+    await writeFile(filePath, Buffer.alloc(1024));
+
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "media", "upload-video", filePath, "--as-org", "12345"]);
+
+    expect(coreMock.getOrganization).toHaveBeenCalledWith(expect.anything(), "12345");
+    expect(coreMock.uploadVideo).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        owner: "urn:li:organization:12345",
+      }),
+    );
+    expect(coreMock.getCurrentPersonUrn).not.toHaveBeenCalled();
+  });
+
+  it("uses person URN when --as-org is not specified", async () => {
+    const filePath = join(tempDir, "clip.mp4");
+    await writeFile(filePath, Buffer.alloc(1024));
+
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "media", "upload-video", filePath]);
+
+    expect(coreMock.getOrganization).not.toHaveBeenCalled();
+    expect(coreMock.uploadVideo).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        owner: "urn:li:person:person123",
+      }),
+    );
   });
 });

--- a/packages/cli/src/commands/media/upload-video.ts
+++ b/packages/cli/src/commands/media/upload-video.ts
@@ -4,12 +4,20 @@
 import { readFile, stat } from "node:fs/promises";
 
 import { Command, Option } from "commander";
-import { resolveConfig, LinkedInClient, getCurrentPersonUrn, uploadVideo, LinkedInApiError } from "@linkedctl/core";
+import {
+  resolveConfig,
+  LinkedInClient,
+  getCurrentPersonUrn,
+  getOrganization,
+  uploadVideo,
+  LinkedInApiError,
+} from "@linkedctl/core";
 import { resolveFormat, formatOutput } from "../../output/index.js";
 import type { OutputFormat } from "../../output/index.js";
 
 interface UploadVideoOpts {
   format?: string | undefined;
+  asOrg?: string | undefined;
 }
 
 export function uploadVideoCommand(): Command {
@@ -17,13 +25,15 @@ export function uploadVideoCommand(): Command {
   cmd.description("Upload a video to LinkedIn via multipart upload");
   cmd.argument("<file>", "path to the video file (MP4)");
   cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
+  cmd.option("--as-org <id>", "upload as an organization (specify org ID)");
 
   cmd.addHelpText(
     "after",
     `
 Examples:
   linkedctl media upload-video clip.mp4
-  linkedctl media upload-video ~/Videos/demo.mp4 --format json`,
+  linkedctl media upload-video ~/Videos/demo.mp4 --format json
+  linkedctl media upload-video promo.mp4 --as-org 12345`,
   );
 
   cmd.action(async (file: string, opts: UploadVideoOpts, actionCmd: Command) => {
@@ -44,7 +54,13 @@ Examples:
     const apiVersion = config.apiVersion ?? "";
     const client = new LinkedInClient({ accessToken, apiVersion });
 
-    const ownerUrn = await getCurrentPersonUrn(client);
+    let ownerUrn: string;
+    if (opts.asOrg !== undefined) {
+      await getOrganization(client, opts.asOrg);
+      ownerUrn = `urn:li:organization:${opts.asOrg}`;
+    } else {
+      ownerUrn = await getCurrentPersonUrn(client);
+    }
 
     try {
       console.error(`Uploading video (${data.byteLength} bytes)…`);

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -1009,6 +1009,72 @@ describe("createMcpServer", () => {
       ]);
       expect(result.isError).toBe(true);
     });
+
+    it("creates post as organization when as_org is specified", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getOrganization).mockResolvedValue({ id: 12345, localizedName: "Test Org" });
+      vi.mocked(createPost).mockResolvedValue("urn:li:share:org123");
+
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: { text: "Org post", as_org: "12345" },
+      });
+
+      expect(getOrganization).toHaveBeenCalledWith(expect.anything(), "12345");
+      expect(createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          author: "urn:li:organization:12345",
+        }),
+      );
+      expect(getCurrentPersonUrn).not.toHaveBeenCalled();
+      expect(result.content).toEqual([{ type: "text", text: "Post created: urn:li:share:org123" }]);
+    });
+
+    it("uses org URN as owner for file uploads when as_org is specified", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getOrganization).mockResolvedValue({ id: 12345, localizedName: "Test Org" });
+      vi.mocked(readFile).mockResolvedValue(Buffer.from("fake-image"));
+      vi.mocked(uploadImage).mockResolvedValue("urn:li:image:org456");
+      vi.mocked(createPost).mockResolvedValue("urn:li:share:org789");
+
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: { text: "Org image post", image_file: "/path/to/logo.jpg", as_org: "12345" },
+      });
+
+      expect(uploadImage).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          owner: "urn:li:organization:12345",
+        }),
+      );
+      expect(createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          author: "urn:li:organization:12345",
+        }),
+      );
+      expect(result.content).toEqual([{ type: "text", text: "Post created: urn:li:share:org789" }]);
+    });
   });
 
   describe("comment_create", () => {
@@ -1282,6 +1348,42 @@ describe("createMcpServer", () => {
         profile: "work",
         requiredScopes: ["openid", "profile", "email", "w_member_social"],
       });
+    });
+
+    it("uploads as organization when as_org is specified", async () => {
+      vi.mocked(stat).mockResolvedValue({ size: 1024 } as ReturnType<
+        typeof import("node:fs/promises").stat
+      > extends Promise<infer T>
+        ? T
+        : never);
+      vi.mocked(readFile).mockResolvedValue(Buffer.from("fake-pdf-content"));
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getOrganization).mockResolvedValue({ id: 12345, localizedName: "Test Org" });
+      vi.mocked(uploadDocument).mockResolvedValue("urn:li:document:D789");
+
+      const result = await client.callTool({
+        name: "document_upload",
+        arguments: { file: "/path/to/deck.pdf", as_org: "12345" },
+      });
+
+      expect(getOrganization).toHaveBeenCalledWith(expect.anything(), "12345");
+      expect(uploadDocument).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          owner: "urn:li:organization:12345",
+        }),
+      );
+      expect(getCurrentPersonUrn).not.toHaveBeenCalled();
+      expect(result.content).toEqual([{ type: "text", text: "Document uploaded: urn:li:document:D789" }]);
     });
   });
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -129,6 +129,7 @@ export function createMcpServer(): McpServer {
           .enum(["ONE_DAY", "THREE_DAYS", "ONE_WEEK", "TWO_WEEKS"])
           .optional()
           .describe("How long the poll stays open (defaults to THREE_DAYS)"),
+        as_org: z.string().optional().describe("Organization ID to upload as (e.g. 12345)"),
         profile: z.string().optional().describe("Profile name to use from config file"),
       },
     },
@@ -206,7 +207,13 @@ export function createMcpServer(): McpServer {
       const apiVersion = config.apiVersion ?? "";
       const client = new LinkedInClient({ accessToken, apiVersion });
 
-      const authorUrn = await getCurrentPersonUrn(client);
+      let authorUrn: string;
+      if (args.as_org !== undefined) {
+        await getOrganization(client, args.as_org);
+        authorUrn = `urn:li:organization:${args.as_org}`;
+      } else {
+        authorUrn = await getCurrentPersonUrn(client);
+      }
 
       // Handle file-based uploads if no URN-based content was resolved
       if (postContent === undefined) {
@@ -318,6 +325,7 @@ export function createMcpServer(): McpServer {
       description: "Upload a document to LinkedIn (PDF, DOCX, PPTX, DOC, PPT; max 100 MB). Returns the document URN.",
       inputSchema: {
         file: z.string().describe("Absolute path to the document file"),
+        as_org: z.string().optional().describe("Organization ID to upload as (e.g. 12345)"),
         profile: z.string().optional().describe("Profile name to use from config file"),
       },
     },
@@ -352,7 +360,13 @@ export function createMcpServer(): McpServer {
       const apiVersion = config.apiVersion ?? "";
       const client = new LinkedInClient({ accessToken, apiVersion });
 
-      const ownerUrn = await getCurrentPersonUrn(client);
+      let ownerUrn: string;
+      if (args.as_org !== undefined) {
+        await getOrganization(client, args.as_org);
+        ownerUrn = `urn:li:organization:${args.as_org}`;
+      } else {
+        ownerUrn = await getCurrentPersonUrn(client);
+      }
       const data = new Uint8Array(await readFile(args.file));
 
       const documentUrn = await uploadDocument(client, { owner: ownerUrn, data });


### PR DESCRIPTION
## Summary

- Add `--as-org <id>` flag to CLI media upload commands (`upload-image`, `upload-video`, `upload-document`) to set the media owner to an organization
- Add `as_org` parameter to MCP `document_upload` and `post_create` tools for organization-owned uploads
- Validates organization exists via `getOrganization()` before uploading

Closes #22

## Test plan

- [x] Unit tests for `--as-org` flag in all three CLI media upload commands
- [x] Unit tests verify organization URN is used as owner when `--as-org` is specified
- [x] Unit tests verify person URN is used when `--as-org` is not specified
- [x] MCP tests for `as_org` parameter in `document_upload` tool
- [x] MCP tests for `as_org` parameter in `post_create` tool (text-only and file upload)
- [x] All 622 existing + new tests pass
- [x] Build, typecheck, lint, and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)