### PR TITLE
(feat) add member stats CLI commands

### DIFF
--- a/packages/cli/src/commands/stats/helpers.ts
+++ b/packages/cli/src/commands/stats/helpers.ts
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { ConfigError } from "@linkedctl/core";
+import type { AnalyticsDate, MetricResult, PostAnalytics } from "@linkedctl/core";
+
+/**
+ * Human-readable labels for each metric key.
+ */
+const METRIC_LABELS: Record<keyof PostAnalytics, string> = {
+  impressions: "Impressions",
+  membersReached: "Members reached",
+  reactions: "Reactions",
+  comments: "Comments",
+  reshares: "Reshares",
+};
+
+/**
+ * Print warnings to stderr for any unavailable or excluded metrics.
+ */
+export function warnUnavailableMetrics(analytics: PostAnalytics): void {
+  const warnings: string[] = [];
+  for (const [key, result] of Object.entries(analytics) as [keyof PostAnalytics, MetricResult][]) {
+    if (result.status === "unavailable") {
+      warnings.push(`${METRIC_LABELS[key]}: ${result.reason}`);
+    } else if (result.status === "excluded") {
+      warnings.push(`${METRIC_LABELS[key]}: ${result.reason}`);
+    }
+  }
+  if (warnings.length > 0) {
+    console.error(`warning: Some metrics are unavailable:\n${warnings.map((w) => `  - ${w}`).join("\n")}`);
+  }
+}
+
+/**
+ * Build table rows for TOTAL aggregation: one row per successful metric.
+ */
+export function buildTotalRows(analytics: PostAnalytics): { metric: string; count: number }[] {
+  const rows: { metric: string; count: number }[] = [];
+  for (const [key, result] of Object.entries(analytics) as [keyof PostAnalytics, MetricResult][]) {
+    if (result.status === "success") {
+      const total = result.dataPoints.reduce((sum, dp) => sum + dp.count, 0);
+      rows.push({ metric: METRIC_LABELS[key], count: total });
+    }
+  }
+  return rows;
+}
+
+/**
+ * Build table rows for DAILY aggregation: one row per date with metric columns.
+ */
+export function buildDailyRows(analytics: PostAnalytics): Record<string, unknown>[] {
+  const dateMap = new Map<string, Record<string, unknown>>();
+
+  for (const [key, result] of Object.entries(analytics) as [keyof PostAnalytics, MetricResult][]) {
+    if (result.status !== "success") continue;
+    for (const dp of result.dataPoints) {
+      if (dp.dateRange?.start === undefined) continue;
+      const dateStr = formatDate(dp.dateRange.start);
+      let row = dateMap.get(dateStr);
+      if (row === undefined) {
+        row = { date: dateStr };
+        dateMap.set(dateStr, row);
+      }
+      row[METRIC_LABELS[key]] = dp.count;
+    }
+  }
+
+  const sortedDates = [...dateMap.keys()].sort();
+  return sortedDates.flatMap((date) => {
+    const row = dateMap.get(date);
+    return row !== undefined ? [row] : [];
+  });
+}
+
+/**
+ * Parse a YYYY-MM-DD string into an AnalyticsDate.
+ */
+export function parseDate(value: string): AnalyticsDate {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (match === null) {
+    throw new Error(`Invalid date format: "${value}". Expected YYYY-MM-DD.`);
+  }
+  const [, yearStr, monthStr, dayStr] = match;
+  if (yearStr === undefined || monthStr === undefined || dayStr === undefined) {
+    throw new Error(`Invalid date format: "${value}". Expected YYYY-MM-DD.`);
+  }
+  const year = parseInt(yearStr, 10);
+  const month = parseInt(monthStr, 10);
+  const day = parseInt(dayStr, 10);
+
+  if (month < 1 || month > 12 || day < 1 || day > 31) {
+    throw new Error(`Invalid date: "${value}". Month must be 1-12, day must be 1-31.`);
+  }
+
+  return { year, month, day };
+}
+
+/**
+ * Format an AnalyticsDate as YYYY-MM-DD.
+ */
+export function formatDate(date: AnalyticsDate): string {
+  return `${String(date.year)}-${String(date.month).padStart(2, "0")}-${String(date.day).padStart(2, "0")}`;
+}
+
+/**
+ * Add one day to an AnalyticsDate, handling month/year boundaries.
+ * Used to convert an inclusive --to date to the API's exclusive end date.
+ */
+export function addDay(date: AnalyticsDate): AnalyticsDate {
+  const d = new Date(date.year, date.month - 1, date.day + 1);
+  return {
+    year: d.getFullYear(),
+    month: d.getMonth() + 1,
+    day: d.getDate(),
+  };
+}
+
+/**
+ * Enhance a ConfigError for analytics scope requirements.
+ *
+ * When the error is about missing `r_member_postAnalytics`, throws a new
+ * ConfigError with additional guidance about product exclusivity and
+ * a suggested dedicated analytics profile name.
+ */
+export function enhanceAnalyticsScopeError(error: unknown, profile: string | undefined): void {
+  if (!(error instanceof ConfigError)) return;
+  if (!error.message.includes("r_member_postAnalytics")) return;
+
+  const profileName = profile !== undefined ? `${profile}-analytics` : "analytics";
+  throw new ConfigError(
+    error.message +
+      ` LinkedIn's Community Management API requires a dedicated Developer App` +
+      ` that cannot share scopes with other products.` +
+      ` Consider a dedicated analytics profile: linkedctl auth setup --product community-management --profile ${profileName}`,
+  );
+}

