### PR TITLE
Update README, add Smithery config, stamp smithery version on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,11 @@ jobs:
             s.packages.forEach(p => { p.version = process.env.VERSION; });
             fs.writeFileSync('server.json', JSON.stringify(s, null, 2) + '\n');
           "
+          VERSION="$VERSION" node -e "
+            const fs = require('fs');
+            const y = fs.readFileSync('smithery.yaml', 'utf8');
+            fs.writeFileSync('smithery.yaml', y.replace(/linkedctl@[^'\"]+/g, 'linkedctl@' + process.env.VERSION));
+          "
 
       - run: pnpm build
 

--- a/packages/linkedctl/README.md
+++ b/packages/linkedctl/README.md
@@ -1,4 +1,4 @@
-# LinkedCtl
+![LinkedCtl: The Complete CLI & MCP for LinkedIn](https://raw.githubusercontent.com/linkedctl/.github/main/profile/assets/social-preview.png)
 
 [![CI](https://img.shields.io/github/check-runs/alexey-pelykh/linkedctl/main)](https://github.com/alexey-pelykh/linkedctl/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/alexey-pelykh/linkedctl)](https://www.gnu.org/licenses/agpl-3.0.txt)
@@ -8,6 +8,10 @@ OAuth2 CLI and MCP server for the [LinkedIn](https://www.linkedin.com) API.
 ## What It Does
 
 - **Post content** to LinkedIn via the official API
+- **Manage posts** — create, list, update, delete (with polls, drafts, rich media)
+- **Comments & reactions** on posts
+- **Organization management** — lookup, post as org, media uploads as org
+- **Media uploads** — images, videos, documents
 - **OAuth 2.0 authentication** with your own LinkedIn app
 - **Direct token passing** for tokens obtained from other applications
 - **MCP server** for AI assistant integration (Claude, Cursor, etc.)
@@ -36,24 +40,23 @@ npx linkedctl --help
 2. Configure OAuth 2.0 credentials
 3. Authenticate:
     ```sh
-    linkedctl auth login
+    linkedctl auth login --client-id YOUR_CLIENT_ID --client-secret YOUR_CLIENT_SECRET
     ```
 4. Start using:
     ```sh
     linkedctl post "Hello from LinkedCtl!"
     ```
 
+See the [OAuth Setup Guide](https://github.com/alexey-pelykh/linkedctl/blob/main/docs/oauth-setup.md) for detailed step-by-step instructions.
+
 ## MCP Integration
 
-### Claude Code
+### MCP Client Configuration
 
-```sh
-claude mcp add linkedctl -- npx linkedctl mcp
-```
+<details>
+<summary><b>Claude Desktop</b></summary>
 
-### Claude Desktop
-
-Add to `claude_desktop_config.json`:
+Add to your Claude Desktop configuration (`claude_desktop_config.json`):
 
 ```json
 {
@@ -66,9 +69,144 @@ Add to `claude_desktop_config.json`:
 }
 ```
 
+</details>
+
+<details>
+<summary><b>Claude Code</b></summary>
+
+```sh
+claude mcp add linkedctl -- npx linkedctl mcp
+```
+
+</details>
+
+<details>
+<summary><b>Cursor</b></summary>
+
+Add to `.cursor/mcp.json` in your project root:
+
+```json
+{
+    "mcpServers": {
+        "linkedctl": {
+            "command": "npx",
+            "args": ["linkedctl", "mcp"]
+        }
+    }
+}
+```
+
+</details>
+
+<details>
+<summary><b>Windsurf</b></summary>
+
+Add to `~/.codeium/windsurf/mcp_config.json`:
+
+```json
+{
+    "mcpServers": {
+        "linkedctl": {
+            "command": "npx",
+            "args": ["linkedctl", "mcp"]
+        }
+    }
+}
+```
+
+</details>
+
+### Available Tools
+
+| Tool              | Description                                           |
+| ----------------- | ----------------------------------------------------- |
+| `whoami`          | Show the authenticated user's profile                 |
+| `post_create`     | Create a post (text, media, polls, drafts, as org)    |
+| `post_get`        | Get a single post by URN                              |
+| `post_list`       | List posts with pagination                            |
+| `post_update`     | Update a post's commentary                            |
+| `post_delete`     | Delete a post                                         |
+| `comment_create`  | Create a comment on a post (supports `as_org`)        |
+| `comment_list`    | List comments on a post                               |
+| `comment_get`     | Get a single comment by URN                           |
+| `comment_delete`  | Delete a comment                                      |
+| `reaction_create` | React to a post (supports `as_org`)                   |
+| `reaction_list`   | List reactions on a post                              |
+| `reaction_delete` | Remove a reaction (supports `as_org`)                 |
+| `document_upload` | Upload a document (supports `as_org`)                 |
+| `org_list`        | List organizations the authenticated user administers |
+| `org_get`         | Get organization details by ID                        |
+| `org_followers`   | Get follower count for an organization                |
+| `auth_status`     | Show authentication status and token expiry           |
+| `auth_revoke`     | Revoke access token and clear local credentials       |
+
 ## Configuration
 
-### OAuth 2.0 (Recommended)
+### Config File Format
+
+LinkedCtl stores configuration in YAML files. Each file represents a single profile:
+
+```yaml
+api-version: "202601"
+oauth:
+    client-id: "YOUR_CLIENT_ID"
+    client-secret: "YOUR_CLIENT_SECRET"
+    access-token: "YOUR_ACCESS_TOKEN"
+    refresh-token: "YOUR_REFRESH_TOKEN"
+    token-expires-at: "2026-05-03T12:00:00.000Z"
+```
+
+**Available keys:**
+
+| Key                      | Description                           |
+| ------------------------ | ------------------------------------- |
+| `api-version`            | LinkedIn API version (e.g. `202601`)  |
+| `oauth.client-id`        | OAuth 2.0 client ID                   |
+| `oauth.client-secret`    | OAuth 2.0 client secret               |
+| `oauth.access-token`     | OAuth 2.0 access token                |
+| `oauth.refresh-token`    | OAuth 2.0 refresh token               |
+| `oauth.token-expires-at` | Token expiration timestamp (ISO 8601) |
+
+Config files are written with `0600` permissions (owner read/write only).
+
+### File Location and Precedence
+
+Without a profile, LinkedCtl searches for config files in this order:
+
+1. `.linkedctl.yaml` in the current working directory
+2. `~/.linkedctl.yaml` in the home directory
+
+The first file found is used. When writing (e.g. after `auth login`), LinkedCtl writes to the CWD file if it exists, otherwise to the home directory file.
+
+### Profiles
+
+Profiles let you manage multiple LinkedIn accounts or configurations. Each profile is stored as a separate YAML file under `~/.linkedctl/`:
+
+| Profile    | Config file path             |
+| ---------- | ---------------------------- |
+| (default)  | `~/.linkedctl.yaml`          |
+| `work`     | `~/.linkedctl/work.yaml`     |
+| `personal` | `~/.linkedctl/personal.yaml` |
+
+Use the `--profile` flag with any command:
+
+```sh
+linkedctl --profile work auth login --client-id ID --client-secret SECRET
+linkedctl --profile work post "Hello from my work account!"
+```
+
+Manage profiles with the `profile` command:
+
+```sh
+linkedctl profile create work --access-token YOUR_TOKEN --api-version 202601
+linkedctl profile list
+linkedctl profile show work
+linkedctl profile delete work
+```
+
+### Authentication Methods
+
+#### OAuth 2.0 (Recommended)
 
 LinkedCtl supports OAuth 2.0 with your own LinkedIn Developer App:
 
@@ -76,7 +214,7 @@ LinkedCtl supports OAuth 2.0 with your own LinkedIn Developer App:
 linkedctl auth login --client-id YOUR_CLIENT_ID --client-secret YOUR_CLIENT_SECRET
 ```
 
-### Direct Token
+#### Direct Token
 
 If you already have an access token from another application:
 
@@ -86,11 +224,188 @@ linkedctl auth token --access-token YOUR_TOKEN
 
 ### Environment Variables
 
-| Variable                  | Description                               |
-| ------------------------- | ----------------------------------------- |
-| `LINKEDCTL_CLIENT_ID`     | LinkedIn OAuth 2.0 client ID              |
-| `LINKEDCTL_CLIENT_SECRET` | LinkedIn OAuth 2.0 client secret          |
-| `LINKEDCTL_ACCESS_TOKEN`  | Direct access token (bypasses OAuth flow) |
+| Variable                  | Description                                              |
+| ------------------------- | -------------------------------------------------------- |
+| `LINKEDCTL_CLIENT_ID`     | LinkedIn OAuth 2.0 client ID                             |
+| `LINKEDCTL_CLIENT_SECRET` | LinkedIn OAuth 2.0 client secret                         |
+| `LINKEDCTL_ACCESS_TOKEN`  | Direct access token (bypasses OAuth flow)                |
+| `LINKEDCTL_API_VERSION`   | LinkedIn API version string (e.g. `202601`) **required** |
+
+Environment variables take precedence over config file values.
+
+#### Profile-Prefixed Environment Variables
+
+When using a named profile, LinkedCtl also reads profile-prefixed environment variables. The profile name is uppercased with hyphens converted to underscores:
+
+| Profile    | Variable                          |
+| ---------- | --------------------------------- |
+| (default)  | `LINKEDCTL_ACCESS_TOKEN`          |
+| `work`     | `LINKEDCTL_WORK_ACCESS_TOKEN`     |
+| `my-brand` | `LINKEDCTL_MY_BRAND_ACCESS_TOKEN` |
+
+The same pattern applies to `CLIENT_ID`, `CLIENT_SECRET`, and `API_VERSION`.
+
+### Precedence Order
+
+Configuration values are resolved in this order (highest priority first):
+
+1. **Environment variables** (profile-prefixed if a profile is active)
+2. **Config file** (profile-specific file, or CWD/home fallback)
+
+## CLI Reference
+
+### Global Options
+
+| Option             | Description                          |
+| ------------------ | ------------------------------------ |
+| `--profile <name>` | Use a specific configuration profile |
+
+### `auth` -- Manage Authentication
+
+| Command        | Description                                                |
+| -------------- | ---------------------------------------------------------- |
+| `auth login`   | Authenticate via OAuth 2.0 (opens browser)                 |
+| `auth token`   | Store a direct access token                                |
+| `auth status`  | Show authentication status and token expiry                |
+| `auth logout`  | Clear stored credentials from the active profile           |
+| `auth refresh` | Refresh the access token using a stored refresh token      |
+| `auth revoke`  | Revoke the access token server-side and clear local tokens |
+
+**`auth login` options:**
+
+| Option                     | Description                        | Default                          |
+| -------------------------- | ---------------------------------- | -------------------------------- |
+| `--client-id <id>`         | OAuth 2.0 client ID                | from config                      |
+| `--client-secret <secret>` | OAuth 2.0 client secret            | from config                      |
+| `--scope <scopes>`         | OAuth 2.0 scopes (space-separated) | `openid profile w_member_social` |
+
+**`auth token` options:**
+
+| Option                   | Description                      |
+| ------------------------ | -------------------------------- |
+| `--access-token <token>` | Access token to store (required) |
+
+### `post` -- Manage LinkedIn Posts
+
+```sh
+# Shorthand: pass text as an argument
+linkedctl post "Hello from LinkedCtl!"
+
+# Explicit subcommand
+linkedctl post create --text "Hello from LinkedCtl!"
+
+# Pipe content from stdin
+echo "Hello from LinkedCtl!" | linkedctl post create
+```
+
+**`post create` options:**
+
+| Option                       | Description                                      | Default     |
+| ---------------------------- | ------------------------------------------------ | ----------- |
+| `--text <text>`              | Text content of the post                         |             |
+| `--text-file <path>`         | Read text content from a file                    |             |
+| `--visibility <visibility>`  | `PUBLIC` or `CONNECTIONS`                        | `PUBLIC`    |
+| `--image <path>`             | Attach an image                                  |             |
+| `--video <path>`             | Attach a video                                   |             |
+| `--document <path>`          | Attach a document                                |             |
+| `--draft`                    | Save as draft instead of publishing              |             |
+| `--poll-question <q>`        | Create a poll with this question                 |             |
+| `--poll-option <option>`     | Poll option (repeat 2–4 times)                   |             |
+| `--poll-duration <duration>` | `ONE_DAY`, `THREE_DAYS`, `ONE_WEEK`, `TWO_WEEKS` | `TWO_WEEKS` |
+| `--as-org <id>`              | Post as organization (numeric ID, must be admin) |             |
+| `--format <format>`          | Output format (`json`, `table`)                  | auto        |
+
+When no `--text` is provided, text is read from stdin if available.
+
+The `--format` option defaults to `table` in a terminal and `json` when piped.
+
+### `comment` -- Manage Comments
+
+| Command                | Description                |
+| ---------------------- | -------------------------- |
+| `comment create <urn>` | Create a comment on a post |
+| `comment list <urn>`   | List comments on a post    |
+| `comment get <urn>`    | Get a single comment       |
+| `comment delete <urn>` | Delete a comment           |
+
+**`comment create` options:**
+
+| Option          | Description                      |
+| --------------- | -------------------------------- |
+| `--text <text>` | Comment text (required)          |
+| `--as-org <id>` | Act as organization (numeric ID) |
+
+### `reaction` -- Manage Reactions
+
+| Command                 | Description              |
+| ----------------------- | ------------------------ |
+| `reaction create <urn>` | React to a post          |
+| `reaction list <urn>`   | List reactions on a post |
+| `reaction delete <urn>` | Remove your reaction     |
+
+Supported reaction types: `LIKE`, `PRAISE`, `EMPATHY`, `INTEREST`, `APPRECIATION`, `ENTERTAINMENT`.
+
+**`reaction create` / `reaction delete` options:**
+
+| Option          | Description                      |
+| --------------- | -------------------------------- |
+| `--as-org <id>` | Act as organization (numeric ID) |
+
+### `media` -- Upload Media
+
+| Command                        | Description       |
+| ------------------------------ | ----------------- |
+| `media upload-image <path>`    | Upload an image   |
+| `media upload-video <path>`    | Upload a video    |
+| `media upload-document <path>` | Upload a document |
+
+**Common options:**
+
+| Option          | Description                         |
+| --------------- | ----------------------------------- |
+| `--as-org <id>` | Upload as organization (numeric ID) |
+
+### `org` -- Manage Organizations
+
+| Command              | Description                            |
+| -------------------- | -------------------------------------- |
+| `org list`           | List organizations you administer      |
+| `org get <id>`       | Get organization details               |
+| `org followers <id>` | Get follower count for an organization |
+
+**`org list` options:**
+
+| Option            | Description                 | Default |
+| ----------------- | --------------------------- | ------- |
+| `--count <count>` | Number of results (max 100) | 10      |
+| `--start <start>` | Pagination offset           | 0       |
+
+### `profile` -- Manage Configuration Profiles
+
+| Command                 | Description                     |
+| ----------------------- | ------------------------------- |
+| `profile create <name>` | Create a new profile            |
+| `profile list`          | List all profiles               |
+| `profile show <name>`   | Show profile details (redacted) |
+| `profile delete <name>` | Delete a profile                |
+
+**`profile create` options:**
+
+| Option                    | Description                                    |
+| ------------------------- | ---------------------------------------------- |
+| `--access-token <token>`  | OAuth 2.0 access token (required)              |
+| `--api-version <version>` | LinkedIn API version, e.g. `202601` (required) |
+
+### `whoami` -- Show Current User
+
+```sh
+linkedctl whoami
+linkedctl whoami --format json
+```
+
+| Option              | Description                     | Default |
+| ------------------- | ------------------------------- | ------- |
+| `--format <format>` | Output format (`json`, `table`) | auto    |
 
 ## Disclaimer
 

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,27 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    required:
+      - accessToken
+    properties:
+      accessToken:
+        type: string
+        description: LinkedIn OAuth2 access token
+      clientId:
+        type: string
+        description: LinkedIn OAuth2 client ID (optional, for token refresh)
+      clientSecret:
+        type: string
+        description: LinkedIn OAuth2 client secret (optional, for token refresh)
+  commandFunction: |-
+    (config) => ({
+      command: 'npx',
+      args: ['-y', 'linkedctl@latest', 'mcp'],
+      env: {
+        LINKEDCTL_ACCESS_TOKEN: config.accessToken,
+        ...(config.clientId ? { LINKEDCTL_CLIENT_ID: config.clientId } : {}),
+        ...(config.clientSecret ? { LINKEDCTL_CLIENT_SECRET: config.clientSecret } : {})
+      }
+    })


### PR DESCRIPTION
## Summary

- Expand README with v0.3.0/v0.4.0 features: full MCP tool table (19 tools), CLI reference for comment/reaction/media/org commands, post create options (`--as-org`, `--draft`, `--poll-*`, media), MCP client configs (Claude Desktop, Claude Code, Cursor, Windsurf), config file format, profiles, and env vars
- Add `smithery.yaml` for Smithery MCP registry with `linkedctl@latest` default
- Add smithery.yaml version stamping to release workflow (stamps exact version alongside `server.json`)

## Test plan

- [x] `pnpm format:check` passes
- [x] `pnpm build` passes
- [x] Version stamp script tested: `linkedctl@latest` → `linkedctl@0.4.0`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)