### PR TITLE
(feat) auth product selection and scope-mismatch errors

### DIFF
--- a/packages/cli/src/commands/auth/setup.test.ts
+++ b/packages/cli/src/commands/auth/setup.test.ts
@@ -53,6 +53,10 @@ function mockReadline(answers: string[]) {
   return { closeFn };
 }
 
+// Interactive question order:
+//   [0] logo? [1] client-id [2] client-secret
+//   [3] sign-in? [4] share? [5] community-management? [6] pkce?
+
 describe("auth setup", () => {
   let saveOAuthClientCredentialsSpy: ReturnType<typeof vi.spyOn>;
   let saveOAuthScopeSpy: ReturnType<typeof vi.spyOn>;
@@ -74,8 +78,9 @@ describe("auth setup", () => {
     vi.restoreAllMocks();
   });
 
-  it("saves credentials and scope with both products enabled", () => {
-    mockReadline(["n", "my-client-id", "my-client-secret", "y", "y", "n"]);
+  it("saves credentials and scope with Sign In and Share enabled", () => {
+    // logo=n, id, secret, signIn=y, share=y, community=n, pkce=n
+    mockReadline(["n", "my-client-id", "my-client-secret", "y", "y", "n", "n"]);
 
     const program = wrapInProgram(setupCommand());
     return program.parseAsync(["auth", "setup"], { from: "user" }).then(() => {
@@ -88,7 +93,8 @@ describe("auth setup", () => {
   });
 
   it("trims whitespace from input", () => {
-    mockReadline(["n", "  my-client-id  ", "  my-client-secret  ", "y", "n", "n"]);
+    // logo=n, id (padded), secret (padded), signIn=y, share=n, community=n, pkce=n
+    mockReadline(["n", "  my-client-id  ", "  my-client-secret  ", "y", "n", "n", "n"]);
 
     const program = wrapInProgram(setupCommand());
     return program.parseAsync(["auth", "setup"], { from: "user" }).then(() => {
@@ -116,7 +122,8 @@ describe("auth setup", () => {
   });
 
   it("throws when no products are selected", async () => {
-    mockReadline(["n", "my-client-id", "my-client-secret", "n", "n"]);
+    // logo=n, id, secret, signIn=n, share=n, community=n
+    mockReadline(["n", "my-client-id", "my-client-secret", "n", "n", "n"]);
 
     const program = wrapInProgram(setupCommand());
     await expect(program.parseAsync(["auth", "setup"], { from: "user" })).rejects.toThrow(
@@ -125,7 +132,8 @@ describe("auth setup", () => {
   });
 
   it("saves scope for Sign In only", () => {
-    mockReadline(["n", "my-client-id", "my-client-secret", "y", "n", "n"]);
+    // logo=n, id, secret, signIn=y, share=n, community=n, pkce=n
+    mockReadline(["n", "my-client-id", "my-client-secret", "y", "n", "n", "n"]);
 
     const program = wrapInProgram(setupCommand());
     return program.parseAsync(["auth", "setup"], { from: "user" }).then(() => {
@@ -134,7 +142,8 @@ describe("auth setup", () => {
   });
 
   it("saves scope for Share only (auto-includes openid scopes)", () => {
-    mockReadline(["n", "my-client-id", "my-client-secret", "n", "y", "n"]);
+    // logo=n, id, secret, signIn=n, share=y, community=n, pkce=n
+    mockReadline(["n", "my-client-id", "my-client-secret", "n", "y", "n", "n"]);
 
     const program = wrapInProgram(setupCommand());
     return program.parseAsync(["auth", "setup"], { from: "user" }).then(() => {
@@ -142,8 +151,30 @@ describe("auth setup", () => {
     });
   });
 
+  it("saves scope for Community Management only", () => {
+    // logo=n, id, secret, signIn=n, share=n, community=y, pkce=n
+    mockReadline(["n", "my-client-id", "my-client-secret", "n", "n", "y", "n"]);
+
+    const program = wrapInProgram(setupCommand());
+    return program.parseAsync(["auth", "setup"], { from: "user" }).then(() => {
+      expect(saveOAuthScopeSpy).toHaveBeenCalledWith("r_member_postAnalytics", undefined);
+    });
+  });
+
+  it("warns when Community Management and Share are both selected", () => {
+    // logo=n, id, secret, signIn=n, share=y, community=y, pkce=n
+    mockReadline(["n", "my-client-id", "my-client-secret", "n", "y", "y", "n"]);
+
+    const program = wrapInProgram(setupCommand());
+    return program.parseAsync(["auth", "setup"], { from: "user" }).then(() => {
+      const output = stderrSpy.mock.calls.map((c) => c[0]).join("");
+      expect(output).toContain("must be the sole product");
+    });
+  });
+
   it("respects --profile flag", () => {
-    mockReadline(["n", "my-client-id", "my-client-secret", "y", "n", "n"]);
+    // logo=n, id, secret, signIn=y, share=n, community=n, pkce=n
+    mockReadline(["n", "my-client-id", "my-client-secret", "y", "n", "n", "n"]);
 
     const program = wrapInProgram(setupCommand());
     return program.parseAsync(["--profile", "work", "auth", "setup"], { from: "user" }).then(() => {
@@ -156,7 +187,8 @@ describe("auth setup", () => {
   });
 
   it("prints setup instructions to stderr", () => {
-    mockReadline(["n", "my-client-id", "my-client-secret", "y", "n", "n"]);
+    // logo=n, id, secret, signIn=y, share=n, community=n, pkce=n
+    mockReadline(["n", "my-client-id", "my-client-secret", "y", "n", "n", "n"]);
 
     const program = wrapInProgram(setupCommand());
     return program.parseAsync(["auth", "setup"], { from: "user" }).then(() => {
@@ -169,7 +201,8 @@ describe("auth setup", () => {
   });
 
   it("prints profile label in success message", () => {
-    mockReadline(["n", "my-client-id", "my-client-secret", "y", "n", "n"]);
+    // logo=n, id, secret, signIn=y, share=n, community=n, pkce=n
+    mockReadline(["n", "my-client-id", "my-client-secret", "y", "n", "n", "n"]);
 
     const program = wrapInProgram(setupCommand());
     return program.parseAsync(["--profile", "personal", "auth", "setup"], { from: "user" }).then(() => {
@@ -179,7 +212,8 @@ describe("auth setup", () => {
   });
 
   it("copies logo to ~/Downloads when user accepts", () => {
-    mockReadline(["y", "my-client-id", "my-client-secret", "y", "n", "n"]);
+    // logo=y, id, secret, signIn=y, share=n, community=n, pkce=n
+    mockReadline(["y", "my-client-id", "my-client-secret", "y", "n", "n", "n"]);
 
     const program = wrapInProgram(setupCommand());
     return program.parseAsync(["auth", "setup"], { from: "user" }).then(() => {
@@ -193,7 +227,8 @@ describe("auth setup", () => {
   });
 
   it("does not copy logo when user declines", () => {
-    mockReadline(["n", "my-client-id", "my-client-secret", "y", "n", "n"]);
+    // logo=n, id, secret, signIn=y, share=n, community=n, pkce=n
+    mockReadline(["n", "my-client-id", "my-client-secret", "y", "n", "n", "n"]);
 
     const program = wrapInProgram(setupCommand());
     return program.parseAsync(["auth", "setup"], { from: "user" }).then(() => {
@@ -206,7 +241,8 @@ describe("auth setup", () => {
   });
 
   it("saves pkce setting when enabled", () => {
-    mockReadline(["n", "my-client-id", "my-client-secret", "y", "n", "y"]);
+    // logo=n, id, secret, signIn=y, share=n, community=n, pkce=y
+    mockReadline(["n", "my-client-id", "my-client-secret", "y", "n", "n", "y"]);
 
     const program = wrapInProgram(setupCommand());
     return program.parseAsync(["auth", "setup"], { from: "user" }).then(() => {
@@ -218,7 +254,8 @@ describe("auth setup", () => {
   });
 
   it("saves pkce setting when disabled", () => {
-    mockReadline(["n", "my-client-id", "my-client-secret", "y", "n", "n"]);
+    // logo=n, id, secret, signIn=y, share=n, community=n, pkce=n
+    mockReadline(["n", "my-client-id", "my-client-secret", "y", "n", "n", "n"]);
 
     const program = wrapInProgram(setupCommand());
     return program.parseAsync(["auth", "setup"], { from: "user" }).then(() => {
@@ -229,7 +266,8 @@ describe("auth setup", () => {
   });
 
   it("saves default api-version", () => {
-    mockReadline(["n", "my-client-id", "my-client-secret", "y", "n", "n"]);
+    // logo=n, id, secret, signIn=y, share=n, community=n, pkce=n
+    mockReadline(["n", "my-client-id", "my-client-secret", "y", "n", "n", "n"]);
 
     const program = wrapInProgram(setupCommand());
     return program.parseAsync(["auth", "setup"], { from: "user" }).then(() => {
@@ -238,7 +276,8 @@ describe("auth setup", () => {
   });
 
   it("saves api-version with profile flag", () => {
-    mockReadline(["n", "my-client-id", "my-client-secret", "y", "n", "n"]);
+    // logo=n, id, secret, signIn=y, share=n, community=n, pkce=n
+    mockReadline(["n", "my-client-id", "my-client-secret", "y", "n", "n", "n"]);
 
     const program = wrapInProgram(setupCommand());
     return program.parseAsync(["--profile", "work", "auth", "setup"], { from: "user" }).then(() => {
@@ -248,7 +287,8 @@ describe("auth setup", () => {
 
   it("shows error when logo copy fails after user accepts", () => {
     copyFileSpy.mockRejectedValue(new Error("ENOENT"));
-    mockReadline(["y", "my-client-id", "my-client-secret", "y", "n", "n"]);
+    // logo=y, id, secret, signIn=y, share=n, community=n, pkce=n
+    mockReadline(["y", "my-client-id", "my-client-secret", "y", "n", "n", "n"]);
 
     const program = wrapInProgram(setupCommand());
     return program.parseAsync(["auth", "setup"], { from: "user" }).then(() => {
@@ -256,6 +296,52 @@ describe("auth setup", () => {
       expect(output).toContain("Could not save logo");
       expect(output).not.toContain("linkedctl-logo.png");
       expect(output).toContain("App logo");
+    });
+  });
+
+  describe("--product flag", () => {
+    it("sets scopes for share product without interactive product questions", () => {
+      // logo=n, id, secret, pkce=n (no product questions)
+      mockReadline(["n", "my-client-id", "my-client-secret", "n"]);
+
+      const program = wrapInProgram(setupCommand());
+      return program.parseAsync(["auth", "setup", "--product", "share"], { from: "user" }).then(() => {
+        expect(saveOAuthScopeSpy).toHaveBeenCalledWith("openid profile w_member_social", undefined);
+      });
+    });
+
+    it("sets scopes for community-management product", () => {
+      // logo=n, id, secret, pkce=n
+      mockReadline(["n", "my-client-id", "my-client-secret", "n"]);
+
+      const program = wrapInProgram(setupCommand());
+      return program.parseAsync(["auth", "setup", "--product", "community-management"], { from: "user" }).then(() => {
+        expect(saveOAuthScopeSpy).toHaveBeenCalledWith("r_member_postAnalytics", undefined);
+      });
+    });
+
+    it("prints selected product and scopes", () => {
+      // logo=n, id, secret, pkce=n
+      mockReadline(["n", "my-client-id", "my-client-secret", "n"]);
+
+      const program = wrapInProgram(setupCommand());
+      return program.parseAsync(["auth", "setup", "--product", "share"], { from: "user" }).then(() => {
+        const output = stderrSpy.mock.calls.map((c) => c[0]).join("");
+        expect(output).toContain('"share"');
+        expect(output).toContain("openid profile w_member_social");
+      });
+    });
+
+    it("respects --profile flag with --product", () => {
+      // logo=n, id, secret, pkce=n
+      mockReadline(["n", "my-client-id", "my-client-secret", "n"]);
+
+      const program = wrapInProgram(setupCommand());
+      return program
+        .parseAsync(["--profile", "analytics", "auth", "setup", "--product", "community-management"], { from: "user" })
+        .then(() => {
+          expect(saveOAuthScopeSpy).toHaveBeenCalledWith("r_member_postAnalytics", { profile: "analytics" });
+        });
     });
   });
 });

--- a/packages/cli/src/commands/auth/setup.ts
+++ b/packages/cli/src/commands/auth/setup.ts
@@ -6,13 +6,15 @@ import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { createInterface } from "node:readline/promises";
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import {
   saveOAuthClientCredentials,
   saveOAuthScope,
   saveOAuthPkce,
   saveApiVersion,
   DEFAULT_API_VERSION,
+  PRODUCT_NAMES,
+  resolveProductScopes,
 } from "@linkedctl/core";
 
 import { DEFAULT_REDIRECT_PORT } from "./login.js";
@@ -21,8 +23,13 @@ export function setupCommand(): Command {
   const cmd = new Command("setup");
   cmd.description("Configure OAuth client credentials interactively");
   cmd.addHelpText("after", "\nLinkedIn Developer Portal: https://www.linkedin.com/developers/apps");
+  cmd.addOption(
+    new Option("--product <product>", "pre-select a LinkedIn product (skips interactive product selection)").choices(
+      PRODUCT_NAMES,
+    ),
+  );
 
-  cmd.action(async () => {
+  cmd.action(async (opts: { product?: string | undefined }) => {
     const program = cmd.parent?.parent;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const profileFlag: string | undefined = program?.opts()["profile"];
@@ -58,7 +65,9 @@ export function setupCommand(): Command {
     process.stderr.write('3. Under the "Auth" tab, note your Client ID and Primary Client Secret\n');
     process.stderr.write(`4. Add a redirect URL: http://127.0.0.1:${DEFAULT_REDIRECT_PORT}/callback\n`);
     process.stderr.write('5. Under "Products", request access to the products you need\n');
-    process.stderr.write("   (e.g. Share on LinkedIn, Sign In with LinkedIn using OpenID Connect)\n");
+    process.stderr.write(
+      "   (e.g. Share on LinkedIn, Sign In with LinkedIn using OpenID Connect, Community Management API)\n",
+    );
     process.stderr.write("6. Copy the Client ID and Client Secret below\n");
     process.stderr.write("\n");
 
@@ -83,40 +92,21 @@ export function setupCommand(): Command {
 
       await saveOAuthClientCredentials({ clientId: clientId.trim(), clientSecret: clientSecret.trim() }, writeOpts);
 
-      process.stderr.write("\n");
-      process.stderr.write("Which LinkedIn products have you enabled for this app?\n");
-      process.stderr.write("\n");
+      let scope: string;
 
-      const scopes: string[] = [];
-
-      const signIn = await rl.question("Sign In with LinkedIn using OpenID Connect? [y/N] ");
-      if (signIn.trim().toLowerCase() === "y" || signIn.trim().toLowerCase() === "yes") {
-        scopes.push("openid", "profile", "email");
-      }
-
-      const share = await rl.question("Share on LinkedIn? [y/N] ");
-      if (share.trim().toLowerCase() === "y" || share.trim().toLowerCase() === "yes") {
-        scopes.push("w_member_social");
-        // Posting requires the author's person URN, which is only available via
-        // the /v2/userinfo endpoint. That endpoint needs openid scopes, so we
-        // force-enable them when Share on LinkedIn is selected.
-        if (!scopes.includes("openid")) {
-          scopes.push("openid", "profile", "email");
-          process.stderr.write(
-            '  → Also enabling "Sign In with LinkedIn" scopes (required to resolve author identity for posts)\n',
-          );
+      if (opts.product !== undefined) {
+        // Non-interactive: resolve scopes from the product preset
+        const productScope = resolveProductScopes(opts.product);
+        if (productScope === undefined) {
+          throw new Error(`Unknown product: ${opts.product}. Valid products: ${PRODUCT_NAMES.join(", ")}`);
         }
+        scope = productScope;
+        process.stderr.write(`\nProduct "${opts.product}" selected — scopes: ${scope}\n`);
+      } else {
+        // Interactive product selection
+        scope = await interactiveProductSelection(rl);
       }
 
-      if (scopes.length === 0) {
-        throw new Error(
-          "At least one LinkedIn product must be enabled for OAuth to work. " +
-            'Enable products under the "Products" tab of your app at https://www.linkedin.com/developers/apps ' +
-            "and then re-run this setup.",
-        );
-      }
-
-      const scope = [...new Set(scopes)].join(" ");
       await saveOAuthScope(scope, writeOpts);
 
       process.stderr.write("\n");
@@ -146,4 +136,64 @@ export function setupCommand(): Command {
   });
 
   return cmd;
+}
+
+/**
+ * Walk the user through interactive product selection.
+ *
+ * Asks about each LinkedIn product and collects the corresponding scopes.
+ * Warns when mutually exclusive products are selected together.
+ */
+async function interactiveProductSelection(rl: { question(query: string): Promise<string> }): Promise<string> {
+  process.stderr.write("\n");
+  process.stderr.write("Which LinkedIn products have you enabled for this app?\n");
+  process.stderr.write("\n");
+
+  const scopes: string[] = [];
+  let hasCommunityManagement = false;
+
+  const signIn = await rl.question("Sign In with LinkedIn using OpenID Connect? [y/N] ");
+  if (signIn.trim().toLowerCase() === "y" || signIn.trim().toLowerCase() === "yes") {
+    scopes.push("openid", "profile", "email");
+  }
+
+  const share = await rl.question("Share on LinkedIn? [y/N] ");
+  if (share.trim().toLowerCase() === "y" || share.trim().toLowerCase() === "yes") {
+    scopes.push("w_member_social");
+    // Posting requires the author's person URN, which is only available via
+    // the /v2/userinfo endpoint. That endpoint needs openid scopes, so we
+    // force-enable them when Share on LinkedIn is selected.
+    if (!scopes.includes("openid")) {
+      scopes.push("openid", "profile", "email");
+      process.stderr.write(
+        '  → Also enabling "Sign In with LinkedIn" scopes (required to resolve author identity for posts)\n',
+      );
+    }
+  }
+
+  const communityManagement = await rl.question("Community Management API? [y/N] ");
+  if (communityManagement.trim().toLowerCase() === "y" || communityManagement.trim().toLowerCase() === "yes") {
+    scopes.push("r_member_postAnalytics");
+    hasCommunityManagement = true;
+  }
+
+  if (scopes.length === 0) {
+    throw new Error(
+      "At least one LinkedIn product must be enabled for OAuth to work. " +
+        'Enable products under the "Products" tab of your app at https://www.linkedin.com/developers/apps ' +
+        "and then re-run this setup.",
+    );
+  }
+
+  // Warn about product exclusivity
+  if (hasCommunityManagement && scopes.includes("w_member_social")) {
+    process.stderr.write("\n");
+    process.stderr.write(
+      "  ⚠ Warning: Community Management API must be the sole product on a LinkedIn Developer App.\n",
+    );
+    process.stderr.write("  Using it alongside Share on LinkedIn requires separate apps and separate profiles.\n");
+    process.stderr.write('  Consider running "linkedctl auth setup --profile analytics" for a dedicated profile.\n');
+  }
+
+  return [...new Set(scopes)].join(" ");
 }

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -16,3 +16,7 @@ export {
   clearOAuthTokens,
 } from "./writer.js";
 export { resolveConfig, ConfigError } from "./resolve.js";
+export { PRODUCT_PRESETS, PRODUCT_NAMES, resolveProductScopes } from "./products.js";
+export type { ProductPreset } from "./products.js";
+export { listProfileScopes, findProfilesWithScopes } from "./profiles.js";
+export type { ProfileScopeSummary } from "./profiles.js";

--- a/packages/core/src/config/products.test.ts
+++ b/packages/core/src/config/products.test.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, expect, it } from "vitest";
+import { PRODUCT_PRESETS, PRODUCT_NAMES, resolveProductScopes } from "./products.js";
+
+describe("PRODUCT_PRESETS", () => {
+  it("defines a share preset", () => {
+    expect(PRODUCT_PRESETS["share"]).toBeDefined();
+    expect(PRODUCT_PRESETS["share"]?.scopes).toEqual(["openid", "profile", "w_member_social"]);
+  });
+
+  it("defines a community-management preset", () => {
+    expect(PRODUCT_PRESETS["community-management"]).toBeDefined();
+    expect(PRODUCT_PRESETS["community-management"]?.scopes).toEqual(["r_member_postAnalytics"]);
+  });
+});
+
+describe("PRODUCT_NAMES", () => {
+  it("lists all product identifiers", () => {
+    expect(PRODUCT_NAMES).toContain("share");
+    expect(PRODUCT_NAMES).toContain("community-management");
+  });
+});
+
+describe("resolveProductScopes", () => {
+  it("returns scopes for share product", () => {
+    expect(resolveProductScopes("share")).toBe("openid profile w_member_social");
+  });
+
+  it("returns scopes for community-management product", () => {
+    expect(resolveProductScopes("community-management")).toBe("r_member_postAnalytics");
+  });
+
+  it("returns undefined for unknown product", () => {
+    expect(resolveProductScopes("unknown")).toBeUndefined();
+  });
+});

--- a/packages/core/src/config/products.ts
+++ b/packages/core/src/config/products.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * A LinkedIn product preset that maps a product name to the OAuth scopes it requires.
+ */
+export interface ProductPreset {
+  /** Human-readable product name. */
+  readonly label: string;
+  /** OAuth scopes required by this product. */
+  readonly scopes: readonly string[];
+}
+
+/**
+ * Known LinkedIn product presets.
+ *
+ * Each key is a CLI-friendly product identifier; the value describes the
+ * scopes that must be requested when configuring OAuth for that product.
+ */
+export const PRODUCT_PRESETS: Readonly<Record<string, ProductPreset>> = {
+  share: {
+    label: "Share on LinkedIn",
+    scopes: ["openid", "profile", "w_member_social"],
+  },
+  "community-management": {
+    label: "Community Management API",
+    scopes: ["r_member_postAnalytics"],
+  },
+};
+
+/**
+ * Valid product identifiers accepted by `--product`.
+ */
+export const PRODUCT_NAMES = Object.keys(PRODUCT_PRESETS);
+
+/**
+ * Resolve a product identifier to its scope string.
+ * Returns `undefined` when the identifier is not recognised.
+ */
+export function resolveProductScopes(product: string): string | undefined {
+  const preset = PRODUCT_PRESETS[product];
+  if (preset === undefined) {
+    return undefined;
+  }
+  return preset.scopes.join(" ");
+}

--- a/packages/core/src/config/profiles.test.ts
+++ b/packages/core/src/config/profiles.test.ts
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { rm, mkdir, writeFile } from "node:fs/promises";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { listProfileScopes, findProfilesWithScopes } from "./profiles.js";
+
+function tempDir(): string {
+  return join(tmpdir(), `linkedctl-test-${randomUUID()}`);
+}
+
+describe("listProfileScopes", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = tempDir();
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("returns empty array when no profile directory exists", async () => {
+    const result = await listProfileScopes({ home: dir });
+    expect(result).toEqual([]);
+  });
+
+  it("lists profiles with their scopes", async () => {
+    const profileDir = join(dir, ".linkedctl");
+    await mkdir(profileDir, { recursive: true });
+    await writeFile(
+      join(profileDir, "work.yaml"),
+      `oauth:
+  scope: "openid profile w_member_social"
+`,
+    );
+    await writeFile(
+      join(profileDir, "analytics.yaml"),
+      `oauth:
+  scope: "r_member_postAnalytics"
+`,
+    );
+
+    const result = await listProfileScopes({ home: dir });
+    expect(result).toHaveLength(2);
+
+    const work = result.find((p) => p.name === "work");
+    expect(work?.scope).toBe("openid profile w_member_social");
+
+    const analytics = result.find((p) => p.name === "analytics");
+    expect(analytics?.scope).toBe("r_member_postAnalytics");
+  });
+
+  it("includes profiles without scope configured", async () => {
+    const profileDir = join(dir, ".linkedctl");
+    await mkdir(profileDir, { recursive: true });
+    await writeFile(
+      join(profileDir, "empty.yaml"),
+      `oauth:
+  client-id: "test"
+`,
+    );
+
+    const result = await listProfileScopes({ home: dir });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.scope).toBeUndefined();
+  });
+
+  it("skips non-yaml files", async () => {
+    const profileDir = join(dir, ".linkedctl");
+    await mkdir(profileDir, { recursive: true });
+    await writeFile(join(profileDir, "notes.txt"), "not a profile");
+    await writeFile(
+      join(profileDir, "work.yaml"),
+      `oauth:
+  scope: "openid"
+`,
+    );
+
+    const result = await listProfileScopes({ home: dir });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.name).toBe("work");
+  });
+});
+
+describe("findProfilesWithScopes", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = tempDir();
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("finds profiles that have all required scopes", async () => {
+    const profileDir = join(dir, ".linkedctl");
+    await mkdir(profileDir, { recursive: true });
+    await writeFile(
+      join(profileDir, "full.yaml"),
+      `oauth:
+  scope: "openid profile email w_member_social"
+`,
+    );
+    await writeFile(
+      join(profileDir, "minimal.yaml"),
+      `oauth:
+  scope: "openid profile"
+`,
+    );
+
+    const result = await findProfilesWithScopes(["openid", "profile", "w_member_social"], { home: dir });
+    expect(result).toEqual(["full"]);
+  });
+
+  it("excludes specified profile", async () => {
+    const profileDir = join(dir, ".linkedctl");
+    await mkdir(profileDir, { recursive: true });
+    await writeFile(
+      join(profileDir, "work.yaml"),
+      `oauth:
+  scope: "openid profile w_member_social"
+`,
+    );
+
+    const result = await findProfilesWithScopes(["openid", "profile", "w_member_social"], {
+      home: dir,
+      excludeProfile: "work",
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty when no profiles match", async () => {
+    const profileDir = join(dir, ".linkedctl");
+    await mkdir(profileDir, { recursive: true });
+    await writeFile(
+      join(profileDir, "basic.yaml"),
+      `oauth:
+  scope: "openid"
+`,
+    );
+
+    const result = await findProfilesWithScopes(["r_member_postAnalytics"], { home: dir });
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty when no profile directory exists", async () => {
+    const result = await findProfilesWithScopes(["openid"], { home: dir });
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/core/src/config/profiles.ts
+++ b/packages/core/src/config/profiles.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+import { CONFIG_DIR } from "./loader.js";
+import { loadConfigFile } from "./loader.js";
+import { validateConfig } from "./validate.js";
+
+/**
+ * Summary of a profile's configured OAuth scopes.
+ */
+export interface ProfileScopeSummary {
+  /** Profile name (filename without `.yaml` extension). */
+  name: string;
+  /** Space-separated scope string, or `undefined` when not configured. */
+  scope: string | undefined;
+}
+
+/**
+ * List all profiles and their configured scopes.
+ *
+ * Reads `~/.linkedctl/*.yaml` and extracts the `oauth.scope` value from each.
+ * Profiles that fail to load or validate are silently skipped.
+ */
+export async function listProfileScopes(options?: { home?: string | undefined }): Promise<ProfileScopeSummary[]> {
+  const home = options?.home ?? homedir();
+  const profileDir = join(home, CONFIG_DIR);
+
+  let entries: string[];
+  try {
+    entries = await readdir(profileDir);
+  } catch (error: unknown) {
+    if (error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+
+  const names = entries.filter((e) => e.endsWith(".yaml")).map((e) => e.replace(/\.yaml$/, ""));
+  const results: ProfileScopeSummary[] = [];
+
+  for (const name of names) {
+    try {
+      const { raw } = await loadConfigFile({ profile: name, home });
+      if (raw === undefined) {
+        continue;
+      }
+      const { config } = validateConfig(raw);
+      results.push({ name, scope: config.oauth?.scope });
+    } catch {
+      // Skip profiles that cannot be loaded or validated.
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Find profiles whose configured scopes include all of the given required scopes.
+ */
+export async function findProfilesWithScopes(
+  requiredScopes: string[],
+  options?: { home?: string | undefined; excludeProfile?: string | undefined },
+): Promise<string[]> {
+  const profiles = await listProfileScopes({ home: options?.home });
+  const matching: string[] = [];
+
+  for (const profile of profiles) {
+    if (options?.excludeProfile !== undefined && profile.name === options.excludeProfile) {
+      continue;
+    }
+    if (profile.scope === undefined) {
+      continue;
+    }
+    const granted = profile.scope.split(" ");
+    if (requiredScopes.every((s) => granted.includes(s))) {
+      matching.push(profile.name);
+    }
+  }
+
+  return matching;
+}

--- a/packages/core/src/config/resolve.test.ts
+++ b/packages/core/src/config/resolve.test.ts
@@ -229,4 +229,67 @@ api-version: "202601"
 
     await expect(resolveConfig({ home: dir, cwd: dir, env: {} })).rejects.toThrow(/No access token configured/);
   });
+
+  it("suggests matching profile when scope mismatch occurs", async () => {
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, ".linkedctl.yaml"),
+      `oauth:
+  access-token: "tok"
+  scope: "openid profile"
+api-version: "202601"
+`,
+    );
+
+    // Create a profile that has the required scopes
+    const profileDir = join(dir, ".linkedctl");
+    await mkdir(profileDir, { recursive: true });
+    await writeFile(
+      join(profileDir, "analytics.yaml"),
+      `oauth:
+  scope: "openid profile r_member_postAnalytics"
+`,
+    );
+
+    await expect(
+      resolveConfig({ home: dir, cwd: dir, env: {}, requiredScopes: ["openid", "profile", "r_member_postAnalytics"] }),
+    ).rejects.toThrow(/--profile analytics/);
+  });
+
+  it("suggests auth setup command when no matching profile exists", async () => {
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, ".linkedctl.yaml"),
+      `oauth:
+  access-token: "tok"
+  scope: "openid profile"
+api-version: "202601"
+`,
+    );
+
+    await expect(
+      resolveConfig({ home: dir, cwd: dir, env: {}, requiredScopes: ["openid", "profile", "r_member_postAnalytics"] }),
+    ).rejects.toThrow(/auth setup --product community-management/);
+  });
+
+  it("explains product exclusivity when scopes span exclusive products", async () => {
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, ".linkedctl.yaml"),
+      `oauth:
+  access-token: "tok"
+  scope: "openid profile"
+api-version: "202601"
+`,
+    );
+
+    await expect(
+      resolveConfig({
+        home: dir,
+        cwd: dir,
+        env: {},
+        requiredScopes: ["w_member_social", "r_member_postAnalytics"],
+      }),
+    ).rejects.toThrow(/product exclusivity/);
+  });
 });

--- a/packages/core/src/config/resolve.ts
+++ b/packages/core/src/config/resolve.ts
@@ -5,6 +5,8 @@ import type { ConfigResult, ResolveOptions } from "./types.js";
 import { loadConfigFile } from "./loader.js";
 import { validateConfig } from "./validate.js";
 import { applyEnvOverlay } from "./env.js";
+import { findProfilesWithScopes } from "./profiles.js";
+import { PRODUCT_PRESETS } from "./products.js";
 
 /**
  * Error thrown when configuration is invalid or incomplete.
@@ -76,9 +78,11 @@ export async function resolveConfig(options?: ResolveOptions): Promise<ConfigRes
     const grantedScopes = configuredScope.split(" ");
     const missingScopes = requiredScopes.filter((s) => !grantedScopes.includes(s));
     if (missingScopes.length > 0) {
-      throw new ConfigError(
-        `Missing required OAuth scopes: ${missingScopes.join(", ")}. Re-run "linkedctl auth setup" to configure the required scopes, then "linkedctl auth login" to re-authenticate.`,
-      );
+      const message = await buildScopeMismatchMessage(missingScopes, requiredScopes, {
+        profile: options?.profile,
+        home: options?.home,
+      });
+      throw new ConfigError(message);
     }
   }
 
@@ -90,4 +94,78 @@ function describeSearchLocations(options?: ResolveOptions): string {
     return `~/.linkedctl/${options.profile}.yaml`;
   }
   return ".linkedctl.yaml (CWD), ~/.linkedctl.yaml (home)";
+}
+
+/**
+ * Build a helpful scope-mismatch error message.
+ *
+ * When other profiles already have the required scopes, suggests `--profile`.
+ * Otherwise, suggests the exact `auth setup` command to create a new profile.
+ * Also explains LinkedIn's product exclusivity constraint when relevant.
+ */
+async function buildScopeMismatchMessage(
+  missingScopes: string[],
+  requiredScopes: string[],
+  options?: { profile?: string | undefined; home?: string | undefined },
+): Promise<string> {
+  const parts: string[] = [`Missing required OAuth scopes: ${missingScopes.join(", ")}.`];
+
+  // Check if any existing profile already has the required scopes
+  let matchingProfiles: string[] = [];
+  try {
+    matchingProfiles = await findProfilesWithScopes(requiredScopes, {
+      home: options?.home,
+      excludeProfile: options?.profile,
+    });
+  } catch {
+    // If profile scanning fails, fall through to generic advice.
+  }
+
+  if (matchingProfiles.length > 0) {
+    const profileList = matchingProfiles.map((p) => `--profile ${p}`).join(", ");
+    parts.push(`Other profiles already have the required scopes: ${profileList}.`);
+  } else {
+    // Suggest the right auth setup command based on missing scopes
+    const setupHint = suggestSetupCommand(missingScopes, options?.profile);
+    parts.push(setupHint);
+  }
+
+  // Explain product exclusivity when scopes span multiple exclusive products
+  if (involvesExclusiveProducts(requiredScopes)) {
+    parts.push(
+      "Note: LinkedIn enforces product exclusivity — the Community Management API " +
+        "must be the sole product on a Developer App. Use separate profiles for " +
+        "separate apps (e.g. --profile analytics).",
+    );
+  }
+
+  return parts.join(" ");
+}
+
+/**
+ * Suggest the appropriate `auth setup` command for the missing scopes.
+ */
+function suggestSetupCommand(missingScopes: string[], currentProfile: string | undefined): string {
+  // Find a product preset that covers all missing scopes
+  for (const [productId, preset] of Object.entries(PRODUCT_PRESETS)) {
+    if (missingScopes.every((s) => preset.scopes.includes(s))) {
+      const profileArg = currentProfile !== undefined ? ` --profile ${currentProfile}` : "";
+      return `Run: linkedctl auth setup --product ${productId}${profileArg}`;
+    }
+  }
+
+  // Generic fallback
+  const profileArg = currentProfile !== undefined ? ` --profile ${currentProfile}` : "";
+  return `Re-run "linkedctl auth setup${profileArg}" to configure the required scopes, then "linkedctl auth login" to re-authenticate.`;
+}
+
+/**
+ * Check whether the required scopes span multiple exclusive LinkedIn products.
+ * The Community Management API (`r_member_postAnalytics`) is exclusive and
+ * cannot coexist with Share (`w_member_social`) on the same Developer App.
+ */
+function involvesExclusiveProducts(scopes: string[]): boolean {
+  const hasCommunityManagement = scopes.includes("r_member_postAnalytics");
+  const hasShare = scopes.includes("w_member_social");
+  return hasCommunityManagement && hasShare;
 }

--- a/packages/core/src/http/errors.test.ts
+++ b/packages/core/src/http/errors.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   LinkedInApiError,
   LinkedInAuthError,
+  LinkedInForbiddenError,
   LinkedInRateLimitError,
   LinkedInServerError,
   LinkedInUpgradeRequiredError,
@@ -47,6 +48,26 @@ describe("LinkedInAuthError", () => {
   it("stores response body", () => {
     const body = { message: "Token expired" };
     const error = new LinkedInAuthError("unauthorized", body);
+    expect(error.responseBody).toEqual(body);
+  });
+});
+
+describe("LinkedInForbiddenError", () => {
+  it("has status 403 and correct name", () => {
+    const error = new LinkedInForbiddenError("forbidden");
+    expect(error.status).toBe(403);
+    expect(error.name).toBe("LinkedInForbiddenError");
+    expect(error.message).toBe("forbidden");
+  });
+
+  it("is an instance of LinkedInApiError", () => {
+    const error = new LinkedInForbiddenError("forbidden");
+    expect(error).toBeInstanceOf(LinkedInApiError);
+  });
+
+  it("stores response body", () => {
+    const body = { message: "Insufficient permissions" };
+    const error = new LinkedInForbiddenError("forbidden", body);
     expect(error.responseBody).toEqual(body);
   });
 });

--- a/packages/core/src/http/errors.ts
+++ b/packages/core/src/http/errors.ts
@@ -27,6 +27,20 @@ export class LinkedInAuthError extends LinkedInApiError {
 }
 
 /**
+ * Thrown on HTTP 403 — the request is forbidden.
+ *
+ * This typically means the OAuth access token does not have the required
+ * permissions, or the LinkedIn Developer App does not have the necessary
+ * product enabled.
+ */
+export class LinkedInForbiddenError extends LinkedInApiError {
+  constructor(message: string, responseBody?: unknown) {
+    super(message, 403, responseBody);
+    this.name = "LinkedInForbiddenError";
+  }
+}
+
+/**
  * Thrown on HTTP 429 when all retry attempts have been exhausted.
  */
 export class LinkedInRateLimitError extends LinkedInApiError {

--- a/packages/core/src/http/linkedin-client.test.ts
+++ b/packages/core/src/http/linkedin-client.test.ts
@@ -6,6 +6,7 @@ import { LinkedInClient } from "./linkedin-client.js";
 import {
   LinkedInApiError,
   LinkedInAuthError,
+  LinkedInForbiddenError,
   LinkedInRateLimitError,
   LinkedInServerError,
   LinkedInUpgradeRequiredError,
@@ -266,9 +267,44 @@ describe("LinkedInClient", () => {
     });
   });
 
-  describe("other error status codes", () => {
-    it("throws LinkedInApiError for 4xx (non-401, non-429)", async () => {
+  describe("403 forbidden error", () => {
+    it("throws LinkedInForbiddenError with product guidance", async () => {
+      fetchSpy.mockResolvedValue(jsonResponse({}, 403));
+
+      const client = new LinkedInClient(CLIENT_OPTIONS);
+
+      await expect(client.request("/v2/me")).rejects.toThrow(LinkedInForbiddenError);
+      await expect(client.request("/v2/me")).rejects.toThrow(/product enabled/);
+    });
+
+    it("includes response body in error", async () => {
+      const errorBody = { code: "FORBIDDEN", message: "Access denied" };
+      fetchSpy.mockResolvedValueOnce(jsonResponse(errorBody, 403));
+
+      const client = new LinkedInClient(CLIENT_OPTIONS);
+
+      try {
+        await client.request("/v2/me");
+        expect.fail("should have thrown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(LinkedInForbiddenError);
+        expect((error as LinkedInForbiddenError).responseBody).toEqual(errorBody);
+      }
+    });
+
+    it("does not retry on 403", async () => {
       fetchSpy.mockResolvedValueOnce(jsonResponse({}, 403));
+
+      const client = new LinkedInClient(CLIENT_OPTIONS);
+
+      await expect(client.request("/v2/me")).rejects.toThrow(LinkedInForbiddenError);
+      expect(fetchSpy).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("other error status codes", () => {
+    it("throws LinkedInApiError for 4xx (non-401, non-403, non-429)", async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({}, 409));
 
       const client = new LinkedInClient(CLIENT_OPTIONS);
 
@@ -353,8 +389,8 @@ describe("LinkedInClient", () => {
 
   describe("error response body handling", () => {
     it("includes JSON error body in thrown error", async () => {
-      const errorBody = { code: "FORBIDDEN", message: "Access denied" };
-      fetchSpy.mockResolvedValueOnce(jsonResponse(errorBody, 403));
+      const errorBody = { code: "NOT_FOUND", message: "Resource not found" };
+      fetchSpy.mockResolvedValueOnce(jsonResponse(errorBody, 404));
 
       const client = new LinkedInClient(CLIENT_OPTIONS);
 

--- a/packages/core/src/http/linkedin-client.ts
+++ b/packages/core/src/http/linkedin-client.ts
@@ -4,6 +4,7 @@
 import {
   LinkedInApiError,
   LinkedInAuthError,
+  LinkedInForbiddenError,
   LinkedInRateLimitError,
   LinkedInServerError,
   LinkedInUpgradeRequiredError,
@@ -171,6 +172,15 @@ export class LinkedInClient {
 
       if (response.status === 426) {
         throw new LinkedInUpgradeRequiredError(this.apiVersion, body);
+      }
+
+      if (response.status === 403) {
+        throw new LinkedInForbiddenError(
+          "LinkedIn API request forbidden (HTTP 403). " +
+            "Verify that your LinkedIn Developer App has the correct product enabled " +
+            "and that the OAuth scopes match the product's requirements.",
+          body,
+        );
       }
 
       if (response.status === 401) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,11 @@ export {
   clearOAuthTokens,
   resolveConfig,
   ConfigError,
+  PRODUCT_PRESETS,
+  PRODUCT_NAMES,
+  resolveProductScopes,
+  listProfileScopes,
+  findProfilesWithScopes,
 } from "./config/index.js";
 export type {
   OAuthCredentials,
@@ -24,12 +29,15 @@ export type {
   ResolveOptions,
   LoadResult,
   ValidationResult,
+  ProductPreset,
+  ProfileScopeSummary,
 } from "./config/index.js";
 export { getTokenExpiry } from "./auth/token-introspection.js";
 export type { TokenExpiry } from "./auth/token-introspection.js";
 export {
   LinkedInApiError,
   LinkedInAuthError,
+  LinkedInForbiddenError,
   LinkedInRateLimitError,
   LinkedInServerError,
   LinkedInUpgradeRequiredError,


### PR DESCRIPTION
## Summary

Closes #148

- Add `--product` flag to `auth setup` for non-interactive product selection (`share`, `community-management`)
- Extend interactive wizard with Community Management API option and exclusivity warning
- Enhance scope-mismatch errors to suggest matching profiles (`--profile <name>`) or exact `auth setup` commands
- Add `LinkedInForbiddenError` for 403 responses with Developer App product guidance
- Add product presets module (`PRODUCT_PRESETS`, `resolveProductScopes`) and profile scanning helpers (`listProfileScopes`, `findProfilesWithScopes`)

## Test plan

- [x] `auth setup --product community-management` pre-sets scopes to `r_member_postAnalytics`
- [x] `auth setup --product share` pre-sets scopes to `openid profile w_member_social`
- [x] Interactive mode shows product selection prompt including Community Management
- [x] Scope mismatch with matching profile suggests `--profile <name>`
- [x] Scope mismatch without matching profile shows exact `auth setup` command
- [x] 403 from LinkedIn API mentions verifying Developer App product
- [x] Product exclusivity warning when conflicting products selected
- [x] All 590 unit tests pass, typecheck/lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)