### PR TITLE
(feat) add org stats CLI commands

### DIFF
--- a/packages/cli/src/commands/stats/index.ts
+++ b/packages/cli/src/commands/stats/index.ts
@@ -2,6 +2,7 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { Command } from "commander";
+import { orgCommand } from "./org.js";
 import { postCommand } from "./post.js";
 import { meCommand } from "./me.js";
 
@@ -14,12 +15,17 @@ export function statsCommand(): Command {
     `
 Examples:
   linkedctl stats post urn:li:share:123
+  linkedctl stats post urn:li:share:123 --org 12345
   linkedctl stats me
-  linkedctl stats me --from 2024-05-01 --to 2024-05-31`,
+  linkedctl stats me --from 2024-05-01 --to 2024-05-31
+  linkedctl stats org 12345
+  linkedctl stats org 12345 --from 2025-01-01 --to 2025-06-01
+  linkedctl stats org 12345 --from 2025-01-01 --to 2025-02-01 --granularity day`,
   );
 
   cmd.addCommand(postCommand());
   cmd.addCommand(meCommand());
+  cmd.addCommand(orgCommand());
 
   return cmd;
 }

--- a/packages/cli/src/commands/stats/org.test.ts
+++ b/packages/cli/src/commands/stats/org.test.ts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { createProgram } from "../../program.js";
+
+vi.mock("@linkedctl/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@linkedctl/core")>();
+  return {
+    ...actual,
+    resolveConfig: vi.fn().mockResolvedValue({
+      config: {
+        oauth: { accessToken: "test-token" },
+        apiVersion: "202601",
+      },
+      warnings: [],
+    }),
+    getOrgStats: vi.fn().mockResolvedValue({
+      elements: [
+        {
+          organizationalEntity: "urn:li:organization:12345",
+          totalShareStatistics: {
+            clickCount: 100,
+            commentCount: 25,
+            engagement: 0.05,
+            impressionCount: 1000,
+            likeCount: 50,
+            shareCount: 10,
+            uniqueImpressionsCount: 800,
+          },
+        },
+      ],
+      paging: { count: 1, start: 0 },
+    }),
+  };
+});
+
+const coreMock = await import("@linkedctl/core");
+
+describe("stats org", () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches lifetime org statistics", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "stats", "org", "12345"]);
+
+    expect(coreMock.getOrgStats).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        organizationUrn: "urn:li:organization:12345",
+      }),
+    );
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+
+  it("outputs JSON when --format json is specified", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "stats", "org", "12345", "--format", "json"]);
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(output) as Record<string, unknown>;
+    expect(parsed).toHaveProperty("elements");
+  });
+
+  it("passes time range and granularity for time-bound queries", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "linkedctl",
+      "stats",
+      "org",
+      "12345",
+      "--from",
+      "2025-01-01",
+      "--to",
+      "2025-06-01",
+    ]);
+
+    expect(coreMock.getOrgStats).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        organizationUrn: "urn:li:organization:12345",
+        timeGranularity: "MONTH",
+        timeRange: {
+          start: new Date("2025-01-01").getTime(),
+          end: new Date("2025-06-01").getTime(),
+        },
+      }),
+    );
+  });
+
+  it("passes daily granularity when --granularity day is specified", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "linkedctl",
+      "stats",
+      "org",
+      "12345",
+      "--from",
+      "2025-01-01",
+      "--to",
+      "2025-02-01",
+      "--granularity",
+      "day",
+    ]);
+
+    expect(coreMock.getOrgStats).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        timeGranularity: "DAY",
+      }),
+    );
+  });
+
+  it("rejects --from without --to", async () => {
+    const program = createProgram();
+    await expect(
+      program.parseAsync(["node", "linkedctl", "stats", "org", "12345", "--from", "2025-01-01"]),
+    ).rejects.toThrow(/Both --from and --to must be specified together/);
+  });
+
+  it("rejects --granularity without date range", async () => {
+    const program = createProgram();
+    await expect(
+      program.parseAsync(["node", "linkedctl", "stats", "org", "12345", "--granularity", "day"]),
+    ).rejects.toThrow(/--granularity requires --from and --to/);
+  });
+
+  it("resolves config with required scopes", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "stats", "org", "12345"]);
+
+    expect(coreMock.resolveConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requiredScopes: ["rw_organization_admin"],
+      }),
+    );
+  });
+
+  it("resolves config with profile from global options", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "--profile", "analytics", "stats", "org", "12345"]);
+
+    expect(coreMock.resolveConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profile: "analytics",
+      }),
+    );
+  });
+
+  it("wraps API errors with actionable message", async () => {
+    const { LinkedInApiError } = await import("@linkedctl/core");
+    vi.mocked(coreMock.getOrgStats).mockRejectedValueOnce(new LinkedInApiError("Forbidden", 403));
+
+    const program = createProgram();
+    await expect(program.parseAsync(["node", "linkedctl", "stats", "org", "12345"])).rejects.toThrow(
+      /Failed to get organization statistics/,
+    );
+  });
+});

--- a/packages/cli/src/commands/stats/org.ts
+++ b/packages/cli/src/commands/stats/org.ts
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { Command, Option } from "commander";
+import { resolveConfig, LinkedInClient, getOrgStats, LinkedInApiError } from "@linkedctl/core";
+import type { OrgStatsElement, OrgStatsTimeGranularity } from "@linkedctl/core";
+import type { OutputFormat } from "../../output/index.js";
+import { resolveFormat, formatOutput } from "../../output/index.js";
+
+function formatDate(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+function formatStatsRow(el: OrgStatsElement): Record<string, unknown> {
+  const s = el.totalShareStatistics;
+  const row: Record<string, unknown> = {};
+  if (el.timeRange !== undefined) {
+    row["period"] = `${formatDate(el.timeRange.start)} - ${formatDate(el.timeRange.end)}`;
+  }
+  row["impressions"] = s.impressionCount;
+  row["uniqueImpressions"] = s.uniqueImpressionsCount;
+  row["clicks"] = s.clickCount;
+  row["likes"] = s.likeCount;
+  row["comments"] = s.commentCount;
+  row["shares"] = s.shareCount;
+  row["engagement"] = s.engagement;
+  return row;
+}
+
+export function orgCommand(): Command {
+  const cmd = new Command("org");
+  cmd.description("Get organization share statistics");
+  cmd.argument("<id>", "organization ID (numeric, e.g. 12345)");
+  cmd.option("--from <date>", "start date for time-bound stats (ISO 8601, e.g. 2025-01-01)");
+  cmd.option("--to <date>", "end date for time-bound stats (ISO 8601, e.g. 2025-06-01)");
+  cmd.addOption(
+    new Option("--granularity <granularity>", "time granularity for bucketed results")
+      .choices(["day", "month"])
+      .default("month"),
+  );
+  cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
+
+  cmd.action(async (id: string, opts: Record<string, unknown>, actionCmd: Command) => {
+    const globals = actionCmd.optsWithGlobals<{ profile?: string | undefined; json?: boolean | undefined }>();
+
+    const from = opts["from"] as string | undefined;
+    const to = opts["to"] as string | undefined;
+    const granularity = opts["granularity"] as string;
+
+    if ((from === undefined) !== (to === undefined)) {
+      throw new Error("Both --from and --to must be specified together.");
+    }
+
+    if (from === undefined && to === undefined && granularity !== "month") {
+      throw new Error("--granularity requires --from and --to.");
+    }
+
+    const { config } = await resolveConfig({
+      profile: globals.profile,
+      requiredScopes: ["rw_organization_admin"],
+    });
+    const accessToken = config.oauth?.accessToken ?? "";
+    const apiVersion = config.apiVersion ?? "";
+    const client = new LinkedInClient({ accessToken, apiVersion });
+
+    try {
+      const organizationUrn = `urn:li:organization:${id}`;
+      const options: Parameters<typeof getOrgStats>[1] = { organizationUrn };
+
+      if (from !== undefined && to !== undefined) {
+        options.timeGranularity = granularity.toUpperCase() as OrgStatsTimeGranularity;
+        options.timeRange = {
+          start: new Date(from).getTime(),
+          end: new Date(to).getTime(),
+        };
+      }
+
+      const response = await getOrgStats(client, options);
+
+      const format = resolveFormat(opts["format"] as OutputFormat | undefined, process.stdout, globals.json === true);
+      if (format === "json") {
+        console.log(formatOutput(response, format));
+      } else {
+        const rows = response.elements.map(formatStatsRow);
+        const data = rows.length === 1 ? rows[0] : rows;
+        console.log(formatOutput(data, format));
+      }
+    } catch (error) {
+      if (error instanceof LinkedInApiError) {
+        throw new Error(`Failed to get organization statistics: ${error.message}`);
+      }
+      throw error;
+    }
+  });
+
+  return cmd;
+}

--- a/packages/cli/src/commands/stats/post.test.ts
+++ b/packages/cli/src/commands/stats/post.test.ts
@@ -17,6 +17,24 @@ vi.mock("@linkedctl/core", async (importOriginal) => {
       warnings: [],
     }),
     getPostAnalytics: vi.fn(),
+    getOrgStats: vi.fn().mockResolvedValue({
+      elements: [
+        {
+          organizationalEntity: "urn:li:organization:12345",
+          share: "urn:li:share:999",
+          totalShareStatistics: {
+            clickCount: 42,
+            commentCount: 5,
+            engagement: 0.03,
+            impressionCount: 500,
+            likeCount: 20,
+            shareCount: 3,
+            uniqueImpressionsCount: 400,
+          },
+        },
+      ],
+      paging: { count: 1, start: 0 },
+    }),
   };
 });
 
@@ -30,7 +48,7 @@ const SAMPLE_ANALYTICS: PostAnalytics = {
   reshares: { status: "success", dataPoints: [{ count: 5 }] },
 };
 
-describe("stats post", () => {
+describe("stats post (member analytics)", () => {
   let consoleSpy: ReturnType<typeof vi.spyOn>;
   let stderrSpy: ReturnType<typeof vi.spyOn>;
 
@@ -219,5 +237,115 @@ describe("stats post", () => {
     } finally {
       Object.defineProperty(process.stdout, "isTTY", { value: originalIsTTY, writable: true });
     }
+  });
+});
+
+describe("stats post --org (org share statistics)", () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches per-post org statistics", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "stats", "post", "urn:li:share:999", "--org", "12345"]);
+
+    expect(coreMock.getOrgStats).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        organizationUrn: "urn:li:organization:12345",
+        shares: ["urn:li:share:999"],
+      }),
+    );
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+
+  it("outputs JSON when --format json is specified", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "linkedctl",
+      "stats",
+      "post",
+      "urn:li:share:999",
+      "--org",
+      "12345",
+      "--format",
+      "json",
+    ]);
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(output) as Record<string, unknown>;
+    expect(parsed).toHaveProperty("elements");
+  });
+
+  it("resolves config with required scopes", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "stats", "post", "urn:li:share:999", "--org", "12345"]);
+
+    expect(coreMock.resolveConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requiredScopes: ["rw_organization_admin"],
+      }),
+    );
+  });
+
+  it("resolves config with profile from global options", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "linkedctl",
+      "--profile",
+      "analytics",
+      "stats",
+      "post",
+      "urn:li:share:999",
+      "--org",
+      "12345",
+    ]);
+
+    expect(coreMock.resolveConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profile: "analytics",
+      }),
+    );
+  });
+
+  it("wraps API errors with actionable message", async () => {
+    const { LinkedInApiError } = await import("@linkedctl/core");
+    vi.mocked(coreMock.getOrgStats).mockRejectedValueOnce(new LinkedInApiError("Forbidden", 403));
+
+    const program = createProgram();
+    await expect(
+      program.parseAsync(["node", "linkedctl", "stats", "post", "urn:li:share:999", "--org", "12345"]),
+    ).rejects.toThrow(/Failed to get post statistics/);
+  });
+
+  it("handles empty results gracefully in table format", async () => {
+    vi.mocked(coreMock.getOrgStats).mockResolvedValueOnce({
+      elements: [],
+      paging: { count: 0, start: 0 },
+    });
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "linkedctl",
+      "stats",
+      "post",
+      "urn:li:share:999",
+      "--org",
+      "12345",
+      "--format",
+      "table",
+    ]);
+
+    expect(consoleSpy).toHaveBeenCalledWith("No statistics found for this post.");
   });
 });

--- a/packages/cli/src/commands/stats/post.ts
+++ b/packages/cli/src/commands/stats/post.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { Command, Option } from "commander";
-import { resolveConfig, LinkedInClient, getPostAnalytics, LinkedInApiError } from "@linkedctl/core";
+import { resolveConfig, LinkedInClient, getPostAnalytics, getOrgStats, LinkedInApiError } from "@linkedctl/core";
 import type { OutputFormat } from "../../output/index.js";
 import { resolveFormat, formatOutput } from "../../output/index.js";
 import { warnUnavailableMetrics, buildTotalRows, enhanceAnalyticsScopeError } from "./helpers.js";
@@ -11,44 +11,114 @@ export function postCommand(): Command {
   const cmd = new Command("post");
   cmd.description("Get analytics for a LinkedIn post");
   cmd.argument("<urn>", "post URN (e.g. urn:li:share:123 or urn:li:ugcPost:123)");
+  cmd.option("--org <id>", "organization ID for org share statistics (numeric, e.g. 12345)");
   cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
 
   cmd.action(async (urn: string, opts: Record<string, unknown>, actionCmd: Command) => {
     const globals = actionCmd.optsWithGlobals<{ profile?: string | undefined; json?: boolean | undefined }>();
+    const orgId = opts["org"] as string | undefined;
 
-    try {
-      const { config } = await resolveConfig({
-        profile: globals.profile,
-        requiredScopes: ["r_member_postAnalytics"],
-      });
-      const accessToken = config.oauth?.accessToken ?? "";
-      const apiVersion = config.apiVersion ?? "";
-      const client = new LinkedInClient({ accessToken, apiVersion });
-
-      const analytics = await getPostAnalytics(client, { postUrn: urn });
-
-      warnUnavailableMetrics(analytics);
-
-      const format = resolveFormat(opts["format"] as OutputFormat | undefined, process.stdout, globals.json === true);
-
-      if (format === "json") {
-        console.log(formatOutput(analytics, format));
-      } else {
-        const rows = buildTotalRows(analytics);
-        if (rows.length === 0) {
-          console.log("No metrics available.");
-          return;
-        }
-        console.log(formatOutput(rows, format));
-      }
-    } catch (error) {
-      enhanceAnalyticsScopeError(error, globals.profile);
-      if (error instanceof LinkedInApiError) {
-        throw new Error(`Failed to get post analytics: ${error.message}`);
-      }
-      throw error;
+    if (orgId !== undefined) {
+      await handleOrgPostStats(urn, orgId, opts, globals);
+    } else {
+      await handleMemberPostStats(urn, opts, globals);
     }
   });
 
   return cmd;
+}
+
+async function handleMemberPostStats(
+  urn: string,
+  opts: Record<string, unknown>,
+  globals: { profile?: string | undefined; json?: boolean | undefined },
+): Promise<void> {
+  try {
+    const { config } = await resolveConfig({
+      profile: globals.profile,
+      requiredScopes: ["r_member_postAnalytics"],
+    });
+    const accessToken = config.oauth?.accessToken ?? "";
+    const apiVersion = config.apiVersion ?? "";
+    const client = new LinkedInClient({ accessToken, apiVersion });
+
+    const analytics = await getPostAnalytics(client, { postUrn: urn });
+
+    warnUnavailableMetrics(analytics);
+
+    const format = resolveFormat(opts["format"] as OutputFormat | undefined, process.stdout, globals.json === true);
+
+    if (format === "json") {
+      console.log(formatOutput(analytics, format));
+    } else {
+      const rows = buildTotalRows(analytics);
+      if (rows.length === 0) {
+        console.log("No metrics available.");
+        return;
+      }
+      console.log(formatOutput(rows, format));
+    }
+  } catch (error) {
+    enhanceAnalyticsScopeError(error, globals.profile);
+    if (error instanceof LinkedInApiError) {
+      throw new Error(`Failed to get post analytics: ${error.message}`);
+    }
+    throw error;
+  }
+}
+
+async function handleOrgPostStats(
+  urn: string,
+  orgId: string,
+  opts: Record<string, unknown>,
+  globals: { profile?: string | undefined; json?: boolean | undefined },
+): Promise<void> {
+  const { config } = await resolveConfig({
+    profile: globals.profile,
+    requiredScopes: ["rw_organization_admin"],
+  });
+  const accessToken = config.oauth?.accessToken ?? "";
+  const apiVersion = config.apiVersion ?? "";
+  const client = new LinkedInClient({ accessToken, apiVersion });
+
+  try {
+    const organizationUrn = `urn:li:organization:${orgId}`;
+
+    const response = await getOrgStats(client, {
+      organizationUrn,
+      shares: [urn],
+    });
+
+    const format = resolveFormat(opts["format"] as OutputFormat | undefined, process.stdout, globals.json === true);
+    if (format === "json") {
+      console.log(formatOutput(response, format));
+    } else {
+      const el = response.elements[0];
+      if (el === undefined) {
+        console.log("No statistics found for this post.");
+        return;
+      }
+      const s = el.totalShareStatistics;
+      console.log(
+        formatOutput(
+          {
+            post: el.share ?? urn,
+            impressions: s.impressionCount,
+            uniqueImpressions: s.uniqueImpressionsCount,
+            clicks: s.clickCount,
+            likes: s.likeCount,
+            comments: s.commentCount,
+            shares: s.shareCount,
+            engagement: s.engagement,
+          },
+          format,
+        ),
+      );
+    }
+  } catch (error) {
+    if (error instanceof LinkedInApiError) {
+      throw new Error(`Failed to get post statistics: ${error.message}`);
+    }
+    throw error;
+  }
 }


### PR DESCRIPTION
## Summary

- Add `stats org <id>` command for organization share statistics (lifetime and time-bound with `--from`/`--to`/`--granularity`)
- Add `stats post <urn> --org <id>` command for per-post organization share statistics
- Both commands require `rw_organization_admin` scope with helpful error messages on mismatch
- Support `--format json|table` and `--json` global option

Closes #152

## Test plan

- [x] `stats org` fetches lifetime org statistics
- [x] `stats org` with `--from`/`--to` passes time range with default MONTH granularity
- [x] `stats org` with `--granularity day` passes DAY granularity
- [x] `stats org` rejects `--from` without `--to` (and vice versa)
- [x] `stats org` rejects `--granularity` without date range
- [x] `stats org` outputs JSON with `--format json`
- [x] `stats org` resolves config with `rw_organization_admin` scope
- [x] `stats org` passes profile from global `--profile` option
- [x] `stats org` wraps API errors with actionable message
- [x] `stats post` fetches per-post statistics with share URN
- [x] `stats post` outputs JSON with `--format json`
- [x] `stats post` resolves config with `rw_organization_admin` scope
- [x] `stats post` passes profile from global `--profile` option
- [x] `stats post` wraps API errors with actionable message
- [x] `stats post` handles empty results gracefully in table format

🤖 Generated with [Claude Code](https://claude.com/claude-code)