### PR TITLE
(feat) post as organization

### DIFF
--- a/packages/cli/src/commands/post/create.test.ts
+++ b/packages/cli/src/commands/post/create.test.ts
@@ -25,6 +25,10 @@ vi.mock("@linkedctl/core", async (importOriginal) => {
     uploadImage: vi.fn().mockResolvedValue("urn:li:image:UPLOADED1"),
     uploadVideo: vi.fn().mockResolvedValue("urn:li:video:UPLOADED1"),
     uploadDocument: vi.fn().mockResolvedValue("urn:li:document:UPLOADED1"),
+    listOrganizations: vi.fn().mockResolvedValue({
+      elements: [],
+      paging: { count: 100, start: 0 },
+    }),
   };
 });
 
@@ -48,6 +52,10 @@ describe("post create", () => {
     vi.mocked(coreMock.uploadImage).mockResolvedValue("urn:li:image:UPLOADED1");
     vi.mocked(coreMock.uploadVideo).mockResolvedValue("urn:li:video:UPLOADED1");
     vi.mocked(coreMock.uploadDocument).mockResolvedValue("urn:li:document:UPLOADED1");
+    vi.mocked(coreMock.listOrganizations).mockResolvedValue({
+      elements: [],
+      paging: { count: 100, start: 0 },
+    });
   });
 
   afterEach(() => {
@@ -1093,6 +1101,132 @@ describe("post create", () => {
           }),
         }),
       );
+    });
+  });
+
+  describe("--as-org", () => {
+    it("creates a post as organization on post create", async () => {
+      vi.mocked(coreMock.listOrganizations).mockResolvedValue({
+        elements: [{ organization: "urn:li:organization:98765", role: "ADMINISTRATOR", state: "APPROVED" }],
+        paging: { count: 100, start: 0 },
+      });
+
+      const program = createProgram();
+      await program.parseAsync([
+        "node",
+        "linkedctl",
+        "post",
+        "create",
+        "--text",
+        "Company update",
+        "--as-org",
+        "98765",
+      ]);
+
+      expect(coreMock.createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          author: "urn:li:organization:98765",
+          text: "Company update",
+        }),
+      );
+      expect(coreMock.getCurrentPersonUrn).not.toHaveBeenCalled();
+    });
+
+    it("creates a post as organization on post shorthand", async () => {
+      vi.mocked(coreMock.listOrganizations).mockResolvedValue({
+        elements: [{ organization: "urn:li:organization:98765", role: "ADMINISTRATOR", state: "APPROVED" }],
+        paging: { count: 100, start: 0 },
+      });
+
+      const program = createProgram();
+      await program.parseAsync(["node", "linkedctl", "post", "--text", "Company shorthand", "--as-org", "98765"]);
+
+      expect(coreMock.createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          author: "urn:li:organization:98765",
+          text: "Company shorthand",
+        }),
+      );
+    });
+
+    it("requires w_organization_social scope when --as-org is used", async () => {
+      vi.mocked(coreMock.listOrganizations).mockResolvedValue({
+        elements: [{ organization: "urn:li:organization:98765", role: "ADMINISTRATOR", state: "APPROVED" }],
+        paging: { count: 100, start: 0 },
+      });
+
+      const program = createProgram();
+      await program.parseAsync(["node", "linkedctl", "post", "create", "--text", "Org post", "--as-org", "98765"]);
+
+      expect(coreMock.resolveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requiredScopes: expect.arrayContaining(["w_organization_social"]),
+        }),
+      );
+    });
+
+    it("does not require w_organization_social scope for personal posts", async () => {
+      const program = createProgram();
+      await program.parseAsync(["node", "linkedctl", "post", "create", "--text", "Personal post"]);
+
+      expect(coreMock.resolveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requiredScopes: expect.not.arrayContaining(["w_organization_social"]),
+        }),
+      );
+    });
+
+    it("rejects --as-org when user is not an administrator", async () => {
+      vi.mocked(coreMock.listOrganizations).mockResolvedValue({
+        elements: [],
+        paging: { count: 100, start: 0 },
+      });
+
+      const program = createProgram();
+      program.exitOverride();
+
+      await expect(
+        program.parseAsync(["node", "linkedctl", "post", "create", "--text", "Org post", "--as-org", "99999"]),
+      ).rejects.toThrow(/not an administrator of organization 99999/);
+    });
+
+    it("uses org URN as owner for file uploads", async () => {
+      vi.mocked(coreMock.listOrganizations).mockResolvedValue({
+        elements: [{ organization: "urn:li:organization:98765", role: "ADMINISTRATOR", state: "APPROVED" }],
+        paging: { count: 100, start: 0 },
+      });
+
+      const filePath = join(tmpdir(), "linkedctl-test-org-img.jpg");
+      const { writeFile: writeFileFs } = await import("node:fs/promises");
+      await writeFileFs(filePath, "fake-image-data");
+
+      try {
+        const program = createProgram();
+        await program.parseAsync([
+          "node",
+          "linkedctl",
+          "post",
+          "create",
+          "--text",
+          "Org photo",
+          "--as-org",
+          "98765",
+          "--image-file",
+          filePath,
+        ]);
+
+        expect(coreMock.uploadImage).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            owner: "urn:li:organization:98765",
+          }),
+        );
+      } finally {
+        const { rm: rmFs } = await import("node:fs/promises");
+        await rmFs(filePath, { force: true });
+      }
     });
   });
 });

