### PR TITLE
(feat) add member stats API client

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -112,3 +112,18 @@ export type {
   DeleteCommentOptions,
 } from "./comments/comments-service.js";
 export type { Comment } from "./comments/types.js";
+export { getPostAnalytics, getMemberAnalytics } from "./member-stats/member-stats-service.js";
+export type { GetPostAnalyticsOptions, GetMemberAnalyticsOptions } from "./member-stats/member-stats-service.js";
+export { ANALYTICS_METRIC_TYPES } from "./member-stats/types.js";
+export type {
+  AnalyticsMetricType,
+  AnalyticsAggregation,
+  AnalyticsDate,
+  AnalyticsDateRange,
+  AnalyticsDataPoint,
+  MetricSuccess,
+  MetricUnavailable,
+  MetricExcluded,
+  MetricResult,
+  PostAnalytics,
+} from "./member-stats/types.js";

--- a/packages/core/src/member-stats/member-stats-service.test.ts
+++ b/packages/core/src/member-stats/member-stats-service.test.ts
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, expect, it, vi } from "vitest";
+import { LinkedInRateLimitError } from "../http/errors.js";
+import type { LinkedInClient } from "../http/linkedin-client.js";
+import { getPostAnalytics, getMemberAnalytics } from "./member-stats-service.js";
+import type {
+  MemberCreatorPostAnalyticsApiResponse,
+  MetricExcluded,
+  MetricSuccess,
+  MetricUnavailable,
+} from "./types.js";
+
+const METRIC_TYPE_KEY = "com.linkedin.adsexternalapi.memberanalytics.v1.CreatorPostAnalyticsMetricTypeV1";
+
+function mockClient(): LinkedInClient {
+  return {
+    request: vi.fn(),
+  } as unknown as LinkedInClient;
+}
+
+function apiResponse(count: number, metricType: string): MemberCreatorPostAnalyticsApiResponse {
+  return {
+    elements: [
+      {
+        count,
+        metricType: { [METRIC_TYPE_KEY]: metricType },
+      },
+    ],
+    paging: { count: 10, start: 0, links: [] },
+  };
+}
+
+function apiResponseWithDateRange(
+  count: number,
+  metricType: string,
+  start: { year: number; month: number; day: number },
+  end: { year: number; month: number; day: number },
+): MemberCreatorPostAnalyticsApiResponse {
+  return {
+    elements: [
+      {
+        count,
+        metricType: { [METRIC_TYPE_KEY]: metricType },
+        dateRange: { start, end },
+      },
+    ],
+    paging: { count: 10, start: 0, links: [] },
+  };
+}
+
+function mockAllMetricsSuccess(client: LinkedInClient): void {
+  const request = vi.mocked(client.request);
+  request.mockResolvedValueOnce(apiResponse(100, "IMPRESSION"));
+  request.mockResolvedValueOnce(apiResponse(80, "MEMBERS_REACHED"));
+  request.mockResolvedValueOnce(apiResponse(25, "REACTION"));
+  request.mockResolvedValueOnce(apiResponse(10, "COMMENT"));
+  request.mockResolvedValueOnce(apiResponse(5, "RESHARE"));
+}
+
+describe("getPostAnalytics", () => {
+  it("fetches all 5 metrics with TOTAL aggregation by default", async () => {
+    const client = mockClient();
+    mockAllMetricsSuccess(client);
+
+    const result = await getPostAnalytics(client, { postUrn: "urn:li:share:123" });
+
+    expect(client.request).toHaveBeenCalledTimes(5);
+    expect(client.request).toHaveBeenNthCalledWith(
+      1,
+      "/rest/memberCreatorPostAnalytics?q=entity&queryType=IMPRESSION&aggregation=TOTAL&entity=(share:urn%3Ali%3Ashare%3A123)",
+    );
+    expect(client.request).toHaveBeenNthCalledWith(
+      2,
+      "/rest/memberCreatorPostAnalytics?q=entity&queryType=MEMBERS_REACHED&aggregation=TOTAL&entity=(share:urn%3Ali%3Ashare%3A123)",
+    );
+    expect(client.request).toHaveBeenNthCalledWith(
+      3,
+      "/rest/memberCreatorPostAnalytics?q=entity&queryType=REACTION&aggregation=TOTAL&entity=(share:urn%3Ali%3Ashare%3A123)",
+    );
+    expect(client.request).toHaveBeenNthCalledWith(
+      4,
+      "/rest/memberCreatorPostAnalytics?q=entity&queryType=COMMENT&aggregation=TOTAL&entity=(share:urn%3Ali%3Ashare%3A123)",
+    );
+    expect(client.request).toHaveBeenNthCalledWith(
+      5,
+      "/rest/memberCreatorPostAnalytics?q=entity&queryType=RESHARE&aggregation=TOTAL&entity=(share:urn%3Ali%3Ashare%3A123)",
+    );
+
+    expect((result.impressions as MetricSuccess).status).toBe("success");
+    expect((result.impressions as MetricSuccess).dataPoints).toEqual([{ count: 100 }]);
+    expect((result.membersReached as MetricSuccess).dataPoints).toEqual([{ count: 80 }]);
+    expect((result.reactions as MetricSuccess).dataPoints).toEqual([{ count: 25 }]);
+    expect((result.comments as MetricSuccess).dataPoints).toEqual([{ count: 10 }]);
+    expect((result.reshares as MetricSuccess).dataPoints).toEqual([{ count: 5 }]);
+  });
+
+  it("encodes ugcPost URNs with ugc prefix", async () => {
+    const client = mockClient();
+    mockAllMetricsSuccess(client);
+
+    await getPostAnalytics(client, { postUrn: "urn:li:ugcPost:456" });
+
+    expect(client.request).toHaveBeenNthCalledWith(
+      1,
+      "/rest/memberCreatorPostAnalytics?q=entity&queryType=IMPRESSION&aggregation=TOTAL&entity=(ugc:urn%3Ali%3AugcPost%3A456)",
+    );
+  });
+
+  it("includes dateRange in REST.li record format", async () => {
+    const client = mockClient();
+    mockAllMetricsSuccess(client);
+
+    await getPostAnalytics(client, {
+      postUrn: "urn:li:share:123",
+      dateRange: {
+        start: { year: 2024, month: 5, day: 4 },
+        end: { year: 2024, month: 5, day: 6 },
+      },
+    });
+
+    expect(client.request).toHaveBeenNthCalledWith(
+      1,
+      "/rest/memberCreatorPostAnalytics?q=entity&queryType=IMPRESSION&aggregation=TOTAL&entity=(share:urn%3Ali%3Ashare%3A123)&dateRange=(start:(day:4,month:5,year:2024),end:(day:6,month:5,year:2024))",
+    );
+  });
+
+  it("maps response elements with dateRange to data points", async () => {
+    const client = mockClient();
+    const start = { year: 2024, month: 5, day: 4 };
+    const end = { year: 2024, month: 5, day: 5 };
+    vi.mocked(client.request).mockResolvedValueOnce(apiResponseWithDateRange(10, "IMPRESSION", start, end));
+    vi.mocked(client.request).mockResolvedValueOnce(apiResponse(80, "MEMBERS_REACHED"));
+    vi.mocked(client.request).mockResolvedValueOnce(apiResponse(25, "REACTION"));
+    vi.mocked(client.request).mockResolvedValueOnce(apiResponse(10, "COMMENT"));
+    vi.mocked(client.request).mockResolvedValueOnce(apiResponse(5, "RESHARE"));
+
+    const result = await getPostAnalytics(client, { postUrn: "urn:li:share:123" });
+
+    expect((result.impressions as MetricSuccess).dataPoints).toEqual([{ count: 10, dateRange: { start, end } }]);
+  });
+
+  it("excludes MEMBERS_REACHED and IMPRESSION with DAILY aggregation", async () => {
+    const client = mockClient();
+    // Only 3 calls expected: REACTION, COMMENT, RESHARE
+    vi.mocked(client.request).mockResolvedValueOnce(apiResponse(25, "REACTION"));
+    vi.mocked(client.request).mockResolvedValueOnce(apiResponse(10, "COMMENT"));
+    vi.mocked(client.request).mockResolvedValueOnce(apiResponse(5, "RESHARE"));
+
+    const result = await getPostAnalytics(client, {
+      postUrn: "urn:li:share:123",
+      aggregation: "DAILY",
+    });
+
+    expect(client.request).toHaveBeenCalledTimes(3);
+    expect(result.impressions.status).toBe("excluded");
+    expect((result.impressions as MetricExcluded).reason).toContain("IMPRESSION");
+    expect(result.membersReached.status).toBe("excluded");
+    expect((result.membersReached as MetricExcluded).reason).toContain("MEMBERS_REACHED");
+    expect((result.reactions as MetricSuccess).dataPoints).toEqual([{ count: 25 }]);
+  });
+
+  it("reports failed metric as unavailable on non-429 error", async () => {
+    const client = mockClient();
+    vi.mocked(client.request).mockResolvedValueOnce(apiResponse(100, "IMPRESSION"));
+    vi.mocked(client.request).mockRejectedValueOnce(new Error("LinkedIn API request failed (HTTP 403)"));
+    vi.mocked(client.request).mockResolvedValueOnce(apiResponse(25, "REACTION"));
+    vi.mocked(client.request).mockResolvedValueOnce(apiResponse(10, "COMMENT"));
+    vi.mocked(client.request).mockResolvedValueOnce(apiResponse(5, "RESHARE"));
+
+    const result = await getPostAnalytics(client, { postUrn: "urn:li:share:123" });
+
+    expect(result.impressions.status).toBe("success");
+    expect(result.membersReached.status).toBe("unavailable");
+    expect((result.membersReached as MetricUnavailable).reason).toContain("403");
+    expect(result.reactions.status).toBe("success");
+  });
+
+  it("throws when all metric requests fail", async () => {
+    const client = mockClient();
+    vi.mocked(client.request).mockRejectedValue(new Error("Service unavailable"));
+
+    await expect(getPostAnalytics(client, { postUrn: "urn:li:share:123" })).rejects.toThrow(
+      "All metric requests failed",
+    );
+  });
+
+  it("propagates LinkedInRateLimitError immediately", async () => {
+    const client = mockClient();
+    vi.mocked(client.request).mockResolvedValueOnce(apiResponse(100, "IMPRESSION"));
+    vi.mocked(client.request).mockRejectedValueOnce(new LinkedInRateLimitError("Rate limited", 3));
+
+    await expect(getPostAnalytics(client, { postUrn: "urn:li:share:123" })).rejects.toThrow(LinkedInRateLimitError);
+
+    // Should stop after 2 calls (did not continue to remaining metrics)
+    expect(client.request).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses explicit TOTAL aggregation when specified", async () => {
+    const client = mockClient();
+    mockAllMetricsSuccess(client);
+
+    await getPostAnalytics(client, { postUrn: "urn:li:share:123", aggregation: "TOTAL" });
+
+    expect(client.request).toHaveBeenNthCalledWith(1, expect.stringContaining("aggregation=TOTAL"));
+  });
+});
+
+describe("getMemberAnalytics", () => {
+  it("fetches all 5 metrics with q=me and TOTAL aggregation", async () => {
+    const client = mockClient();
+    mockAllMetricsSuccess(client);
+
+    const result = await getMemberAnalytics(client);
+
+    expect(client.request).toHaveBeenCalledTimes(5);
+    expect(client.request).toHaveBeenNthCalledWith(
+      1,
+      "/rest/memberCreatorPostAnalytics?q=me&queryType=IMPRESSION&aggregation=TOTAL",
+    );
+    expect(client.request).toHaveBeenNthCalledWith(
+      2,
+      "/rest/memberCreatorPostAnalytics?q=me&queryType=MEMBERS_REACHED&aggregation=TOTAL",
+    );
+    expect((result.impressions as MetricSuccess).dataPoints).toEqual([{ count: 100 }]);
+    expect((result.reshares as MetricSuccess).dataPoints).toEqual([{ count: 5 }]);
+  });
+
+  it("includes dateRange parameter for aggregate stats", async () => {
+    const client = mockClient();
+    mockAllMetricsSuccess(client);
+
+    await getMemberAnalytics(client, {
+      dateRange: {
+        start: { year: 2024, month: 1, day: 1 },
+        end: { year: 2024, month: 12, day: 31 },
+      },
+    });
+
+    expect(client.request).toHaveBeenNthCalledWith(
+      1,
+      "/rest/memberCreatorPostAnalytics?q=me&queryType=IMPRESSION&aggregation=TOTAL&dateRange=(start:(day:1,month:1,year:2024),end:(day:31,month:12,year:2024))",
+    );
+  });
+
+  it("excludes MEMBERS_REACHED with DAILY aggregation but keeps IMPRESSION", async () => {
+    const client = mockClient();
+    // 4 calls: IMPRESSION, REACTION, COMMENT, RESHARE (MEMBERS_REACHED excluded)
+    vi.mocked(client.request).mockResolvedValueOnce(apiResponse(100, "IMPRESSION"));
+    vi.mocked(client.request).mockResolvedValueOnce(apiResponse(25, "REACTION"));
+    vi.mocked(client.request).mockResolvedValueOnce(apiResponse(10, "COMMENT"));
+    vi.mocked(client.request).mockResolvedValueOnce(apiResponse(5, "RESHARE"));
+
+    const result = await getMemberAnalytics(client, { aggregation: "DAILY" });
+
+    expect(client.request).toHaveBeenCalledTimes(4);
+    expect(result.impressions.status).toBe("success");
+    expect(result.membersReached.status).toBe("excluded");
+    expect((result.membersReached as MetricExcluded).reason).toContain("MEMBERS_REACHED");
+  });
+
+  it("defaults to TOTAL aggregation when no options provided", async () => {
+    const client = mockClient();
+    mockAllMetricsSuccess(client);
+
+    await getMemberAnalytics(client);
+
+    expect(client.request).toHaveBeenNthCalledWith(1, expect.stringContaining("aggregation=TOTAL"));
+  });
+
+  it("returns lifetime totals when no dateRange is specified", async () => {
+    const client = mockClient();
+    mockAllMetricsSuccess(client);
+
+    await getMemberAnalytics(client);
+
+    // Verify no dateRange parameter in the URL
+    for (let i = 1; i <= 5; i++) {
+      expect(client.request).toHaveBeenNthCalledWith(i, expect.not.stringContaining("dateRange"));
+    }
+  });
+
+  it("throws when all metric requests fail", async () => {
+    const client = mockClient();
+    vi.mocked(client.request).mockRejectedValue(new Error("Internal server error"));
+
+    await expect(getMemberAnalytics(client)).rejects.toThrow("All metric requests failed");
+  });
+
+  it("propagates LinkedInRateLimitError immediately", async () => {
+    const client = mockClient();
+    vi.mocked(client.request).mockRejectedValueOnce(new LinkedInRateLimitError("Rate limited", 3));
+
+    await expect(getMemberAnalytics(client)).rejects.toThrow(LinkedInRateLimitError);
+    expect(client.request).toHaveBeenCalledTimes(1);
+  });
+
+  it("supports dateRange with only start date", async () => {
+    const client = mockClient();
+    mockAllMetricsSuccess(client);
+
+    await getMemberAnalytics(client, {
+      dateRange: { start: { year: 2024, month: 6, day: 1 } },
+    });
+
+    expect(client.request).toHaveBeenNthCalledWith(
+      1,
+      "/rest/memberCreatorPostAnalytics?q=me&queryType=IMPRESSION&aggregation=TOTAL&dateRange=(start:(day:1,month:6,year:2024))",
+    );
+  });
+});