--- a/packages/cli/src/commands/stats/index.ts
+++ b/packages/cli/src/commands/stats/index.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { Command } from "commander";
+import { postCommand } from "./post.js";
+import { meCommand } from "./me.js";
+
+export function statsCommand(): Command {
+  const cmd = new Command("stats");
+  cmd.description("View analytics and statistics");
+
+  cmd.addHelpText(
+    "after",
+    `
+Examples:
+  linkedctl stats post urn:li:share:123
+  linkedctl stats me
+  linkedctl stats me --from 2024-05-01 --to 2024-05-31`,
+  );
+
+  cmd.addCommand(postCommand());
+  cmd.addCommand(meCommand());
+
+  return cmd;
+}

--- a/packages/cli/src/commands/stats/me.test.ts
+++ b/packages/cli/src/commands/stats/me.test.ts
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { PostAnalytics } from "@linkedctl/core";
+import { createProgram } from "../../program.js";
+
+vi.mock("@linkedctl/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@linkedctl/core")>();
+  return {
+    ...actual,
+    resolveConfig: vi.fn().mockResolvedValue({
+      config: {
+        oauth: { accessToken: "test-token" },
+        apiVersion: "202601",
+      },
+      warnings: [],
+    }),
+    getMemberAnalytics: vi.fn(),
+  };
+});
+
+const coreMock = await import("@linkedctl/core");
+
+const SAMPLE_TOTAL_ANALYTICS: PostAnalytics = {
+  impressions: { status: "success", dataPoints: [{ count: 5678 }] },
+  membersReached: { status: "success", dataPoints: [{ count: 1234 }] },
+  reactions: { status: "success", dataPoints: [{ count: 234 }] },
+  comments: { status: "success", dataPoints: [{ count: 56 }] },
+  reshares: { status: "success", dataPoints: [{ count: 23 }] },
+};
+
+const SAMPLE_DAILY_ANALYTICS: PostAnalytics = {
+  impressions: {
+    status: "success",
+    dataPoints: [
+      { count: 100, dateRange: { start: { year: 2024, month: 5, day: 1 }, end: { year: 2024, month: 5, day: 2 } } },
+      { count: 120, dateRange: { start: { year: 2024, month: 5, day: 2 }, end: { year: 2024, month: 5, day: 3 } } },
+    ],
+  },
+  membersReached: {
+    status: "excluded",
+    reason: "MEMBERS_REACHED with DAILY aggregation is not supported by the LinkedIn API",
+  },
+  reactions: {
+    status: "success",
+    dataPoints: [
+      { count: 10, dateRange: { start: { year: 2024, month: 5, day: 1 }, end: { year: 2024, month: 5, day: 2 } } },
+      { count: 15, dateRange: { start: { year: 2024, month: 5, day: 2 }, end: { year: 2024, month: 5, day: 3 } } },
+    ],
+  },
+  comments: {
+    status: "success",
+    dataPoints: [
+      { count: 2, dateRange: { start: { year: 2024, month: 5, day: 1 }, end: { year: 2024, month: 5, day: 2 } } },
+      { count: 3, dateRange: { start: { year: 2024, month: 5, day: 2 }, end: { year: 2024, month: 5, day: 3 } } },
+    ],
+  },
+  reshares: {
+    status: "success",
+    dataPoints: [
+      { count: 1, dateRange: { start: { year: 2024, month: 5, day: 1 }, end: { year: 2024, month: 5, day: 2 } } },
+      { count: 0, dateRange: { start: { year: 2024, month: 5, day: 2 }, end: { year: 2024, month: 5, day: 3 } } },
+    ],
+  },
+};
+
+describe("stats me", () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(coreMock.getMemberAnalytics).mockResolvedValue(SAMPLE_TOTAL_ANALYTICS);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("displays lifetime totals table when no date range is given (TTY)", async () => {
+    const originalIsTTY = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, "isTTY", { value: true, writable: true });
+
+    try {
+      const program = createProgram();
+      await program.parseAsync(["node", "linkedctl", "stats", "me"]);
+
+      expect(coreMock.getMemberAnalytics).toHaveBeenCalledWith(expect.anything(), undefined);
+      expect(consoleSpy).toHaveBeenCalledOnce();
+
+      const output = consoleSpy.mock.calls[0]?.[0] as string;
+      expect(output).toContain("Impressions");
+      expect(output).toContain("5678");
+      expect(output).toContain("Members reached");
+      expect(output).toContain("1234");
+    } finally {
+      Object.defineProperty(process.stdout, "isTTY", { value: originalIsTTY, writable: true });
+    }
+  });
+
+  it("outputs JSON for lifetime totals when piped", async () => {
+    const originalIsTTY = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, "isTTY", { value: false, writable: true });
+
+    try {
+      const program = createProgram();
+      await program.parseAsync(["node", "linkedctl", "stats", "me"]);
+
+      const output = consoleSpy.mock.calls[0]?.[0] as string;
+      const parsed = JSON.parse(output) as PostAnalytics;
+      expect(parsed.impressions).toEqual({ status: "success", dataPoints: [{ count: 5678 }] });
+    } finally {
+      Object.defineProperty(process.stdout, "isTTY", { value: originalIsTTY, writable: true });
+    }
+  });
+
+  it("displays daily breakdown table with --from and --to (TTY)", async () => {
+    vi.mocked(coreMock.getMemberAnalytics).mockResolvedValueOnce(SAMPLE_DAILY_ANALYTICS);
+
+    const originalIsTTY = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, "isTTY", { value: true, writable: true });
+
+    try {
+      const program = createProgram();
+      await program.parseAsync(["node", "linkedctl", "stats", "me", "--from", "2024-05-01", "--to", "2024-05-02"]);
+
+      expect(coreMock.getMemberAnalytics).toHaveBeenCalledWith(expect.anything(), {
+        aggregation: "DAILY",
+        dateRange: {
+          start: { year: 2024, month: 5, day: 1 },
+          end: { year: 2024, month: 5, day: 3 },
+        },
+      });
+
+      const output = consoleSpy.mock.calls[0]?.[0] as string;
+      expect(output).toContain("2024-05-01");
+      expect(output).toContain("2024-05-02");
+      expect(output).toContain("100");
+      expect(output).toContain("120");
+    } finally {
+      Object.defineProperty(process.stdout, "isTTY", { value: originalIsTTY, writable: true });
+    }
+  });
+
+  it("outputs JSON for daily breakdown with --format json", async () => {
+    vi.mocked(coreMock.getMemberAnalytics).mockResolvedValueOnce(SAMPLE_DAILY_ANALYTICS);
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "linkedctl",
+      "stats",
+      "me",
+      "--from",
+      "2024-05-01",
+      "--to",
+      "2024-05-02",
+      "--format",
+      "json",
+    ]);
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(output) as PostAnalytics;
+    expect(parsed.impressions.status).toBe("success");
+  });
+
+  it("errors when --from is given without --to", async () => {
+    const program = createProgram();
+    program.exitOverride();
+
+    await expect(program.parseAsync(["node", "linkedctl", "stats", "me", "--from", "2024-05-01"])).rejects.toThrow(
+      "--from and --to must be used together",
+    );
+  });
+
+  it("errors when --to is given without --from", async () => {
+    const program = createProgram();
+    program.exitOverride();
+
+    await expect(program.parseAsync(["node", "linkedctl", "stats", "me", "--to", "2024-05-31"])).rejects.toThrow(
+      "--from and --to must be used together",
+    );
+  });
+
+  it("errors on invalid date format", async () => {
+    const program = createProgram();
+    program.exitOverride();
+
+    await expect(
+      program.parseAsync(["node", "linkedctl", "stats", "me", "--from", "05/01/2024", "--to", "05/31/2024"]),
+    ).rejects.toThrow(/Invalid date format.*Expected YYYY-MM-DD/);
+  });
+
+  it("errors on invalid date values", async () => {
+    const program = createProgram();
+    program.exitOverride();
+
+    await expect(
+      program.parseAsync(["node", "linkedctl", "stats", "me", "--from", "2024-13-01", "--to", "2024-13-31"]),
+    ).rejects.toThrow(/Invalid date.*Month must be 1-12/);
+  });
+
+  it("warns about excluded metrics on stderr for daily breakdown", async () => {
+    vi.mocked(coreMock.getMemberAnalytics).mockResolvedValueOnce(SAMPLE_DAILY_ANALYTICS);
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "linkedctl",
+      "stats",
+      "me",
+      "--from",
+      "2024-05-01",
+      "--to",
+      "2024-05-02",
+      "--format",
+      "json",
+    ]);
+
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("Members reached"));
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("DAILY aggregation is not supported"));
+  });
+
+  it("resolves config with r_member_postAnalytics scope", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "stats", "me", "--format", "json"]);
+
+    expect(coreMock.resolveConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requiredScopes: ["r_member_postAnalytics"],
+      }),
+    );
+  });
+
+  it("wraps API errors with actionable message", async () => {
+    const { LinkedInApiError } = await import("@linkedctl/core");
+    vi.mocked(coreMock.getMemberAnalytics).mockRejectedValueOnce(new LinkedInApiError("Server Error", 500));
+
+    const program = createProgram();
+    program.exitOverride();
+
+    await expect(program.parseAsync(["node", "linkedctl", "stats", "me"])).rejects.toThrow(
+      /Failed to get member analytics/,
+    );
+  });
+
+  it("enhances scope mismatch error with analytics profile suggestion", async () => {
+    const { ConfigError } = await import("@linkedctl/core");
+    vi.mocked(coreMock.resolveConfig).mockRejectedValueOnce(
+      new ConfigError("Missing required OAuth scopes: r_member_postAnalytics."),
+    );
+
+    const program = createProgram();
+    program.exitOverride();
+
+    await expect(program.parseAsync(["node", "linkedctl", "stats", "me"])).rejects.toThrow(
+      /dedicated analytics profile.*--profile analytics/,
+    );
+  });
+
+  it("converts inclusive --to date to exclusive API end date", async () => {
+    vi.mocked(coreMock.getMemberAnalytics).mockResolvedValueOnce(SAMPLE_DAILY_ANALYTICS);
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "linkedctl",
+      "stats",
+      "me",
+      "--from",
+      "2024-12-30",
+      "--to",
+      "2024-12-31",
+      "--format",
+      "json",
+    ]);
+
+    expect(coreMock.getMemberAnalytics).toHaveBeenCalledWith(expect.anything(), {
+      aggregation: "DAILY",
+      dateRange: {
+        start: { year: 2024, month: 12, day: 30 },
+        end: { year: 2025, month: 1, day: 1 },
+      },
+    });
+  });
+});