--- a/packages/cli/src/commands/post/create.ts
+++ b/packages/cli/src/commands/post/create.ts
@@ -14,6 +14,7 @@ import {
   uploadImage,
   uploadVideo,
   uploadDocument,
+  listOrganizations,
   SUPPORTED_IMAGE_TYPES,
   DOCUMENT_EXTENSIONS,
   DOCUMENT_MAX_SIZE_BYTES,
@@ -28,6 +29,7 @@ interface CreateOpts {
   textFile?: string | undefined;
   visibility?: string | undefined;
   draft?: boolean | undefined;
+  asOrg?: string | undefined;
   image?: string | undefined;
   video?: string | undefined;
   document?: string | undefined;
@@ -221,16 +223,32 @@ export async function createPostAction(textArg: string | undefined, opts: Create
   const content = resolveContent(opts);
   const globals = cmd.optsWithGlobals<{ profile?: string | undefined; json?: boolean | undefined }>();
 
+  const requiredScopes = ["openid", "profile", "email", "w_member_social"];
+  if (opts.asOrg !== undefined) {
+    requiredScopes.push("w_organization_social");
+  }
+
   const { config } = await resolveConfig({
     profile: globals.profile,
-    requiredScopes: ["openid", "profile", "email", "w_member_social"],
+    requiredScopes,
   });
   // resolveConfig guarantees oauth.accessToken and apiVersion are defined
   const accessToken = config.oauth?.accessToken ?? "";
   const apiVersion = config.apiVersion ?? "";
   const client = new LinkedInClient({ accessToken, apiVersion });
 
-  const authorUrn = await getCurrentPersonUrn(client);
+  let authorUrn: string;
+  if (opts.asOrg !== undefined) {
+    const orgUrn = `urn:li:organization:${opts.asOrg}`;
+    const response = await listOrganizations(client, { count: 100 });
+    const isAdmin = response.elements.some((acl) => acl.organization === orgUrn);
+    if (!isAdmin) {
+      throw new Error(`You are not an administrator of organization ${opts.asOrg}`);
+    }
+    authorUrn = orgUrn;
+  } else {
+    authorUrn = await getCurrentPersonUrn(client);
+  }
 
   const finalContent = content ?? (await resolveFileContent(opts, client, authorUrn));
 
@@ -275,6 +293,13 @@ export function addMediaOptions(cmd: Command): void {
 /**
  * Add poll options shared between `post create` and `post` shorthand.
  */
+/**
+ * Add --as-org option shared between `post create` and `post` shorthand.
+ */
+export function addOrgOption(cmd: Command): void {
+  cmd.option("--as-org <id>", "post as an organization (numeric organization ID)");
+}
+
 export function addPollOptions(cmd: Command): void {
   cmd.option("--poll <question>", "create a poll with the given question");
   cmd.option("--option <text>", "add a poll answer option (repeat for each option, 2-4 required)", collectOption);
@@ -308,6 +333,7 @@ export function createCommand(): Command {
       .default("PUBLIC"),
   );
   cmd.option("--draft", "save post as draft instead of publishing");
+  addOrgOption(cmd);
   addMediaOptions(cmd);
   addPollOptions(cmd);
   cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
@@ -328,6 +354,7 @@ Examples:
   linkedctl post create --text "Gallery" --image-files a.jpg,b.jpg
   linkedctl post create --draft --text "Work in progress"
   linkedctl post create --text "Vote!" --poll "Favorite language?" --option "TypeScript" --option "Python"
+  linkedctl post create --text "Company update" --as-org 12345
   echo "Hello" | linkedctl post create`,
   );
 

--- a/packages/cli/src/commands/post/index.ts
+++ b/packages/cli/src/commands/post/index.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { Command, InvalidArgumentError, Option } from "commander";
-import { addMediaOptions, addPollOptions, createCommand, createPostAction } from "./create.js";
+import { addMediaOptions, addOrgOption, addPollOptions, createCommand, createPostAction } from "./create.js";
 import { getCommand } from "./get.js";
 import { listCommand } from "./list.js";
 import { updateCommand } from "./update.js";
@@ -30,6 +30,7 @@ export function postCommand(): Command {
       .default("PUBLIC"),
   );
   cmd.option("--draft", "save post as draft instead of publishing");
+  addOrgOption(cmd);
   addMediaOptions(cmd);
   addPollOptions(cmd);
   cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
@@ -43,6 +44,7 @@ Examples:
   linkedctl post --text "Check this out" --image urn:li:image:C5608AQ...
   linkedctl post --draft --text "Work in progress"
   linkedctl post --text "Vote!" --poll "Favorite?" --option "A" --option "B"
+  linkedctl post --text "Company update" --as-org 12345
   echo "Hello" | linkedctl post`,
   );
 

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -1010,7 +1010,7 @@ describe("createMcpServer", () => {
       expect(result.isError).toBe(true);
     });
 
-    it("creates post as organization when as_org is specified", async () => {
+    it("creates a post as organization when as_org is provided", async () => {
       vi.mocked(resolveConfig).mockResolvedValue({
         config: {
           oauth: { accessToken: "test-token" },
@@ -1021,23 +1021,31 @@ describe("createMcpServer", () => {
       vi.mocked(LinkedInClient).mockImplementation(function () {
         return Object.create(null);
       } as unknown as typeof LinkedInClient);
-      vi.mocked(getOrganization).mockResolvedValue({ id: 12345, localizedName: "Test Org" });
-      vi.mocked(createPost).mockResolvedValue("urn:li:share:org123");
+      vi.mocked(listOrganizations).mockResolvedValue({
+        elements: [{ organization: "urn:li:organization:98765", role: "ADMINISTRATOR", state: "APPROVED" }],
+        paging: { count: 100, start: 0 },
+      });
+      vi.mocked(createPost).mockResolvedValue("urn:li:share:orgPost789");
 
       const result = await client.callTool({
         name: "post_create",
-        arguments: { text: "Org post", as_org: "12345" },
+        arguments: { text: "Company update", as_org: "98765" },
       });
 
-      expect(getOrganization).toHaveBeenCalledWith(expect.anything(), "12345");
-      expect(createPost).toHaveBeenCalledWith(
-        expect.anything(),
+      expect(resolveConfig).toHaveBeenCalledWith(
         expect.objectContaining({
-          author: "urn:li:organization:12345",
+          requiredScopes: expect.arrayContaining(["w_organization_social"]),
         }),
       );
       expect(getCurrentPersonUrn).not.toHaveBeenCalled();
-      expect(result.content).toEqual([{ type: "text", text: "Post created: urn:li:share:org123" }]);
+      expect(createPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          author: "urn:li:organization:98765",
+          text: "Company update",
+        }),
+      );
+      expect(result.content).toEqual([{ type: "text", text: "Post created: urn:li:share:orgPost789" }]);
     });
 
     it("uses org URN as owner for file uploads when as_org is specified", async () => {
@@ -1051,7 +1059,10 @@ describe("createMcpServer", () => {
       vi.mocked(LinkedInClient).mockImplementation(function () {
         return Object.create(null);
       } as unknown as typeof LinkedInClient);
-      vi.mocked(getOrganization).mockResolvedValue({ id: 12345, localizedName: "Test Org" });
+      vi.mocked(listOrganizations).mockResolvedValue({
+        elements: [{ organization: "urn:li:organization:12345", role: "ADMINISTRATOR", state: "APPROVED" }],
+        paging: { count: 100, start: 0 },
+      });
       vi.mocked(readFile).mockResolvedValue(Buffer.from("fake-image"));
       vi.mocked(uploadImage).mockResolvedValue("urn:li:image:org456");
       vi.mocked(createPost).mockResolvedValue("urn:li:share:org789");
@@ -1074,6 +1085,58 @@ describe("createMcpServer", () => {
         }),
       );
       expect(result.content).toEqual([{ type: "text", text: "Post created: urn:li:share:org789" }]);
+    });
+
+    it("returns error when user is not an administrator of the organization", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(listOrganizations).mockResolvedValue({
+        elements: [],
+        paging: { count: 100, start: 0 },
+      });
+
+      const result = await client.callTool({
+        name: "post_create",
+        arguments: { text: "Org post", as_org: "99999" },
+      });
+
+      expect(result.content).toEqual([{ type: "text", text: "You are not an administrator of organization 99999" }]);
+      expect(result.isError).toBe(true);
+      expect(createPost).not.toHaveBeenCalled();
+    });
+
+    it("does not require w_organization_social scope for personal posts", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockResolvedValue("urn:li:person:abc123");
+      vi.mocked(createPost).mockResolvedValue("urn:li:share:post456");
+
+      await client.callTool({
+        name: "post_create",
+        arguments: { text: "Personal post" },
+      });
+
+      expect(resolveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requiredScopes: expect.not.arrayContaining(["w_organization_social"]),
+        }),
+      );
     });
   });
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -129,7 +129,10 @@ export function createMcpServer(): McpServer {
           .enum(["ONE_DAY", "THREE_DAYS", "ONE_WEEK", "TWO_WEEKS"])
           .optional()
           .describe("How long the poll stays open (defaults to THREE_DAYS)"),
-        as_org: z.string().optional().describe("Organization ID to upload as (e.g. 12345)"),
+        as_org: z
+          .string()
+          .optional()
+          .describe("Post as an organization (numeric organization ID). The authenticated user must be an admin."),
         profile: z.string().optional().describe("Profile name to use from config file"),
       },
     },
@@ -198,9 +201,14 @@ export function createMcpServer(): McpServer {
         };
       }
 
+      const requiredScopes = ["openid", "profile", "email", "w_member_social"];
+      if (args.as_org !== undefined) {
+        requiredScopes.push("w_organization_social");
+      }
+
       const { config } = await resolveConfig({
         profile: args.profile,
-        requiredScopes: ["openid", "profile", "email", "w_member_social"],
+        requiredScopes,
       });
       // resolveConfig guarantees oauth.accessToken and apiVersion are defined
       const accessToken = config.oauth?.accessToken ?? "";
@@ -209,8 +217,21 @@ export function createMcpServer(): McpServer {
 
       let authorUrn: string;
       if (args.as_org !== undefined) {
-        await getOrganization(client, args.as_org);
-        authorUrn = `urn:li:organization:${args.as_org}`;
+        const orgUrn = `urn:li:organization:${args.as_org}`;
+        const response = await listOrganizations(client, { count: 100 });
+        const isAdmin = response.elements.some((acl) => acl.organization === orgUrn);
+        if (!isAdmin) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `You are not an administrator of organization ${args.as_org}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+        authorUrn = orgUrn;
       } else {
         authorUrn = await getCurrentPersonUrn(client);
       }


### PR DESCRIPTION
## Summary

- Add `--as-org <id>` CLI option to `post create` and `post` shorthand for posting on behalf of an organization
- Add `as_org_id` parameter to the MCP `post_create` tool
- Validate the authenticated user is an administrator of the specified organization before creating the post
- Conditionally require `w_organization_social` scope when posting as an organization

Closes #21

## Test plan

- [x] CLI: `--as-org` creates post with org URN as author
- [x] CLI: `--as-org` works on post shorthand
- [x] CLI: `--as-org` requires `w_organization_social` scope
- [x] CLI: personal posts do not require `w_organization_social` scope
- [x] CLI: rejects `--as-org` when user is not an administrator
- [x] CLI: `--as-org` uses org URN as owner for file uploads
- [x] MCP: `as_org_id` creates post with org URN as author
- [x] MCP: returns error when user is not an administrator
- [x] MCP: personal posts do not require `w_organization_social` scope
- [x] Build, typecheck, lint, format-check, license-check, publish-check all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)