### PR TITLE
(feat) add scope column to profile list (#149)

### DIFF
--- a/packages/cli/src/commands/profile/list.test.ts
+++ b/packages/cli/src/commands/profile/list.test.ts
@@ -101,6 +101,78 @@ describe("profile list", () => {
     expect(output).toEqual([{ name: "test", status: "not configured" }]);
   });
 
+  it("shows scope in json output when configured", async () => {
+    const futureExp = Math.floor(Date.now() / 1000) + 86400 * 30;
+    const token = buildJwt({ exp: futureExp });
+
+    vi.mocked(readdir).mockResolvedValue(["work.yaml"] as unknown as Awaited<ReturnType<typeof readdir>>);
+    vi.spyOn(core, "loadConfigFile").mockResolvedValue({
+      raw: { oauth: { "access-token": token, scope: "r_liteprofile w_member_social" } },
+      path: "/mock/home/.linkedctl/work.yaml",
+    });
+
+    const cmd = listCommand();
+    await cmd.parseAsync(["--format", "json"], { from: "user" });
+
+    const output = JSON.parse(consoleSpy.mock.calls[0]?.[0] as string) as Record<string, unknown>[];
+    expect(output).toEqual([
+      expect.objectContaining({
+        name: "work",
+        status: "authenticated",
+        scope: "r_liteprofile w_member_social",
+      }),
+    ]);
+  });
+
+  it("omits scope from json output when not configured", async () => {
+    vi.mocked(readdir).mockResolvedValue(["dev.yaml"] as unknown as Awaited<ReturnType<typeof readdir>>);
+    vi.spyOn(core, "loadConfigFile").mockResolvedValue({
+      raw: { oauth: { "access-token": "AQVh7cKZopaque" } },
+      path: "/mock/home/.linkedctl/dev.yaml",
+    });
+
+    const cmd = listCommand();
+    await cmd.parseAsync(["--format", "json"], { from: "user" });
+
+    const output = JSON.parse(consoleSpy.mock.calls[0]?.[0] as string) as Record<string, unknown>[];
+    expect(output[0]).not.toHaveProperty("scope");
+  });
+
+  it("shows scope column with dash in table when scope not configured", async () => {
+    vi.mocked(readdir).mockResolvedValue(["dev.yaml"] as unknown as Awaited<ReturnType<typeof readdir>>);
+    vi.spyOn(core, "loadConfigFile").mockResolvedValue({
+      raw: { oauth: { "access-token": "AQVh7cKZopaque" } },
+      path: "/mock/home/.linkedctl/dev.yaml",
+    });
+
+    const cmd = listCommand();
+    await cmd.parseAsync(["--format", "table"], { from: "user" });
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    const lines = output.split("\n");
+    expect(lines[0]).toMatch(/scope/);
+    expect(lines[2]).toMatch(/-/);
+  });
+
+  it("shows scope value in table when configured", async () => {
+    const futureExp = Math.floor(Date.now() / 1000) + 86400 * 10;
+    const token = buildJwt({ exp: futureExp });
+
+    vi.mocked(readdir).mockResolvedValue(["work.yaml"] as unknown as Awaited<ReturnType<typeof readdir>>);
+    vi.spyOn(core, "loadConfigFile").mockResolvedValue({
+      raw: { oauth: { "access-token": token, scope: "r_liteprofile" } },
+      path: "/mock/home/.linkedctl/work.yaml",
+    });
+
+    const cmd = listCommand();
+    await cmd.parseAsync(["--format", "table"], { from: "user" });
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    const lines = output.split("\n");
+    expect(lines[0]).toMatch(/scope/);
+    expect(lines[2]).toMatch(/r_liteprofile/);
+  });
+
   it("shows not configured when access token is missing", async () => {
     vi.mocked(readdir).mockResolvedValue(["work.yaml"] as unknown as Awaited<ReturnType<typeof readdir>>);
     vi.spyOn(core, "loadConfigFile").mockResolvedValue({
@@ -228,12 +300,12 @@ describe("profile list", () => {
     const output = consoleSpy.mock.calls[0]?.[0] as string;
     const lines = output.split("\n");
     // Header line should have column names
-    expect(lines[0]).toMatch(/name\s+status\s+expires/);
+    expect(lines[0]).toMatch(/name\s+status\s+scope\s+expires/);
     // Separator line
     expect(lines[1]).toMatch(/─+/);
     // Data lines
-    expect(lines[2]).toMatch(/personal\s+authenticated\s+in \d+d/);
-    expect(lines[3]).toMatch(/test\s+not configured/);
+    expect(lines[2]).toMatch(/personal\s+authenticated\s+-\s+in \d+d/);
+    expect(lines[3]).toMatch(/test\s+not configured\s+-/);
   });
 
   it("excludes expiresAt from table format", async () => {

--- a/packages/cli/src/commands/profile/list.ts
+++ b/packages/cli/src/commands/profile/list.ts
@@ -12,6 +12,7 @@ import { resolveFormat, formatOutput } from "../../output/index.js";
 interface ProfileInfo {
   name: string;
   status: "authenticated" | "expired" | "not configured";
+  scope?: string | undefined;
   expiresAt?: string | undefined;
   expires?: string | undefined;
 }
@@ -48,21 +49,23 @@ async function getProfileStatus(name: string): Promise<ProfileInfo> {
   }
 
   const { config } = validateConfig(raw);
+  const scope = config.oauth?.scope;
 
   if (config.oauth?.accessToken === undefined || config.oauth.accessToken === "") {
-    return { name, status: "not configured" };
+    return { name, status: "not configured", scope };
   }
 
   const expiry = getTokenExpiry(config.oauth.accessToken);
 
   if (expiry === undefined) {
-    return { name, status: "authenticated" };
+    return { name, status: "authenticated", scope };
   }
 
   if (expiry.isExpired) {
     return {
       name,
       status: "expired",
+      scope,
       expiresAt: expiry.expiresAt.toISOString(),
       expires: formatTimeDelta(expiry.expiresAt),
     };
@@ -71,6 +74,7 @@ async function getProfileStatus(name: string): Promise<ProfileInfo> {
   return {
     name,
     status: "authenticated",
+    scope,
     expiresAt: expiry.expiresAt.toISOString(),
     expires: formatTimeDelta(expiry.expiresAt),
   };
@@ -107,7 +111,9 @@ export function listCommand(): Command {
     const format = resolveFormat(opts["format"] as OutputFormat | undefined, process.stdout, globalJson);
 
     const data =
-      format === "json" ? profiles : profiles.map((p) => ({ name: p.name, status: p.status, expires: p.expires }));
+      format === "json"
+        ? profiles
+        : profiles.map((p) => ({ name: p.name, status: p.status, scope: p.scope ?? "-", expires: p.expires }));
 
     console.log(formatOutput(data, format));
   });


### PR DESCRIPTION
## Summary

- Extends `profile list` to show a **SCOPE** column displaying each profile's configured `oauth.scope` value
- Table format shows `-` when no scope is configured
- JSON format includes the `scope` field when present (omitted when unconfigured)

Closes #149

## Test plan

- [x] Added test: scope shown in JSON output when configured
- [x] Added test: scope omitted from JSON when not configured
- [x] Added test: scope column with `-` in table when not configured
- [x] Added test: scope value shown in table when configured
- [x] Updated existing table format test to expect scope column
- [x] All 346 CLI tests pass
- [x] Typecheck, lint, format all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)