### PR TITLE
(feat) add organization share statistics API client

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -127,3 +127,12 @@ export type {
   MetricResult,
   PostAnalytics,
 } from "./member-stats/types.js";
+export { getOrgStats } from "./org-stats/org-stats-service.js";
+export type { GetOrgStatsOptions } from "./org-stats/org-stats-service.js";
+export type {
+  OrgStatsTimeGranularity,
+  TimeRange,
+  ShareStatistics,
+  OrgStatsElement,
+  OrgStatsResponse,
+} from "./org-stats/types.js";

--- a/packages/core/src/org-stats/org-stats-service.test.ts
+++ b/packages/core/src/org-stats/org-stats-service.test.ts
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, expect, it, vi } from "vitest";
+import { getOrgStats } from "./org-stats-service.js";
+import type { LinkedInClient } from "../http/linkedin-client.js";
+import type { OrgStatsResponse } from "./types.js";
+
+function mockClient(): LinkedInClient {
+  return {
+    request: vi.fn(),
+  } as unknown as LinkedInClient;
+}
+
+const LIFETIME_RESPONSE: OrgStatsResponse = {
+  elements: [
+    {
+      organizationalEntity: "urn:li:organization:123",
+      totalShareStatistics: {
+        clickCount: 100,
+        commentCount: 25,
+        engagement: 0.05,
+        impressionCount: 1000,
+        likeCount: 50,
+        shareCount: 10,
+        uniqueImpressionsCount: 800,
+      },
+    },
+  ],
+  paging: { count: 1, start: 0 },
+};
+
+describe("getOrgStats", () => {
+  it("fetches lifetime stats with organization URN", async () => {
+    const client = mockClient();
+    vi.mocked(client.request).mockResolvedValue(LIFETIME_RESPONSE);
+
+    const result = await getOrgStats(client, {
+      organizationUrn: "urn:li:organization:123",
+    });
+
+    expect(client.request).toHaveBeenCalledWith(
+      "/rest/organizationalEntityShareStatistics?q=organizationalEntity&organizationalEntity=urn%3Ali%3Aorganization%3A123",
+    );
+    expect(result).toEqual(LIFETIME_RESPONSE);
+  });
+
+  it("includes time interval parameters for time-bound queries", async () => {
+    const client = mockClient();
+    vi.mocked(client.request).mockResolvedValue(LIFETIME_RESPONSE);
+
+    await getOrgStats(client, {
+      organizationUrn: "urn:li:organization:456",
+      timeGranularity: "MONTH",
+      timeRange: { start: 1704067200000, end: 1706745600000 },
+    });
+
+    expect(client.request).toHaveBeenCalledWith(
+      "/rest/organizationalEntityShareStatistics?q=organizationalEntity&organizationalEntity=urn%3Ali%3Aorganization%3A456&timeIntervals.timeGranularityType=MONTH&timeIntervals.timeRange.start=1704067200000&timeIntervals.timeRange.end=1706745600000",
+    );
+  });
+
+  it("includes time interval parameters for daily granularity", async () => {
+    const client = mockClient();
+    vi.mocked(client.request).mockResolvedValue(LIFETIME_RESPONSE);
+
+    await getOrgStats(client, {
+      organizationUrn: "urn:li:organization:789",
+      timeGranularity: "DAY",
+      timeRange: { start: 1704067200000, end: 1704153600000 },
+    });
+
+    expect(client.request).toHaveBeenCalledWith(
+      "/rest/organizationalEntityShareStatistics?q=organizationalEntity&organizationalEntity=urn%3Ali%3Aorganization%3A789&timeIntervals.timeGranularityType=DAY&timeIntervals.timeRange.start=1704067200000&timeIntervals.timeRange.end=1704153600000",
+    );
+  });
+
+  it("includes share URNs for per-post filtering", async () => {
+    const client = mockClient();
+    vi.mocked(client.request).mockResolvedValue(LIFETIME_RESPONSE);
+
+    await getOrgStats(client, {
+      organizationUrn: "urn:li:organization:123",
+      shares: ["urn:li:share:111"],
+    });
+
+    expect(client.request).toHaveBeenCalledWith(
+      "/rest/organizationalEntityShareStatistics?q=organizationalEntity&organizationalEntity=urn%3Ali%3Aorganization%3A123&shares%5B0%5D=urn%3Ali%3Ashare%3A111",
+    );
+  });
+
+  it("includes multiple share URNs", async () => {
+    const client = mockClient();
+    vi.mocked(client.request).mockResolvedValue(LIFETIME_RESPONSE);
+
+    await getOrgStats(client, {
+      organizationUrn: "urn:li:organization:123",
+      shares: ["urn:li:share:111", "urn:li:share:222"],
+    });
+
+    expect(client.request).toHaveBeenCalledWith(
+      "/rest/organizationalEntityShareStatistics?q=organizationalEntity&organizationalEntity=urn%3Ali%3Aorganization%3A123&shares%5B0%5D=urn%3Ali%3Ashare%3A111&shares%5B1%5D=urn%3Ali%3Ashare%3A222",
+    );
+  });
+
+  it("combines time intervals and share filtering", async () => {
+    const client = mockClient();
+    vi.mocked(client.request).mockResolvedValue(LIFETIME_RESPONSE);
+
+    await getOrgStats(client, {
+      organizationUrn: "urn:li:organization:123",
+      timeGranularity: "DAY",
+      timeRange: { start: 1704067200000, end: 1704153600000 },
+      shares: ["urn:li:share:111"],
+    });
+
+    expect(client.request).toHaveBeenCalledWith(
+      "/rest/organizationalEntityShareStatistics?q=organizationalEntity&organizationalEntity=urn%3Ali%3Aorganization%3A123&timeIntervals.timeGranularityType=DAY&timeIntervals.timeRange.start=1704067200000&timeIntervals.timeRange.end=1704153600000&shares%5B0%5D=urn%3Ali%3Ashare%3A111",
+    );
+  });
+
+  it("ignores timeGranularity when timeRange is not provided", async () => {
+    const client = mockClient();
+    vi.mocked(client.request).mockResolvedValue(LIFETIME_RESPONSE);
+
+    await getOrgStats(client, {
+      organizationUrn: "urn:li:organization:123",
+      timeGranularity: "MONTH",
+    });
+
+    expect(client.request).toHaveBeenCalledWith(
+      "/rest/organizationalEntityShareStatistics?q=organizationalEntity&organizationalEntity=urn%3Ali%3Aorganization%3A123",
+    );
+  });
+
+  it("ignores timeRange when timeGranularity is not provided", async () => {
+    const client = mockClient();
+    vi.mocked(client.request).mockResolvedValue(LIFETIME_RESPONSE);
+
+    await getOrgStats(client, {
+      organizationUrn: "urn:li:organization:123",
+      timeRange: { start: 1704067200000, end: 1706745600000 },
+    });
+
+    expect(client.request).toHaveBeenCalledWith(
+      "/rest/organizationalEntityShareStatistics?q=organizationalEntity&organizationalEntity=urn%3Ali%3Aorganization%3A123",
+    );
+  });
+});