--- a/packages/cli/src/commands/stats/me.ts
+++ b/packages/cli/src/commands/stats/me.ts
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { Command, Option } from "commander";
+import { resolveConfig, LinkedInClient, getMemberAnalytics, LinkedInApiError } from "@linkedctl/core";
+import type { OutputFormat } from "../../output/index.js";
+import { resolveFormat, formatOutput } from "../../output/index.js";
+import {
+  warnUnavailableMetrics,
+  buildTotalRows,
+  buildDailyRows,
+  parseDate,
+  addDay,
+  enhanceAnalyticsScopeError,
+} from "./helpers.js";
+
+export function meCommand(): Command {
+  const cmd = new Command("me");
+  cmd.description("Get aggregated analytics across all your posts");
+  cmd.option("--from <date>", "start date for daily breakdown (YYYY-MM-DD, inclusive)");
+  cmd.option("--to <date>", "end date for daily breakdown (YYYY-MM-DD, inclusive)");
+  cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
+
+  cmd.action(async (opts: Record<string, unknown>, actionCmd: Command) => {
+    const globals = actionCmd.optsWithGlobals<{ profile?: string | undefined; json?: boolean | undefined }>();
+
+    const from = opts["from"] as string | undefined;
+    const to = opts["to"] as string | undefined;
+
+    if ((from === undefined) !== (to === undefined)) {
+      throw new Error("--from and --to must be used together");
+    }
+
+    try {
+      const { config } = await resolveConfig({
+        profile: globals.profile,
+        requiredScopes: ["r_member_postAnalytics"],
+      });
+      const accessToken = config.oauth?.accessToken ?? "";
+      const apiVersion = config.apiVersion ?? "";
+      const client = new LinkedInClient({ accessToken, apiVersion });
+
+      const hasDateRange = from !== undefined && to !== undefined;
+      const analytics = await getMemberAnalytics(
+        client,
+        hasDateRange
+          ? {
+              aggregation: "DAILY",
+              dateRange: {
+                start: parseDate(from),
+                end: addDay(parseDate(to)),
+              },
+            }
+          : undefined,
+      );
+
+      warnUnavailableMetrics(analytics);
+
+      const format = resolveFormat(opts["format"] as OutputFormat | undefined, process.stdout, globals.json === true);
+
+      if (format === "json") {
+        console.log(formatOutput(analytics, format));
+      } else if (hasDateRange) {
+        const rows = buildDailyRows(analytics);
+        if (rows.length === 0) {
+          console.log("No data available for the specified date range.");
+          return;
+        }
+        console.log(formatOutput(rows, format));
+      } else {
+        const rows = buildTotalRows(analytics);
+        if (rows.length === 0) {
+          console.log("No metrics available.");
+          return;
+        }
+        console.log(formatOutput(rows, format));
+      }
+    } catch (error) {
+      enhanceAnalyticsScopeError(error, globals.profile);
+      if (error instanceof LinkedInApiError) {
+        throw new Error(`Failed to get member analytics: ${error.message}`);
+      }
+      throw error;
+    }
+  });
+
+  return cmd;
+}

