### PR TITLE
(feat) comments and reactions as organization

### DIFF
--- a/packages/cli/src/commands/comment/create.test.ts
+++ b/packages/cli/src/commands/comment/create.test.ts
@@ -98,6 +98,31 @@ describe("comment create", () => {
     );
   });
 
+  it("uses organization URN as actor when --as-org is specified", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "linkedctl",
+      "comment",
+      "create",
+      "urn:li:share:123",
+      "--text",
+      "Official reply",
+      "--as-org",
+      "99999",
+    ]);
+
+    expect(coreMock.getCurrentPersonUrn).not.toHaveBeenCalled();
+    expect(coreMock.createComment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        actor: "urn:li:organization:99999",
+        object: "urn:li:share:123",
+        message: "Official reply",
+      }),
+    );
+  });
+
   it("wraps API errors with actionable message", async () => {
     const { LinkedInApiError } = await import("@linkedctl/core");
     vi.mocked(coreMock.createComment).mockRejectedValueOnce(new LinkedInApiError("Forbidden", 403));

--- a/packages/cli/src/commands/comment/create.ts
+++ b/packages/cli/src/commands/comment/create.ts
@@ -8,6 +8,7 @@ import type { OutputFormat } from "../../output/index.js";
 
 interface CreateOpts {
   text: string;
+  asOrg?: string | undefined;
   format?: string | undefined;
 }
 
@@ -16,6 +17,7 @@ export function createCommentCreateCommand(): Command {
   cmd.description("Create a comment on a LinkedIn post");
   cmd.argument("<urn>", "post URN to comment on (e.g. urn:li:share:...)");
   cmd.requiredOption("--text <text>", "comment text");
+  cmd.option("--as-org <org-id>", "act as organization (numeric ID, e.g. 12345)");
   cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
 
   cmd.addHelpText(
@@ -23,7 +25,8 @@ export function createCommentCreateCommand(): Command {
     `
 Examples:
   linkedctl comment create urn:li:share:123 --text "Great post!"
-  linkedctl comment create urn:li:share:123 --text "Nice work" --format json`,
+  linkedctl comment create urn:li:share:123 --text "Nice work" --format json
+  linkedctl comment create urn:li:share:123 --text "Official reply" --as-org 12345`,
   );
 
   cmd.action(async (urn: string, opts: CreateOpts, actionCmd: Command) => {
@@ -37,7 +40,7 @@ Examples:
     const apiVersion = config.apiVersion ?? "";
     const client = new LinkedInClient({ accessToken, apiVersion });
 
-    const actorUrn = await getCurrentPersonUrn(client);
+    const actorUrn = opts.asOrg !== undefined ? `urn:li:organization:${opts.asOrg}` : await getCurrentPersonUrn(client);
 
     try {
       const commentUrn = await createComment(client, {

--- a/packages/cli/src/commands/reaction/create.test.ts
+++ b/packages/cli/src/commands/reaction/create.test.ts
@@ -89,6 +89,20 @@ describe("reaction create", () => {
     );
   });
 
+  it("passes organization actor when --as-org is specified", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "reaction", "create", "urn:li:share:abc123", "--as-org", "99999"]);
+
+    expect(coreMock.createReaction).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        entity: "urn:li:share:abc123",
+        reactionType: "LIKE",
+        actor: "urn:li:organization:99999",
+      }),
+    );
+  });
+
   it("rejects invalid --type value", async () => {
     const program = createProgram();
     for (const cmd of program.commands) {

--- a/packages/cli/src/commands/reaction/create.ts
+++ b/packages/cli/src/commands/reaction/create.ts
@@ -9,6 +9,7 @@ import type { OutputFormat } from "../../output/index.js";
 
 interface CreateOpts {
   type?: string | undefined;
+  asOrg?: string | undefined;
   format?: string | undefined;
 }
 
@@ -24,11 +25,13 @@ export async function createReactionAction(entityUrn: string, opts: CreateOpts, 
   const client = new LinkedInClient({ accessToken, apiVersion });
 
   const reactionType = (opts.type ?? "LIKE") as ReactionType;
+  const actor = opts.asOrg !== undefined ? `urn:li:organization:${opts.asOrg}` : undefined;
 
   try {
     const reactionUrn = await createReaction(client, {
       entity: entityUrn,
       reactionType,
+      actor,
     });
 
     const format = resolveFormat(opts.format as OutputFormat | undefined, process.stdout, globals.json === true);
@@ -47,6 +50,7 @@ export function createReactionCommand(): Command {
   cmd.description("Add a reaction to a LinkedIn post");
   cmd.argument("<entity-urn>", "entity URN to react to (e.g. urn:li:share:abc123)");
   cmd.addOption(new Option("--type <type>", "reaction type").choices([...REACTION_TYPES]).default("LIKE"));
+  cmd.option("--as-org <org-id>", "act as organization (numeric ID, e.g. 12345)");
   cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
 
   cmd.addHelpText(
@@ -55,7 +59,8 @@ export function createReactionCommand(): Command {
 Examples:
   linkedctl reaction create urn:li:share:abc123
   linkedctl reaction create urn:li:share:abc123 --type PRAISE
-  linkedctl reaction create urn:li:share:abc123 --type ENTERTAINMENT --format json`,
+  linkedctl reaction create urn:li:share:abc123 --type ENTERTAINMENT --format json
+  linkedctl reaction create urn:li:share:abc123 --as-org 12345`,
   );
 
   cmd.action(async (entityUrn: string, opts: CreateOpts, actionCmd: Command) => {

--- a/packages/cli/src/commands/reaction/delete.test.ts
+++ b/packages/cli/src/commands/reaction/delete.test.ts
@@ -56,6 +56,20 @@ describe("reaction delete", () => {
     );
   });
 
+  it("uses organization URN as actor when --as-org is specified", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "reaction", "delete", "urn:li:share:abc123", "--as-org", "99999"]);
+
+    expect(coreMock.getCurrentPersonUrn).not.toHaveBeenCalled();
+    expect(coreMock.deleteReaction).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        entity: "urn:li:share:abc123",
+        actor: "urn:li:organization:99999",
+      }),
+    );
+  });
+
   it("outputs confirmation message", async () => {
     const program = createProgram();
     await program.parseAsync(["node", "linkedctl", "reaction", "delete", "urn:li:share:abc123"]);

--- a/packages/cli/src/commands/reaction/delete.ts
+++ b/packages/cli/src/commands/reaction/delete.ts
@@ -4,7 +4,11 @@
 import { Command } from "commander";
 import { resolveConfig, LinkedInClient, getCurrentPersonUrn, deleteReaction, LinkedInApiError } from "@linkedctl/core";
 
-export async function deleteReactionAction(entityUrn: string, cmd: Command): Promise<void> {
+interface DeleteOpts {
+  asOrg?: string | undefined;
+}
+
+export async function deleteReactionAction(entityUrn: string, opts: DeleteOpts, cmd: Command): Promise<void> {
   const globals = cmd.optsWithGlobals<{ profile?: string | undefined }>();
 
   const { config } = await resolveConfig({
@@ -15,7 +19,7 @@ export async function deleteReactionAction(entityUrn: string, cmd: Command): Pro
   const apiVersion = config.apiVersion ?? "";
   const client = new LinkedInClient({ accessToken, apiVersion });
 
-  const actorUrn = await getCurrentPersonUrn(client);
+  const actorUrn = opts.asOrg !== undefined ? `urn:li:organization:${opts.asOrg}` : await getCurrentPersonUrn(client);
 
   try {
     await deleteReaction(client, { entity: entityUrn, actor: actorUrn });
@@ -32,16 +36,18 @@ export function deleteReactionCommand(): Command {
   const cmd = new Command("delete");
   cmd.description("Remove your reaction from a LinkedIn post");
   cmd.argument("<entity-urn>", "entity URN to remove reaction from (e.g. urn:li:share:abc123)");
+  cmd.option("--as-org <org-id>", "act as organization (numeric ID, e.g. 12345)");
 
   cmd.addHelpText(
     "after",
     `
 Examples:
-  linkedctl reaction delete urn:li:share:abc123`,
+  linkedctl reaction delete urn:li:share:abc123
+  linkedctl reaction delete urn:li:share:abc123 --as-org 12345`,
   );
 
-  cmd.action(async (entityUrn: string, _opts: Record<string, unknown>, actionCmd: Command) => {
-    await deleteReactionAction(entityUrn, actionCmd);
+  cmd.action(async (entityUrn: string, opts: DeleteOpts, actionCmd: Command) => {
+    await deleteReactionAction(entityUrn, opts, actionCmd);
   });
 
   return cmd;

--- a/packages/core/src/reactions/reactions-service.test.ts
+++ b/packages/core/src/reactions/reactions-service.test.ts
@@ -49,6 +49,25 @@ describe("createReaction", () => {
 
     expect(urn).toBe("urn:li:reaction:456");
   });
+
+  it("includes actor in body when specified", async () => {
+    const client = mockClient();
+    await createReaction(client, { entity: "urn:li:share:abc123", actor: "urn:li:organization:99999" });
+
+    expect(client.create).toHaveBeenCalledWith("/rest/reactions", {
+      root: "urn:li:share:abc123",
+      reactionType: "LIKE",
+      actor: "urn:li:organization:99999",
+    });
+  });
+
+  it("omits actor from body when not specified", async () => {
+    const client = mockClient();
+    await createReaction(client, { entity: "urn:li:share:abc123" });
+
+    const body = vi.mocked(client.create).mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(body).not.toHaveProperty("actor");
+  });
 });
 
 describe("listReactions", () => {

--- a/packages/core/src/reactions/reactions-service.ts
+++ b/packages/core/src/reactions/reactions-service.ts
@@ -30,10 +30,13 @@ function encodeUrnForKey(urn: string): string {
  * Create a reaction on a LinkedIn entity.
  */
 export async function createReaction(client: LinkedInClient, options: CreateReactionOptions): Promise<string> {
-  const body = {
+  const body: Record<string, unknown> = {
     root: options.entity,
     reactionType: options.reactionType ?? "LIKE",
   };
+  if (options.actor !== undefined) {
+    body["actor"] = options.actor;
+  }
 
   return client.create("/rest/reactions", body);
 }

--- a/packages/core/src/reactions/types.ts
+++ b/packages/core/src/reactions/types.ts
@@ -40,6 +40,8 @@ export interface CreateReactionOptions {
   entity: string;
   /** The type of reaction. Defaults to `"LIKE"`. */
   reactionType?: ReactionType | undefined;
+  /** Optional actor URN (e.g. `urn:li:organization:12345`). When omitted the authenticated user is the actor. */
+  actor?: string | undefined;
 }
 
 /**

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -1175,6 +1175,42 @@ describe("createMcpServer", () => {
         { type: "text", text: "Comment created: urn:li:comment:(urn:li:activity:100,200)" },
       ]);
     });
+
+    it("uses organization URN as actor when as_org is specified", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(createComment).mockResolvedValue("urn:li:comment:(urn:li:activity:100,300)");
+
+      const result = await client.callTool({
+        name: "comment_create",
+        arguments: {
+          post_urn: "urn:li:share:123",
+          text: "Official reply",
+          as_org: "99999",
+        },
+      });
+
+      expect(getCurrentPersonUrn).not.toHaveBeenCalled();
+      expect(createComment).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          actor: "urn:li:organization:99999",
+          object: "urn:li:share:123",
+          message: "Official reply",
+        }),
+      );
+      expect(result.content).toEqual([
+        { type: "text", text: "Comment created: urn:li:comment:(urn:li:activity:100,300)" },
+      ]);
+    });
   });
 
   describe("comment_list", () => {
@@ -2045,6 +2081,35 @@ describe("createMcpServer", () => {
       expect(result.content).toEqual([{ type: "text", text: "Reaction created: urn:li:reaction:r456" }]);
     });
 
+    it("passes organization actor when as_org is specified", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(createReaction).mockResolvedValue("urn:li:reaction:r789");
+
+      const result = await client.callTool({
+        name: "reaction_create",
+        arguments: { entity_urn: "urn:li:share:abc123", as_org: "99999" },
+      });
+
+      expect(createReaction).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          entity: "urn:li:share:abc123",
+          reactionType: "LIKE",
+          actor: "urn:li:organization:99999",
+        }),
+      );
+      expect(result.content).toEqual([{ type: "text", text: "Reaction created: urn:li:reaction:r789" }]);
+    });
+
     it("returns error with re-auth guidance for expired token", async () => {
       vi.mocked(resolveConfig).mockResolvedValue({
         config: {
@@ -2231,6 +2296,35 @@ describe("createMcpServer", () => {
         expect.objectContaining({
           entity: "urn:li:share:abc123",
           actor: "urn:li:person:abc123",
+        }),
+      );
+      expect(result.content).toEqual([{ type: "text", text: "Reaction deleted" }]);
+    });
+
+    it("uses organization URN as actor when as_org is specified", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(deleteReaction).mockResolvedValue(undefined);
+
+      const result = await client.callTool({
+        name: "reaction_delete",
+        arguments: { entity_urn: "urn:li:share:abc123", as_org: "99999" },
+      });
+
+      expect(getCurrentPersonUrn).not.toHaveBeenCalled();
+      expect(deleteReaction).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          entity: "urn:li:share:abc123",
+          actor: "urn:li:organization:99999",
         }),
       );
       expect(result.content).toEqual([{ type: "text", text: "Reaction deleted" }]);

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -525,13 +525,14 @@ export function createMcpServer(): McpServer {
     {
       title: "Create Reaction",
       description:
-        "Add a reaction to a LinkedIn post. Supports LIKE (default), PRAISE, EMPATHY, INTEREST, APPRECIATION, ENTERTAINMENT.",
+        "Add a reaction to a LinkedIn post. Supports LIKE (default), PRAISE, EMPATHY, INTEREST, APPRECIATION, ENTERTAINMENT. Use as_org to react as an organization.",
       inputSchema: {
         entity_urn: z.string().describe("Entity URN to react to (e.g. urn:li:share:abc123)"),
         reaction_type: z
           .enum(REACTION_TYPES as unknown as [string, ...string[]])
           .optional()
           .describe("Type of reaction (defaults to LIKE)"),
+        as_org: z.string().optional().describe("Organization ID to act as (numeric, e.g. 12345)"),
         profile: z.string().optional().describe("Profile name to use from config file"),
       },
     },
@@ -545,9 +546,11 @@ export function createMcpServer(): McpServer {
       const client = new LinkedInClient({ accessToken, apiVersion });
 
       try {
+        const actor = args.as_org !== undefined ? `urn:li:organization:${args.as_org}` : undefined;
         const reactionUrn = await createReaction(client, {
           entity: args.entity_urn,
           reactionType: (args.reaction_type as ReactionType | undefined) ?? "LIKE",
+          actor,
         });
 
         return {
@@ -623,9 +626,10 @@ export function createMcpServer(): McpServer {
     "reaction_delete",
     {
       title: "Delete Reaction",
-      description: "Remove your reaction from a LinkedIn post",
+      description: "Remove a reaction from a LinkedIn post. Use as_org to delete an organization's reaction.",
       inputSchema: {
         entity_urn: z.string().describe("Entity URN to remove reaction from (e.g. urn:li:share:abc123)"),
+        as_org: z.string().optional().describe("Organization ID to act as (numeric, e.g. 12345)"),
         profile: z.string().optional().describe("Profile name to use from config file"),
       },
     },
@@ -638,7 +642,8 @@ export function createMcpServer(): McpServer {
       const apiVersion = config.apiVersion ?? "";
       const client = new LinkedInClient({ accessToken, apiVersion });
 
-      const actorUrn = await getCurrentPersonUrn(client);
+      const actorUrn =
+        args.as_org !== undefined ? `urn:li:organization:${args.as_org}` : await getCurrentPersonUrn(client);
 
       try {
         await deleteReaction(client, { entity: args.entity_urn, actor: actorUrn });
@@ -667,10 +672,11 @@ export function createMcpServer(): McpServer {
     "comment_create",
     {
       title: "Create Comment",
-      description: "Create a comment on a LinkedIn post",
+      description: "Create a comment on a LinkedIn post. Use as_org to comment as an organization.",
       inputSchema: {
         post_urn: z.string().describe("Post URN to comment on (e.g. urn:li:share:...)"),
         text: z.string().describe("The comment text"),
+        as_org: z.string().optional().describe("Organization ID to act as (numeric, e.g. 12345)"),
         profile: z.string().optional().describe("Profile name to use from config file"),
       },
     },
@@ -683,7 +689,8 @@ export function createMcpServer(): McpServer {
       const apiVersion = config.apiVersion ?? "";
       const client = new LinkedInClient({ accessToken, apiVersion });
 
-      const actorUrn = await getCurrentPersonUrn(client);
+      const actorUrn =
+        args.as_org !== undefined ? `urn:li:organization:${args.as_org}` : await getCurrentPersonUrn(client);
 
       const commentUrn = await createComment(client, {
         actor: actorUrn,


### PR DESCRIPTION
## Summary

- Add `--as-org <id>` CLI flag and `as_org` MCP parameter to `comment create`, `reaction create`, and `reaction delete`
- When specified, the organization URN is used as the actor instead of the authenticated user's person URN
- Add optional `actor` field to `CreateReactionOptions` in core, passed through to the LinkedIn API body

## Test plan

- [x] Core: `createReaction` includes `actor` in body when specified, omits when not
- [x] CLI: `comment create --as-org` uses org URN, skips `getCurrentPersonUrn`
- [x] CLI: `reaction create --as-org` passes org actor to `createReaction`
- [x] CLI: `reaction delete --as-org` uses org URN, skips `getCurrentPersonUrn`
- [x] MCP: `comment_create` with `as_org` uses org URN
- [x] MCP: `reaction_create` with `as_org` passes org actor
- [x] MCP: `reaction_delete` with `as_org` uses org URN
- [x] All existing tests continue to pass (330 tests)
- [x] Build, typecheck, lint, format check all pass

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)