--- a/packages/core/src/org-stats/org-stats-service.ts
+++ b/packages/core/src/org-stats/org-stats-service.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { LinkedInClient } from "../http/linkedin-client.js";
+import type { OrgStatsResponse, OrgStatsTimeGranularity, TimeRange } from "./types.js";
+
+/**
+ * Options for fetching organization share statistics.
+ */
+export interface GetOrgStatsOptions {
+  /** Organization URN (e.g. `urn:li:organization:123`). */
+  organizationUrn: string;
+  /** Time granularity for bucketed results. Requires {@link timeRange}. */
+  timeGranularity?: OrgStatsTimeGranularity | undefined;
+  /** Time range to filter statistics. Requires {@link timeGranularity}. */
+  timeRange?: TimeRange | undefined;
+  /** Share URNs to filter statistics for specific posts. */
+  shares?: string[] | undefined;
+}
+
+/**
+ * Fetch organization share statistics from the LinkedIn API.
+ *
+ * Returns lifetime aggregate statistics by default. When {@link GetOrgStatsOptions.timeRange}
+ * and {@link GetOrgStatsOptions.timeGranularity} are provided, returns time-bucketed statistics.
+ * When {@link GetOrgStatsOptions.shares} are provided, returns per-share statistics.
+ *
+ * @param client - Authenticated LinkedIn API client.
+ * @param options - Query options for the statistics endpoint.
+ * @returns Organization share statistics response.
+ */
+export async function getOrgStats(client: LinkedInClient, options: GetOrgStatsOptions): Promise<OrgStatsResponse> {
+  const params = new URLSearchParams();
+  params.set("q", "organizationalEntity");
+  params.set("organizationalEntity", options.organizationUrn);
+
+  if (options.timeGranularity !== undefined && options.timeRange !== undefined) {
+    params.set("timeIntervals.timeGranularityType", options.timeGranularity);
+    params.set("timeIntervals.timeRange.start", String(options.timeRange.start));
+    params.set("timeIntervals.timeRange.end", String(options.timeRange.end));
+  }
+
+  if (options.shares !== undefined) {
+    for (const [i, share] of options.shares.entries()) {
+      params.set(`shares[${String(i)}]`, share);
+    }
+  }
+
+  return client.request<OrgStatsResponse>(`/rest/organizationalEntityShareStatistics?${params.toString()}`);
+}