--- a/packages/cli/src/commands/stats/post.test.ts
+++ b/packages/cli/src/commands/stats/post.test.ts
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { PostAnalytics } from "@linkedctl/core";
+import { createProgram } from "../../program.js";
+
+vi.mock("@linkedctl/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@linkedctl/core")>();
+  return {
+    ...actual,
+    resolveConfig: vi.fn().mockResolvedValue({
+      config: {
+        oauth: { accessToken: "test-token" },
+        apiVersion: "202601",
+      },
+      warnings: [],
+    }),
+    getPostAnalytics: vi.fn(),
+  };
+});
+
+const coreMock = await import("@linkedctl/core");
+
+const SAMPLE_ANALYTICS: PostAnalytics = {
+  impressions: { status: "success", dataPoints: [{ count: 1234 }] },
+  membersReached: { status: "success", dataPoints: [{ count: 567 }] },
+  reactions: { status: "success", dataPoints: [{ count: 89 }] },
+  comments: { status: "success", dataPoints: [{ count: 12 }] },
+  reshares: { status: "success", dataPoints: [{ count: 5 }] },
+};
+
+describe("stats post", () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    stderrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(coreMock.getPostAnalytics).mockResolvedValue(SAMPLE_ANALYTICS);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("displays table with metric names and values for TTY", async () => {
+    const originalIsTTY = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, "isTTY", { value: true, writable: true });
+
+    try {
+      const program = createProgram();
+      await program.parseAsync(["node", "linkedctl", "stats", "post", "urn:li:share:123"]);
+
+      expect(coreMock.getPostAnalytics).toHaveBeenCalledWith(expect.anything(), { postUrn: "urn:li:share:123" });
+      expect(consoleSpy).toHaveBeenCalledOnce();
+
+      const output = consoleSpy.mock.calls[0]?.[0] as string;
+      expect(output).toContain("Impressions");
+      expect(output).toContain("1234");
+      expect(output).toContain("Members reached");
+      expect(output).toContain("567");
+      expect(output).toContain("Reactions");
+      expect(output).toContain("89");
+    } finally {
+      Object.defineProperty(process.stdout, "isTTY", { value: originalIsTTY, writable: true });
+    }
+  });
+
+  it("outputs JSON when piped (non-TTY)", async () => {
+    const originalIsTTY = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, "isTTY", { value: false, writable: true });
+
+    try {
+      const program = createProgram();
+      await program.parseAsync(["node", "linkedctl", "stats", "post", "urn:li:share:123"]);
+
+      const output = consoleSpy.mock.calls[0]?.[0] as string;
+      const parsed = JSON.parse(output) as PostAnalytics;
+      expect(parsed.impressions).toEqual({ status: "success", dataPoints: [{ count: 1234 }] });
+      expect(parsed.reactions).toEqual({ status: "success", dataPoints: [{ count: 89 }] });
+    } finally {
+      Object.defineProperty(process.stdout, "isTTY", { value: originalIsTTY, writable: true });
+    }
+  });
+
+  it("outputs JSON when --format json is specified", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "stats", "post", "urn:li:share:123", "--format", "json"]);
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(output) as PostAnalytics;
+    expect(parsed.impressions.status).toBe("success");
+  });
+
+  it("warns about unavailable metrics on stderr", async () => {
+    const analyticsWithUnavailable: PostAnalytics = {
+      ...SAMPLE_ANALYTICS,
+      membersReached: { status: "unavailable", reason: "API error" },
+    };
+    vi.mocked(coreMock.getPostAnalytics).mockResolvedValueOnce(analyticsWithUnavailable);
+
+    const originalIsTTY = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, "isTTY", { value: true, writable: true });
+
+    try {
+      const program = createProgram();
+      await program.parseAsync(["node", "linkedctl", "stats", "post", "urn:li:share:123"]);
+
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("Members reached: API error"));
+
+      const output = consoleSpy.mock.calls[0]?.[0] as string;
+      expect(output).not.toContain("Members reached");
+      expect(output).toContain("Impressions");
+    } finally {
+      Object.defineProperty(process.stdout, "isTTY", { value: originalIsTTY, writable: true });
+    }
+  });
+
+  it("warns about excluded metrics on stderr", async () => {
+    const analyticsWithExcluded: PostAnalytics = {
+      ...SAMPLE_ANALYTICS,
+      impressions: { status: "excluded", reason: "IMPRESSION with DAILY aggregation is not supported" },
+    };
+    vi.mocked(coreMock.getPostAnalytics).mockResolvedValueOnce(analyticsWithExcluded);
+
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "stats", "post", "urn:li:share:123", "--format", "json"]);
+
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Impressions: IMPRESSION with DAILY aggregation is not supported"),
+    );
+  });
+
+  it("resolves config with r_member_postAnalytics scope", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "linkedctl", "stats", "post", "urn:li:share:123", "--format", "json"]);
+
+    expect(coreMock.resolveConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requiredScopes: ["r_member_postAnalytics"],
+      }),
+    );
+  });
+
+  it("passes profile flag to resolveConfig", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "linkedctl",
+      "--profile",
+      "work",
+      "stats",
+      "post",
+      "urn:li:share:123",
+      "--format",
+      "json",
+    ]);
+
+    expect(coreMock.resolveConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profile: "work",
+      }),
+    );
+  });
+
+  it("wraps API errors with actionable message", async () => {
+    const { LinkedInApiError } = await import("@linkedctl/core");
+    vi.mocked(coreMock.getPostAnalytics).mockRejectedValueOnce(new LinkedInApiError("Not Found", 404));
+
+    const program = createProgram();
+    program.exitOverride();
+
+    await expect(program.parseAsync(["node", "linkedctl", "stats", "post", "urn:li:share:123"])).rejects.toThrow(
+      /Failed to get post analytics/,
+    );
+  });
+
+  it("enhances scope mismatch error with analytics profile suggestion", async () => {
+    const { ConfigError } = await import("@linkedctl/core");
+    vi.mocked(coreMock.resolveConfig).mockRejectedValueOnce(
+      new ConfigError("Missing required OAuth scopes: r_member_postAnalytics."),
+    );
+
+    const program = createProgram();
+    program.exitOverride();
+
+    await expect(program.parseAsync(["node", "linkedctl", "stats", "post", "urn:li:share:123"])).rejects.toThrow(
+      /dedicated analytics profile.*--profile analytics/,
+    );
+  });
+
+  it("suggests profile-based analytics name when profile is set", async () => {
+    const { ConfigError } = await import("@linkedctl/core");
+    vi.mocked(coreMock.resolveConfig).mockRejectedValueOnce(
+      new ConfigError("Missing required OAuth scopes: r_member_postAnalytics."),
+    );
+
+    const program = createProgram();
+    program.exitOverride();
+
+    await expect(
+      program.parseAsync(["node", "linkedctl", "--profile", "work", "stats", "post", "urn:li:share:123"]),
+    ).rejects.toThrow(/--profile work-analytics/);
+  });
+
+  it("outputs JSON when global --json is set", async () => {
+    const originalIsTTY = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, "isTTY", { value: true, writable: true });
+
+    try {
+      const program = createProgram();
+      await program.parseAsync(["node", "linkedctl", "--json", "stats", "post", "urn:li:share:123"]);
+
+      const output = consoleSpy.mock.calls[0]?.[0] as string;
+      const parsed = JSON.parse(output) as PostAnalytics;
+      expect(parsed.impressions.status).toBe("success");
+    } finally {
+      Object.defineProperty(process.stdout, "isTTY", { value: originalIsTTY, writable: true });
+    }
+  });
+});