--- a/packages/core/src/member-stats/member-stats-service.ts
+++ b/packages/core/src/member-stats/member-stats-service.ts
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { LinkedInRateLimitError } from "../http/errors.js";
+import type { LinkedInClient } from "../http/linkedin-client.js";
+import type {
+  AnalyticsAggregation,
+  AnalyticsDataPoint,
+  AnalyticsDateRange,
+  AnalyticsMetricType,
+  MemberCreatorPostAnalyticsApiElement,
+  MemberCreatorPostAnalyticsApiResponse,
+  MetricResult,
+  PostAnalytics,
+} from "./types.js";
+import { ANALYTICS_METRIC_TYPES } from "./types.js";
+
+/**
+ * Options for fetching analytics for a single post.
+ */
+export interface GetPostAnalyticsOptions {
+  /** Post URN (e.g. `urn:li:share:123` or `urn:li:ugcPost:123`). */
+  postUrn: string;
+  /** Aggregation mode. Defaults to `"TOTAL"`. */
+  aggregation?: AnalyticsAggregation | undefined;
+  /** Optional date range filter. If omitted, lifetime stats are returned. */
+  dateRange?: AnalyticsDateRange | undefined;
+}
+
+/**
+ * Options for fetching aggregated analytics across all member posts.
+ */
+export interface GetMemberAnalyticsOptions {
+  /** Aggregation mode. Defaults to `"TOTAL"`. */
+  aggregation?: AnalyticsAggregation | undefined;
+  /** Optional date range filter. If omitted, lifetime stats are returned. */
+  dateRange?: AnalyticsDateRange | undefined;
+}
+
+/**
+ * Fetch analytics for a single post across all 5 metric types.
+ *
+ * Calls are made serially to avoid thundering herd on rate limits.
+ * Partial failures are tolerated: successful metrics are returned
+ * alongside failed ones marked as unavailable.
+ *
+ * @throws {LinkedInRateLimitError} If rate limiting persists after retries.
+ * @throws {Error} If all metric requests fail.
+ */
+export async function getPostAnalytics(
+  client: LinkedInClient,
+  options: GetPostAnalyticsOptions,
+): Promise<PostAnalytics> {
+  const aggregation = options.aggregation ?? "TOTAL";
+  return fetchAllMetrics(client, "entity", aggregation, options.dateRange, options.postUrn);
+}
+
+/**
+ * Fetch aggregated analytics across all member posts for all 5 metric types.
+ *
+ * Calls are made serially to avoid thundering herd on rate limits.
+ * Partial failures are tolerated: successful metrics are returned
+ * alongside failed ones marked as unavailable.
+ *
+ * @throws {LinkedInRateLimitError} If rate limiting persists after retries.
+ * @throws {Error} If all metric requests fail.
+ */
+export async function getMemberAnalytics(
+  client: LinkedInClient,
+  options?: GetMemberAnalyticsOptions,
+): Promise<PostAnalytics> {
+  const aggregation = options?.aggregation ?? "TOTAL";
+  return fetchAllMetrics(client, "me", aggregation, options?.dateRange);
+}
+
+/**
+ * Serial fan-out across all metric types with partial failure handling.
+ */
+async function fetchAllMetrics(
+  client: LinkedInClient,
+  finder: "entity" | "me",
+  aggregation: AnalyticsAggregation,
+  dateRange?: AnalyticsDateRange,
+  postUrn?: string,
+): Promise<PostAnalytics> {
+  const results = new Map<AnalyticsMetricType, MetricResult>();
+
+  for (const metricType of ANALYTICS_METRIC_TYPES) {
+    // MEMBERS_REACHED + DAILY is not supported by the API
+    if (metricType === "MEMBERS_REACHED" && aggregation === "DAILY") {
+      results.set(metricType, {
+        status: "excluded",
+        reason: "MEMBERS_REACHED with DAILY aggregation is not supported by the LinkedIn API",
+      });
+      continue;
+    }
+
+    // IMPRESSION + DAILY is not supported for single post analytics (q=entity)
+    if (metricType === "IMPRESSION" && aggregation === "DAILY" && finder === "entity") {
+      results.set(metricType, {
+        status: "excluded",
+        reason: "IMPRESSION with DAILY aggregation is not supported for single post analytics",
+      });
+      continue;
+    }
+
+    try {
+      const url = buildMetricUrl(finder, metricType, aggregation, dateRange, postUrn);
+      const response = await client.request<MemberCreatorPostAnalyticsApiResponse>(url);
+      results.set(metricType, {
+        status: "success",
+        dataPoints: response.elements.map(mapDataPoint),
+      });
+    } catch (error: unknown) {
+      // Rate limit errors indicate a systemic issue; stop execution and propagate.
+      if (error instanceof LinkedInRateLimitError) {
+        throw error;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      results.set(metricType, {
+        status: "unavailable",
+        reason: message,
+      });
+    }
+  }
+
+  // If no metrics succeeded and at least one was attempted (unavailable), throw.
+  const hasSuccess = ANALYTICS_METRIC_TYPES.some((m) => results.get(m)?.status === "success");
+  const hasUnavailable = ANALYTICS_METRIC_TYPES.some((m) => results.get(m)?.status === "unavailable");
+  if (!hasSuccess && hasUnavailable) {
+    throw new Error("All metric requests failed");
+  }
+
+  return {
+    impressions: getMetricResult(results, "IMPRESSION"),
+    membersReached: getMetricResult(results, "MEMBERS_REACHED"),
+    reactions: getMetricResult(results, "REACTION"),
+    comments: getMetricResult(results, "COMMENT"),
+    reshares: getMetricResult(results, "RESHARE"),
+  };
+}
+
+function getMetricResult(results: Map<AnalyticsMetricType, MetricResult>, key: AnalyticsMetricType): MetricResult {
+  const result = results.get(key);
+  if (result === undefined) {
+    throw new Error(`Missing metric result for ${key}`);
+  }
+  return result;
+}
+
+/**
+ * Build the request URL for a single metric query.
+ */
+function buildMetricUrl(
+  finder: "entity" | "me",
+  queryType: AnalyticsMetricType,
+  aggregation: AnalyticsAggregation,
+  dateRange?: AnalyticsDateRange,
+  postUrn?: string,
+): string {
+  const parts = [`q=${finder}`, `queryType=${queryType}`, `aggregation=${aggregation}`];
+
+  if (finder === "entity" && postUrn !== undefined) {
+    parts.push(`entity=${encodeEntityUrn(postUrn)}`);
+  }
+
+  if (dateRange !== undefined) {
+    parts.push(`dateRange=${encodeDateRange(dateRange)}`);
+  }
+
+  return `/rest/memberCreatorPostAnalytics?${parts.join("&")}`;
+}
+
+/**
+ * Encode a post URN into REST.li compound key format for the entity parameter.
+ *
+ * - `urn:li:share:123` → `(share:urn%3Ali%3Ashare%3A123)`
+ * - `urn:li:ugcPost:123` → `(ugc:urn%3Ali%3AugcPost%3A123)`
+ */
+function encodeEntityUrn(urn: string): string {
+  const encodedUrn = urn.replaceAll(":", "%3A");
+  if (urn.startsWith("urn:li:ugcPost:")) {
+    return `(ugc:${encodedUrn})`;
+  }
+  return `(share:${encodedUrn})`;
+}
+
+/**
+ * Encode a date range into REST.li record literal format.
+ *
+ * Example: `(start:(day:4,month:5,year:2024),end:(day:6,month:5,year:2024))`
+ */
+function encodeDateRange(dateRange: AnalyticsDateRange): string {
+  const parts: string[] = [];
+  if (dateRange.start !== undefined) {
+    parts.push(
+      `start:(day:${String(dateRange.start.day)},month:${String(dateRange.start.month)},year:${String(dateRange.start.year)})`,
+    );
+  }
+  if (dateRange.end !== undefined) {
+    parts.push(
+      `end:(day:${String(dateRange.end.day)},month:${String(dateRange.end.month)},year:${String(dateRange.end.year)})`,
+    );
+  }
+  return `(${parts.join(",")})`;
+}
+
+/**
+ * Map an API response element to a public data point.
+ */
+function mapDataPoint(element: MemberCreatorPostAnalyticsApiElement): AnalyticsDataPoint {
+  const dataPoint: AnalyticsDataPoint = {
+    count: element.count,
+  };
+  if (element.dateRange !== undefined) {
+    dataPoint.dateRange = {
+      start: element.dateRange.start,
+      end: element.dateRange.end,
+    };
+  }
+  return dataPoint;
+}

--- a/packages/core/src/member-stats/types.ts
+++ b/packages/core/src/member-stats/types.ts
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * Metric types available for the memberCreatorPostAnalytics endpoint.
+ */
+export type AnalyticsMetricType = "IMPRESSION" | "MEMBERS_REACHED" | "REACTION" | "COMMENT" | "RESHARE";
+
+/**
+ * All available analytics metric types.
+ */
+export const ANALYTICS_METRIC_TYPES: readonly AnalyticsMetricType[] = [
+  "IMPRESSION",
+  "MEMBERS_REACHED",
+  "REACTION",
+  "COMMENT",
+  "RESHARE",
+] as const;
+
+/**
+ * Aggregation mode for analytics queries.
+ */
+export type AnalyticsAggregation = "DAILY" | "TOTAL";
+
+/**
+ * A calendar date used in analytics date ranges.
+ */
+export interface AnalyticsDate {
+  year: number;
+  month: number;
+  day: number;
+}
+
+/**
+ * A date range for filtering analytics data.
+ * Start is inclusive, end is exclusive.
+ */
+export interface AnalyticsDateRange {
+  /** Inclusive start date. */
+  start?: AnalyticsDate | undefined;
+  /** Exclusive end date. */
+  end?: AnalyticsDate | undefined;
+}
+
+/**
+ * A single analytics data point returned by the API.
+ */
+export interface AnalyticsDataPoint {
+  /** The metric count value. */
+  count: number;
+  /** The date range this data point covers. */
+  dateRange?: AnalyticsDateRange | undefined;
+}
+
+/**
+ * A metric that was successfully fetched.
+ */
+export interface MetricSuccess {
+  status: "success";
+  /** One or more data points for this metric. */
+  dataPoints: AnalyticsDataPoint[];
+}
+
+/**
+ * A metric that failed to fetch due to an API error.
+ */
+export interface MetricUnavailable {
+  status: "unavailable";
+  /** Description of why the metric is unavailable. */
+  reason: string;
+}
+
+/**
+ * A metric that was excluded because the requested combination is not supported.
+ */
+export interface MetricExcluded {
+  status: "excluded";
+  /** Description of why the metric was excluded. */
+  reason: string;
+}
+
+/**
+ * The result of fetching a single metric type.
+ */
+export type MetricResult = MetricSuccess | MetricUnavailable | MetricExcluded;
+
+/**
+ * Unified analytics results across all 5 metric types.
+ */
+export interface PostAnalytics {
+  impressions: MetricResult;
+  membersReached: MetricResult;
+  reactions: MetricResult;
+  comments: MetricResult;
+  reshares: MetricResult;
+}
+
+/**
+ * Internal API response element from the memberCreatorPostAnalytics endpoint.
+ * @internal
+ */
+export interface MemberCreatorPostAnalyticsApiElement {
+  count: number;
+  metricType: {
+    "com.linkedin.adsexternalapi.memberanalytics.v1.CreatorPostAnalyticsMetricTypeV1": string;
+  };
+  targetEntity?: Record<string, string> | undefined;
+  dateRange?:
+    | {
+        start: AnalyticsDate;
+        end: AnalyticsDate;
+      }
+    | undefined;
+}
+
+/**
+ * Internal API response from the memberCreatorPostAnalytics endpoint.
+ * @internal
+ */
+export interface MemberCreatorPostAnalyticsApiResponse {
+  elements: MemberCreatorPostAnalyticsApiElement[];
+  paging: {
+    count: number;
+    start: number;
+    links: unknown[];
+  };
+}


### PR DESCRIPTION
## Summary

- Implement `memberCreatorPostAnalytics` API integration in `@linkedctl/core` with two service functions: `getPostAnalytics` (per-post, `q=entity`) and `getMemberAnalytics` (aggregated, `q=me`)
- Serial 5-metric fan-out (IMPRESSION, MEMBERS_REACHED, REACTION, COMMENT, RESHARE) with partial failure tolerance and rate limit propagation
- Auto-excludes unsupported combinations (MEMBERS_REACHED+DAILY, IMPRESSION+DAILY for per-post) and reports them as excluded metrics

## Test plan

- [x] 17 unit tests covering all acceptance criteria:
  - All 5 metrics fetched with correct REST.li entity encoding (share and ugcPost URN formats)
  - Date range encoding in REST.li record literal format
  - Partial failure: non-429 errors marked as unavailable, remaining metrics succeed
  - All-fail case: throws error (not empty stats)
  - Rate limit (429) propagation: stops serial execution immediately
  - MEMBERS_REACHED+DAILY excluded for both finders; IMPRESSION+DAILY excluded for entity only
  - Lifetime totals (no dateRange) and date-filtered queries
- [x] All existing tests pass (236 core, 342 cli, 77 mcp)
- [x] Typecheck, lint, and format checks pass

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)