--- a/packages/core/src/org-stats/types.ts
+++ b/packages/core/src/org-stats/types.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * Time granularity for organization share statistics time intervals.
+ */
+export type OrgStatsTimeGranularity = "DAY" | "MONTH";
+
+/**
+ * A time range with start and end timestamps (milliseconds since epoch).
+ */
+export interface TimeRange {
+  /** Start of the time range (ms since epoch, inclusive). */
+  start: number;
+  /** End of the time range (ms since epoch, exclusive). */
+  end: number;
+}
+
+/**
+ * Aggregate share statistics for an organization or a specific share.
+ */
+export interface ShareStatistics {
+  /** Number of clicks on the share. */
+  clickCount: number;
+  /** Number of comments on the share. */
+  commentCount: number;
+  /** Engagement rate (interactions / impressions). */
+  engagement: number;
+  /** Number of impressions (total views). */
+  impressionCount: number;
+  /** Number of likes (reactions) on the share. */
+  likeCount: number;
+  /** Number of times the share was re-shared. */
+  shareCount: number;
+  /** Number of unique impressions (unique viewers). */
+  uniqueImpressionsCount: number;
+}
+
+/**
+ * A single element in the organization share statistics response.
+ */
+export interface OrgStatsElement {
+  /** Organization URN (e.g. `urn:li:organization:123`). */
+  organizationalEntity: string;
+  /** Share URN, present when filtering by specific share. */
+  share?: string | undefined;
+  /** Aggregate share statistics. */
+  totalShareStatistics: ShareStatistics;
+  /** Time range for this statistics bucket (present for time-bound queries). */
+  timeRange?: TimeRange | undefined;
+}
+
+/**
+ * Response from the organizationalEntityShareStatistics endpoint.
+ */
+export interface OrgStatsResponse {
+  /** Array of statistics elements. */
+  elements: OrgStatsElement[];
+  /** Paging metadata. */
+  paging: {
+    /** Number of results returned. */
+    count: number;
+    /** Starting index. */
+    start: number;
+    /** Total number of results available. */
+    total?: number | undefined;
+  };
+}


### PR DESCRIPTION
## Summary

- Add `getOrgStats()` function to `@linkedctl/core` for the LinkedIn `organizationalEntityShareStatistics` endpoint
- Support lifetime stats, time-bound filtering (DAY/MONTH granularity), and per-share filtering
- Export all new types (`OrgStatsTimeGranularity`, `TimeRange`, `ShareStatistics`, `OrgStatsElement`, `OrgStatsResponse`, `GetOrgStatsOptions`) from the core package

## Test plan

- [x] 8 unit tests covering lifetime stats, time-bound DAY/MONTH, single/multiple share filtering, combined params, and partial-option edge cases
- [x] All 646 existing tests pass
- [x] Build, typecheck, lint, format checks all pass

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)