--- a/packages/cli/src/commands/stats/post.ts
+++ b/packages/cli/src/commands/stats/post.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { Command, Option } from "commander";
+import { resolveConfig, LinkedInClient, getPostAnalytics, LinkedInApiError } from "@linkedctl/core";
+import type { OutputFormat } from "../../output/index.js";
+import { resolveFormat, formatOutput } from "../../output/index.js";
+import { warnUnavailableMetrics, buildTotalRows, enhanceAnalyticsScopeError } from "./helpers.js";
+
+export function postCommand(): Command {
+  const cmd = new Command("post");
+  cmd.description("Get analytics for a LinkedIn post");
+  cmd.argument("<urn>", "post URN (e.g. urn:li:share:123 or urn:li:ugcPost:123)");
+  cmd.addOption(new Option("--format <format>", "output format (json or table)").choices(["json", "table"]));
+
+  cmd.action(async (urn: string, opts: Record<string, unknown>, actionCmd: Command) => {
+    const globals = actionCmd.optsWithGlobals<{ profile?: string | undefined; json?: boolean | undefined }>();
+
+    try {
+      const { config } = await resolveConfig({
+        profile: globals.profile,
+        requiredScopes: ["r_member_postAnalytics"],
+      });
+      const accessToken = config.oauth?.accessToken ?? "";
+      const apiVersion = config.apiVersion ?? "";
+      const client = new LinkedInClient({ accessToken, apiVersion });
+
+      const analytics = await getPostAnalytics(client, { postUrn: urn });
+
+      warnUnavailableMetrics(analytics);
+
+      const format = resolveFormat(opts["format"] as OutputFormat | undefined, process.stdout, globals.json === true);
+
+      if (format === "json") {
+        console.log(formatOutput(analytics, format));
+      } else {
+        const rows = buildTotalRows(analytics);
+        if (rows.length === 0) {
+          console.log("No metrics available.");
+          return;
+        }
+        console.log(formatOutput(rows, format));
+      }
+    } catch (error) {
+      enhanceAnalyticsScopeError(error, globals.profile);
+      if (error instanceof LinkedInApiError) {
+        throw new Error(`Failed to get post analytics: ${error.message}`);
+      }
+      throw error;
+    }
+  });
+
+  return cmd;
+}

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -10,6 +10,7 @@ import { orgCommand } from "./commands/org/index.js";
 import { postCommand } from "./commands/post/index.js";
 import { profileCommand } from "./commands/profile/index.js";
 import { reactionCommand } from "./commands/reaction/index.js";
