### PR TITLE
Add organization share statistics MCP tool

### DIFF
--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -44,6 +44,7 @@ vi.mock("@linkedctl/core", () => ({
   getOrganizationFollowerCount: vi.fn(),
   getPostAnalytics: vi.fn(),
   getMemberAnalytics: vi.fn(),
+  getOrgStats: vi.fn(),
   SUPPORTED_IMAGE_TYPES: new Map([
     [".jpg", "image/jpeg"],
     [".jpeg", "image/jpeg"],
@@ -87,6 +88,7 @@ import {
   getOrganizationFollowerCount,
   getPostAnalytics,
   getMemberAnalytics,
+  getOrgStats,
   loadConfigFile,
   validateConfig,
   getTokenExpiry,
@@ -144,6 +146,7 @@ describe("createMcpServer", () => {
     expect(toolNames).toContain("org_followers");
     expect(toolNames).toContain("stats_post");
     expect(toolNames).toContain("stats_me");
+    expect(toolNames).toContain("stats_org");
   });
 
   describe("whoami", () => {
@@ -2736,6 +2739,141 @@ describe("createMcpServer", () => {
         profile: "community-mgmt",
         requiredScopes: ["openid", "profile", "email", "r_member_postAnalytics"],
       });
+    });
+  });
+
+  describe("stats_org", () => {
+    it("returns lifetime aggregate stats for an organization", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: { oauth: { accessToken: "tok" }, apiVersion: "202601" },
+        warnings: [],
+      } as never);
+
+      const mockResponse = {
+        elements: [
+          {
+            organizationalEntity: "urn:li:organization:12345",
+            totalShareStatistics: {
+              clickCount: 10,
+              commentCount: 5,
+              engagement: 0.02,
+              impressionCount: 500,
+              likeCount: 20,
+              shareCount: 3,
+              uniqueImpressionsCount: 400,
+            },
+          },
+        ],
+        paging: { count: 1, start: 0 },
+      };
+      vi.mocked(getOrgStats).mockResolvedValue(mockResponse);
+
+      const result = await client.callTool({ name: "stats_org", arguments: { id: "12345" } });
+
+      expect(resolveConfig).toHaveBeenCalledWith({
+        profile: undefined,
+        requiredScopes: ["rw_organization_admin"],
+      });
+      expect(getOrgStats).toHaveBeenCalledWith(expect.anything(), {
+        organizationUrn: "urn:li:organization:12345",
+        timeGranularity: undefined,
+        timeRange: undefined,
+        shares: undefined,
+      });
+      const text = (result.content as Array<{ type: string; text: string }>)[0]?.text ?? "";
+      const parsed = JSON.parse(text) as Record<string, unknown>;
+      expect(parsed).toHaveProperty("elements");
+    });
+
+    it("passes time range and granularity", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: { oauth: { accessToken: "tok" }, apiVersion: "202601" },
+        warnings: [],
+      } as never);
+      vi.mocked(getOrgStats).mockResolvedValue({ elements: [], paging: { count: 0, start: 0 } });
+
+      await client.callTool({
+        name: "stats_org",
+        arguments: { id: "12345", time_granularity: "MONTH", start: "2026-01-01", end: "2026-02-01" },
+      });
+
+      expect(getOrgStats).toHaveBeenCalledWith(expect.anything(), {
+        organizationUrn: "urn:li:organization:12345",
+        timeGranularity: "MONTH",
+        timeRange: {
+          start: new Date("2026-01-01").getTime(),
+          end: new Date("2026-02-01").getTime(),
+        },
+        shares: undefined,
+      });
+    });
+
+    it("passes share URNs when provided", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: { oauth: { accessToken: "tok" }, apiVersion: "202601" },
+        warnings: [],
+      } as never);
+      vi.mocked(getOrgStats).mockResolvedValue({ elements: [], paging: { count: 0, start: 0 } });
+
+      await client.callTool({
+        name: "stats_org",
+        arguments: { id: "12345", shares: "urn:li:share:aaa,urn:li:share:bbb" },
+      });
+
+      expect(getOrgStats).toHaveBeenCalledWith(expect.anything(), {
+        organizationUrn: "urn:li:organization:12345",
+        timeGranularity: undefined,
+        timeRange: undefined,
+        shares: ["urn:li:share:aaa", "urn:li:share:bbb"],
+      });
+    });
+
+    it("passes profile parameter to resolveConfig", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: { oauth: { accessToken: "tok" }, apiVersion: "202601" },
+        warnings: [],
+      } as never);
+      vi.mocked(getOrgStats).mockResolvedValue({ elements: [], paging: { count: 0, start: 0 } });
+
+      await client.callTool({ name: "stats_org", arguments: { id: "12345", profile: "work" } });
+
+      expect(resolveConfig).toHaveBeenCalledWith({
+        profile: "work",
+        requiredScopes: ["rw_organization_admin"],
+      });
+    });
+
+    it("returns error when start is provided without end", async () => {
+      const result = await client.callTool({
+        name: "stats_org",
+        arguments: { id: "12345", start: "2026-01-01" },
+      });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content as Array<{ type: string; text: string }>)[0]?.text ?? "";
+      expect(text).toContain("Both start and end must be provided");
+    });
+
+    it("returns error when end is provided without start", async () => {
+      const result = await client.callTool({
+        name: "stats_org",
+        arguments: { id: "12345", end: "2026-02-01" },
+      });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content as Array<{ type: string; text: string }>)[0]?.text ?? "";
+      expect(text).toContain("Both start and end must be provided");
+    });
+
+    it("returns error when time_granularity is provided without date range", async () => {
+      const result = await client.callTool({
+        name: "stats_org",
+        arguments: { id: "12345", time_granularity: "DAY" },
+      });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content as Array<{ type: string; text: string }>)[0]?.text ?? "";
+      expect(text).toContain("time_granularity requires both start and end");
     });
   });
 });

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -32,6 +32,7 @@ import {
   getOrganizationFollowerCount,
   getPostAnalytics,
   getMemberAnalytics,
+  getOrgStats,
   SUPPORTED_IMAGE_TYPES,
   DOCUMENT_EXTENSIONS,
   DOCUMENT_MAX_SIZE_BYTES,
@@ -1089,6 +1090,85 @@ export function createMcpServer(): McpServer {
 
       return {
         content: [{ type: "text" as const, text: JSON.stringify(analytics, null, 2) }],
+      };
+    },
+  );
+
+  server.registerTool(
+    "stats_org",
+    {
+      title: "Organization Share Statistics",
+      description:
+        "Get share statistics for a LinkedIn organization. Returns lifetime aggregate statistics by default. " +
+        "When time_granularity and start/end are provided, returns time-bucketed statistics.",
+      inputSchema: {
+        id: z.string().describe("Organization ID (numeric, e.g. 12345)"),
+        time_granularity: z
+          .enum(["DAY", "MONTH"])
+          .optional()
+          .describe("Time granularity for bucketed results (DAY or MONTH). Requires start and end."),
+        start: z.string().optional().describe("Start of time range (ISO 8601 date, e.g. 2026-01-01). Requires end."),
+        end: z.string().optional().describe("End of time range (ISO 8601 date, e.g. 2026-02-01). Requires start."),
+        shares: z.string().optional().describe("Comma-separated share URNs to filter statistics for specific posts"),
+        profile: z.string().optional().describe("Profile name to use from config file"),
+      },
+    },
+    async (args) => {
+      if (
+        (args.start !== undefined || args.end !== undefined) &&
+        (args.start === undefined || args.end === undefined)
+      ) {
+        return {
+          content: [{ type: "text" as const, text: "Both start and end must be provided for a time range." }],
+          isError: true,
+        };
+      }
+
+      if (args.time_granularity !== undefined && (args.start === undefined || args.end === undefined)) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "time_granularity requires both start and end to be provided.",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const { config } = await resolveConfig({
+        profile: args.profile,
+        requiredScopes: ["rw_organization_admin"],
+      });
+      const accessToken = config.oauth?.accessToken ?? "";
+      const apiVersion = config.apiVersion ?? "";
+      const client = new LinkedInClient({ accessToken, apiVersion });
+
+      const organizationUrn = `urn:li:organization:${args.id}`;
+
+      const timeGranularity = args.time_granularity;
+      const timeRange =
+        args.start !== undefined && args.end !== undefined
+          ? { start: new Date(args.start).getTime(), end: new Date(args.end).getTime() }
+          : undefined;
+
+      const shares =
+        args.shares !== undefined
+          ? args.shares
+              .split(",")
+              .map((s) => s.trim())
+              .filter((s) => s.length > 0)
+          : undefined;
+
+      const response = await getOrgStats(client, {
+        organizationUrn,
+        timeGranularity,
+        timeRange,
+        shares,
+      });
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(response, null, 2) }],
       };
     },
   );


### PR DESCRIPTION
## Summary
- Add `stats_org` MCP tool for organization share statistics (#153)
- Supports lifetime aggregate stats, time-bucketed stats (DAY/MONTH granularity), and per-share filtering
- Requires `rw_organization_admin` scope with scope-mismatch error guidance
- Per-tool `profile` parameter for config resolution

## Test plan
- [x] Unit tests for lifetime stats, time-bound stats, share URN filtering
- [x] Unit tests for profile parameter passthrough
- [x] Unit tests for validation errors (missing start/end, granularity without date range)
- [x] All existing tests pass
- [x] Build, typecheck, lint, and format checks pass

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)