+import { statsCommand } from "./commands/stats/index.js";
 import { whoamiCommand } from "./commands/whoami.js";
 
 /**
@@ -43,6 +44,7 @@ export function createProgram(version?: string): Command {
   program.addCommand(postCommand());
   program.addCommand(profileCommand());
   program.addCommand(reactionCommand());
+  program.addCommand(statsCommand());
   program.addCommand(whoamiCommand());
 
   program.exitOverride();


### PR DESCRIPTION
## Summary

- Add `stats post <urn>` and `stats me` CLI commands for member post analytics (#150)
- `stats post` shows per-post metrics (impressions, members reached, reactions, comments, reshares)
- `stats me` shows aggregated member analytics with optional `--from`/`--to` daily breakdown
- TTY auto-detection (table for terminals, JSON for pipes), `--format json` override
- Partial metric failure tolerance with stderr warnings for unavailable/excluded metrics
- Scope-mismatch errors enhanced with product exclusivity explanation and `{identity}-analytics` profile naming suggestion

## Acceptance Criteria Coverage

| Criteria | Status |
|----------|--------|
| TTY → table with metric names/values | Covered |
| Pipe → JSON output | Covered |
| `--format json` forces JSON | Covered |
| Partial failure → show available + warn | Covered |
| Missing `r_member_postAnalytics` → exclusivity + auth setup + profile name | Covered |
| `stats me` with `--from`/`--to` → daily breakdown | Covered |
| `stats me` without dates → lifetime totals | Covered |
| `--from` without `--to` → error | Covered |
| Invalid date format → error with YYYY-MM-DD hint | Covered |

## Test plan

- [x] 11 tests for `stats post` (table/JSON output, TTY detection, partial failures, scope errors, API errors, global --json)
- [x] 13 tests for `stats me` (lifetime totals, daily breakdown, date validation, scope errors, API errors, inclusive-to-exclusive date conversion)
- [x] All 376 CLI tests pass
- [x] Build, typecheck, lint, format all pass

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)