### PR TITLE
(fix) add unified auth error handling to all MCP tools

### DIFF
--- a/packages/mcp/src/tools/auth.ts
+++ b/packages/mcp/src/tools/auth.ts
@@ -5,9 +5,6 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
 import {
-  resolveConfig,
-  LinkedInClient,
-  LinkedInAuthError,
   getUserInfo,
   loadConfigFile,
   validateConfig,
@@ -15,6 +12,8 @@ import {
   clearOAuthTokens,
   revokeAccessToken,
 } from "@linkedctl/core";
+
+import { withClient } from "./with-client.js";
 
 export function registerAuthTools(server: McpServer): void {
   server.registerTool(
@@ -27,40 +26,24 @@ export function registerAuthTools(server: McpServer): void {
       },
     },
     async (args) => {
-      const { config } = await resolveConfig({
-        profile: args.profile,
-        requiredScopes: ["openid", "profile", "email"],
-      });
-      const accessToken = config.oauth?.accessToken ?? "";
-      const apiVersion = config.apiVersion ?? "";
-      const client = new LinkedInClient({ accessToken, apiVersion });
+      return withClient(
+        {
+          profile: args.profile,
+          requiredScopes: ["openid", "profile", "email"],
+        },
+        async (client) => {
+          const userInfo = await getUserInfo(client);
 
-      let userInfo;
-      try {
-        userInfo = await getUserInfo(client);
-      } catch (error: unknown) {
-        if (error instanceof LinkedInAuthError) {
           return {
             content: [
               {
                 type: "text" as const,
-                text: `Authentication failed: ${error.message}\nRun "linkedctl auth login" to re-authenticate.`,
+                text: `Name: ${userInfo.name}\nEmail: ${userInfo.email}\nPicture: ${userInfo.picture}`,
               },
             ],
-            isError: true,
           };
-        }
-        throw error;
-      }
-
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: `Name: ${userInfo.name}\nEmail: ${userInfo.email}\nPicture: ${userInfo.picture}`,
-          },
-        ],
-      };
+        },
+      );
     },
   );
 

--- a/packages/mcp/src/tools/comments.test.ts
+++ b/packages/mcp/src/tools/comments.test.ts
@@ -62,6 +62,7 @@ vi.mock("@linkedctl/core", () => ({
 import {
   resolveConfig,
   LinkedInClient,
+  LinkedInAuthError,
   getCurrentPersonUrn,
   createComment,
   listComments,
@@ -243,6 +244,57 @@ describe("comment tools", () => {
           text: expect.stringContaining("A comment"),
         },
       ]);
+    });
+  });
+
+  describe("comment_create auth error", () => {
+    it("returns error with re-auth guidance for expired token", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "expired-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockRejectedValue(new LinkedInAuthError("HTTP 401: Unauthorized"));
+
+      const result = await getClient().callTool({
+        name: "comment_create",
+        arguments: { post_urn: "urn:li:share:123", text: "test" },
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: expect.stringContaining('Run "linkedctl auth login" to re-authenticate'),
+        },
+      ]);
+      expect(result.isError).toBe(true);
+    });
+
+    it("re-throws non-auth errors", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockRejectedValue(new Error("Server error"));
+
+      const result = await getClient().callTool({
+        name: "comment_create",
+        arguments: { post_urn: "urn:li:share:123", text: "test" },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual([{ type: "text", text: "Server error" }]);
     });
   });
 

--- a/packages/mcp/src/tools/comments.ts
+++ b/packages/mcp/src/tools/comments.ts
@@ -4,15 +4,9 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import {
-  resolveConfig,
-  LinkedInClient,
-  getCurrentPersonUrn,
-  createComment,
-  listComments,
-  getComment,
-  deleteComment,
-} from "@linkedctl/core";
+import { getCurrentPersonUrn, createComment, listComments, getComment, deleteComment } from "@linkedctl/core";
+
+import { withClient } from "./with-client.js";
 
 export function registerCommentTools(server: McpServer): void {
   server.registerTool(
@@ -28,26 +22,26 @@ export function registerCommentTools(server: McpServer): void {
       },
     },
     async (args) => {
-      const { config } = await resolveConfig({
-        profile: args.profile,
-        requiredScopes: ["openid", "profile", "email", "w_member_social"],
-      });
-      const accessToken = config.oauth?.accessToken ?? "";
-      const apiVersion = config.apiVersion ?? "";
-      const client = new LinkedInClient({ accessToken, apiVersion });
+      return withClient(
+        {
+          profile: args.profile,
+          requiredScopes: ["openid", "profile", "email", "w_member_social"],
+        },
+        async (client) => {
+          const actorUrn =
+            args.as_org !== undefined ? `urn:li:organization:${args.as_org}` : await getCurrentPersonUrn(client);
 
-      const actorUrn =
-        args.as_org !== undefined ? `urn:li:organization:${args.as_org}` : await getCurrentPersonUrn(client);
+          const commentUrn = await createComment(client, {
+            actor: actorUrn,
+            object: args.post_urn,
+            message: args.text,
+          });
 
-      const commentUrn = await createComment(client, {
-        actor: actorUrn,
-        object: args.post_urn,
-        message: args.text,
-      });
-
-      return {
-        content: [{ type: "text" as const, text: `Comment created: ${commentUrn}` }],
-      };
+          return {
+            content: [{ type: "text" as const, text: `Comment created: ${commentUrn}` }],
+          };
+        },
+      );
     },
   );
 
@@ -62,29 +56,29 @@ export function registerCommentTools(server: McpServer): void {
       },
     },
     async (args) => {
-      const { config } = await resolveConfig({
-        profile: args.profile,
-        requiredScopes: ["openid", "profile", "email", "w_member_social"],
-      });
-      const accessToken = config.oauth?.accessToken ?? "";
-      const apiVersion = config.apiVersion ?? "";
-      const client = new LinkedInClient({ accessToken, apiVersion });
+      return withClient(
+        {
+          profile: args.profile,
+          requiredScopes: ["openid", "profile", "email", "w_member_social"],
+        },
+        async (client) => {
+          const comments = await listComments(client, { object: args.post_urn });
 
-      const comments = await listComments(client, { object: args.post_urn });
+          if (comments.length === 0) {
+            return {
+              content: [{ type: "text" as const, text: "No comments found." }],
+            };
+          }
 
-      if (comments.length === 0) {
-        return {
-          content: [{ type: "text" as const, text: "No comments found." }],
-        };
-      }
+          const lines = comments.map(
+            (c) => `URN: ${c.urn}\nActor: ${c.actor}\nMessage: ${c.message}\nCreated: ${c.createdAt}`,
+          );
 
-      const lines = comments.map(
-        (c) => `URN: ${c.urn}\nActor: ${c.actor}\nMessage: ${c.message}\nCreated: ${c.createdAt}`,
+          return {
+            content: [{ type: "text" as const, text: lines.join("\n\n") }],
+          };
+        },
       );
-
-      return {
-        content: [{ type: "text" as const, text: lines.join("\n\n") }],
-      };
     },
   );
 
@@ -99,24 +93,24 @@ export function registerCommentTools(server: McpServer): void {
       },
     },
     async (args) => {
-      const { config } = await resolveConfig({
-        profile: args.profile,
-        requiredScopes: ["openid", "profile", "email", "w_member_social"],
-      });
-      const accessToken = config.oauth?.accessToken ?? "";
-      const apiVersion = config.apiVersion ?? "";
-      const client = new LinkedInClient({ accessToken, apiVersion });
+      return withClient(
+        {
+          profile: args.profile,
+          requiredScopes: ["openid", "profile", "email", "w_member_social"],
+        },
+        async (client) => {
+          const comment = await getComment(client, { commentUrn: args.comment_urn });
 
-      const comment = await getComment(client, { commentUrn: args.comment_urn });
-
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: `URN: ${comment.urn}\nActor: ${comment.actor}\nObject: ${comment.object}\nMessage: ${comment.message}\nCreated: ${comment.createdAt}`,
-          },
-        ],
-      };
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `URN: ${comment.urn}\nActor: ${comment.actor}\nObject: ${comment.object}\nMessage: ${comment.message}\nCreated: ${comment.createdAt}`,
+              },
+            ],
+          };
+        },
+      );
     },
   );
 
@@ -131,19 +125,19 @@ export function registerCommentTools(server: McpServer): void {
       },
     },
     async (args) => {
-      const { config } = await resolveConfig({
-        profile: args.profile,
-        requiredScopes: ["openid", "profile", "email", "w_member_social"],
-      });
-      const accessToken = config.oauth?.accessToken ?? "";
-      const apiVersion = config.apiVersion ?? "";
-      const client = new LinkedInClient({ accessToken, apiVersion });
+      return withClient(
+        {
+          profile: args.profile,
+          requiredScopes: ["openid", "profile", "email", "w_member_social"],
+        },
+        async (client) => {
+          await deleteComment(client, { commentUrn: args.comment_urn });
 
-      await deleteComment(client, { commentUrn: args.comment_urn });
-
-      return {
-        content: [{ type: "text" as const, text: "Comment deleted." }],
-      };
+          return {
+            content: [{ type: "text" as const, text: "Comment deleted." }],
+          };
+        },
+      );
     },
   );
 }

--- a/packages/mcp/src/tools/media.test.ts
+++ b/packages/mcp/src/tools/media.test.ts
@@ -60,7 +60,14 @@ vi.mock("@linkedctl/core", () => ({
 }));
 
 import { readFile, stat } from "node:fs/promises";
-import { resolveConfig, LinkedInClient, getCurrentPersonUrn, getOrganization, uploadDocument } from "@linkedctl/core";
+import {
+  resolveConfig,
+  LinkedInClient,
+  LinkedInAuthError,
+  getCurrentPersonUrn,
+  getOrganization,
+  uploadDocument,
+} from "@linkedctl/core";
 
 describe("media tools", () => {
   const { getClient } = setupMcpTestClient();
@@ -169,6 +176,67 @@ describe("media tools", () => {
         profile: "work",
         requiredScopes: ["openid", "profile", "email", "w_member_social"],
       });
+    });
+
+    it("returns error with re-auth guidance for expired token", async () => {
+      vi.mocked(stat).mockResolvedValue({ size: 1024 } as ReturnType<
+        typeof import("node:fs/promises").stat
+      > extends Promise<infer T>
+        ? T
+        : never);
+      vi.mocked(readFile).mockResolvedValue(Buffer.from("fake-pdf-content"));
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "expired-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockRejectedValue(new LinkedInAuthError("HTTP 401: Unauthorized"));
+
+      const result = await getClient().callTool({
+        name: "document_upload",
+        arguments: { file: "/path/to/deck.pdf" },
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: expect.stringContaining('Run "linkedctl auth login" to re-authenticate'),
+        },
+      ]);
+      expect(result.isError).toBe(true);
+    });
+
+    it("re-throws non-auth errors", async () => {
+      vi.mocked(stat).mockResolvedValue({ size: 1024 } as ReturnType<
+        typeof import("node:fs/promises").stat
+      > extends Promise<infer T>
+        ? T
+        : never);
+      vi.mocked(readFile).mockResolvedValue(Buffer.from("fake-pdf-content"));
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockRejectedValue(new Error("Server error"));
+
+      const result = await getClient().callTool({
+        name: "document_upload",
+        arguments: { file: "/path/to/deck.pdf" },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual([{ type: "text", text: "Server error" }]);
     });
 
     it("uploads as organization when as_org is specified", async () => {

--- a/packages/mcp/src/tools/media.ts
+++ b/packages/mcp/src/tools/media.ts
@@ -7,14 +7,14 @@ import { readFile, stat } from "node:fs/promises";
 import { extname } from "node:path";
 
 import {
-  resolveConfig,
-  LinkedInClient,
   getCurrentPersonUrn,
   getOrganization,
   uploadDocument,
   DOCUMENT_EXTENSIONS,
   DOCUMENT_MAX_SIZE_BYTES,
 } from "@linkedctl/core";
+
+import { withClient } from "./with-client.js";
 
 export function registerMediaTools(server: McpServer): void {
   server.registerTool(
@@ -51,28 +51,28 @@ export function registerMediaTools(server: McpServer): void {
         };
       }
 
-      const { config } = await resolveConfig({
-        profile: args.profile,
-        requiredScopes: ["openid", "profile", "email", "w_member_social"],
-      });
-      const accessToken = config.oauth?.accessToken ?? "";
-      const apiVersion = config.apiVersion ?? "";
-      const client = new LinkedInClient({ accessToken, apiVersion });
+      return withClient(
+        {
+          profile: args.profile,
+          requiredScopes: ["openid", "profile", "email", "w_member_social"],
+        },
+        async (client) => {
+          let ownerUrn: string;
+          if (args.as_org !== undefined) {
+            await getOrganization(client, args.as_org);
+            ownerUrn = `urn:li:organization:${args.as_org}`;
+          } else {
+            ownerUrn = await getCurrentPersonUrn(client);
+          }
+          const data = new Uint8Array(await readFile(args.file));
 
-      let ownerUrn: string;
-      if (args.as_org !== undefined) {
-        await getOrganization(client, args.as_org);
-        ownerUrn = `urn:li:organization:${args.as_org}`;
-      } else {
-        ownerUrn = await getCurrentPersonUrn(client);
-      }
-      const data = new Uint8Array(await readFile(args.file));
+          const documentUrn = await uploadDocument(client, { owner: ownerUrn, data });
 
-      const documentUrn = await uploadDocument(client, { owner: ownerUrn, data });
-
-      return {
-        content: [{ type: "text" as const, text: `Document uploaded: ${documentUrn}` }],
-      };
+          return {
+            content: [{ type: "text" as const, text: `Document uploaded: ${documentUrn}` }],
+          };
+        },
+      );
     },
   );
 }

--- a/packages/mcp/src/tools/orgs.test.ts
+++ b/packages/mcp/src/tools/orgs.test.ts
@@ -59,7 +59,14 @@ vi.mock("@linkedctl/core", () => ({
   revokeAccessToken: vi.fn(),
 }));
 
-import { resolveConfig, listOrganizations, getOrganization, getOrganizationFollowerCount } from "@linkedctl/core";
+import {
+  resolveConfig,
+  LinkedInClient,
+  LinkedInAuthError,
+  listOrganizations,
+  getOrganization,
+  getOrganizationFollowerCount,
+} from "@linkedctl/core";
 
 describe("org tools", () => {
   const { getClient } = setupMcpTestClient();
@@ -101,6 +108,51 @@ describe("org tools", () => {
       await getClient().callTool({ name: "org_list", arguments: { count: 5, start: 10 } });
 
       expect(listOrganizations).toHaveBeenCalledWith(expect.anything(), { count: 5, start: 10 });
+    });
+  });
+
+  describe("org_list auth error", () => {
+    it("returns error with re-auth guidance for expired token", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "expired-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      } as never);
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(listOrganizations).mockRejectedValue(new LinkedInAuthError("HTTP 401: Unauthorized"));
+
+      const result = await getClient().callTool({ name: "org_list", arguments: {} });
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: expect.stringContaining('Run "linkedctl auth login" to re-authenticate'),
+        },
+      ]);
+      expect(result.isError).toBe(true);
+    });
+
+    it("re-throws non-auth errors", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      } as never);
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(listOrganizations).mockRejectedValue(new Error("Server error"));
+
+      const result = await getClient().callTool({ name: "org_list", arguments: {} });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual([{ type: "text", text: "Server error" }]);
     });
   });
 

--- a/packages/mcp/src/tools/orgs.ts
+++ b/packages/mcp/src/tools/orgs.ts
@@ -4,13 +4,9 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import {
-  resolveConfig,
-  LinkedInClient,
-  listOrganizations,
-  getOrganization,
-  getOrganizationFollowerCount,
-} from "@linkedctl/core";
+import { listOrganizations, getOrganization, getOrganizationFollowerCount } from "@linkedctl/core";
+
+import { withClient } from "./with-client.js";
 
 export function registerOrgTools(server: McpServer): void {
   server.registerTool(
@@ -25,22 +21,22 @@ export function registerOrgTools(server: McpServer): void {
       },
     },
     async (args) => {
-      const { config } = await resolveConfig({
-        profile: args.profile,
-        requiredScopes: ["openid", "profile", "email", "w_member_social"],
-      });
-      const accessToken = config.oauth?.accessToken ?? "";
-      const apiVersion = config.apiVersion ?? "";
-      const client = new LinkedInClient({ accessToken, apiVersion });
+      return withClient(
+        {
+          profile: args.profile,
+          requiredScopes: ["openid", "profile", "email", "w_member_social"],
+        },
+        async (client) => {
+          const response = await listOrganizations(client, {
+            count: args.count,
+            start: args.start,
+          });
 
-      const response = await listOrganizations(client, {
-        count: args.count,
-        start: args.start,
-      });
-
-      return {
-        content: [{ type: "text" as const, text: JSON.stringify(response, null, 2) }],
-      };
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(response, null, 2) }],
+          };
+        },
+      );
     },
   );
 
@@ -55,19 +51,19 @@ export function registerOrgTools(server: McpServer): void {
       },
     },
     async (args) => {
-      const { config } = await resolveConfig({
-        profile: args.profile,
-        requiredScopes: ["openid", "profile", "email", "w_member_social"],
-      });
-      const accessToken = config.oauth?.accessToken ?? "";
-      const apiVersion = config.apiVersion ?? "";
-      const client = new LinkedInClient({ accessToken, apiVersion });
+      return withClient(
+        {
+          profile: args.profile,
+          requiredScopes: ["openid", "profile", "email", "w_member_social"],
+        },
+        async (client) => {
+          const org = await getOrganization(client, args.id);
 
-      const org = await getOrganization(client, args.id);
-
-      return {
-        content: [{ type: "text" as const, text: JSON.stringify(org, null, 2) }],
-      };
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(org, null, 2) }],
+          };
+        },
+      );
     },
   );
 
@@ -82,25 +78,25 @@ export function registerOrgTools(server: McpServer): void {
       },
     },
     async (args) => {
-      const { config } = await resolveConfig({
-        profile: args.profile,
-        requiredScopes: ["openid", "profile", "email", "w_member_social"],
-      });
-      const accessToken = config.oauth?.accessToken ?? "";
-      const apiVersion = config.apiVersion ?? "";
-      const client = new LinkedInClient({ accessToken, apiVersion });
+      return withClient(
+        {
+          profile: args.profile,
+          requiredScopes: ["openid", "profile", "email", "w_member_social"],
+        },
+        async (client) => {
+          const organizationUrn = `urn:li:organization:${args.id}`;
+          const followerCount = await getOrganizationFollowerCount(client, organizationUrn);
 
-      const organizationUrn = `urn:li:organization:${args.id}`;
-      const followerCount = await getOrganizationFollowerCount(client, organizationUrn);
-
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: JSON.stringify({ organization: organizationUrn, followerCount }, null, 2),
-          },
-        ],
-      };
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({ organization: organizationUrn, followerCount }, null, 2),
+              },
+            ],
+          };
+        },
+      );
     },
   );
 }

--- a/packages/mcp/src/tools/posts.test.ts
+++ b/packages/mcp/src/tools/posts.test.ts
@@ -63,6 +63,7 @@ import { readFile, stat } from "node:fs/promises";
 import {
   resolveConfig,
   LinkedInClient,
+  LinkedInAuthError,
   getCurrentPersonUrn,
   createPost,
   getPost,
@@ -970,6 +971,57 @@ describe("post tools", () => {
           requiredScopes: expect.not.arrayContaining(["w_organization_social"]),
         }),
       );
+    });
+  });
+
+  describe("post_create auth error", () => {
+    it("returns error with re-auth guidance for expired token", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "expired-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockRejectedValue(new LinkedInAuthError("HTTP 401: Unauthorized"));
+
+      const result = await getClient().callTool({
+        name: "post_create",
+        arguments: { text: "Hello world" },
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: expect.stringContaining('Run "linkedctl auth login" to re-authenticate'),
+        },
+      ]);
+      expect(result.isError).toBe(true);
+    });
+
+    it("re-throws non-auth errors", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      });
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getCurrentPersonUrn).mockRejectedValue(new Error("Server error"));
+
+      const result = await getClient().callTool({
+        name: "post_create",
+        arguments: { text: "Hello world" },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual([{ type: "text", text: "Server error" }]);
     });
   });
 

--- a/packages/mcp/src/tools/posts.ts
+++ b/packages/mcp/src/tools/posts.ts
@@ -7,8 +7,6 @@ import { readFile, stat } from "node:fs/promises";
 import { extname } from "node:path";
 
 import {
-  resolveConfig,
-  LinkedInClient,
   getCurrentPersonUrn,
   createPost,
   getPost,
@@ -24,6 +22,8 @@ import {
   DOCUMENT_MAX_SIZE_BYTES,
 } from "@linkedctl/core";
 import type { PostContent, PostLifecycleState } from "@linkedctl/core";
+
+import { withClient } from "./with-client.js";
 
 export function registerPostTools(server: McpServer): void {
   server.registerTool(
@@ -134,101 +134,32 @@ export function registerPostTools(server: McpServer): void {
         requiredScopes.push("w_organization_social");
       }
 
-      const { config } = await resolveConfig({
-        profile: args.profile,
-        requiredScopes,
-      });
-      // resolveConfig guarantees oauth.accessToken and apiVersion are defined
-      const accessToken = config.oauth?.accessToken ?? "";
-      const apiVersion = config.apiVersion ?? "";
-      const client = new LinkedInClient({ accessToken, apiVersion });
-
-      let authorUrn: string;
-      if (args.as_org !== undefined) {
-        const orgUrn = `urn:li:organization:${args.as_org}`;
-        const response = await listOrganizations(client, { count: 100 });
-        const isAdmin = response.elements.some((acl) => acl.organization === orgUrn);
-        if (!isAdmin) {
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: `You are not an administrator of organization ${args.as_org}`,
-              },
-            ],
-            isError: true,
-          };
+      return withClient({ profile: args.profile, requiredScopes }, async (client) => {
+        let authorUrn: string;
+        if (args.as_org !== undefined) {
+          const orgUrn = `urn:li:organization:${args.as_org}`;
+          const response = await listOrganizations(client, { count: 100 });
+          const isAdmin = response.elements.some((acl) => acl.organization === orgUrn);
+          if (!isAdmin) {
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: `You are not an administrator of organization ${args.as_org}`,
+                },
+              ],
+              isError: true,
+            };
+          }
+          authorUrn = orgUrn;
+        } else {
+          authorUrn = await getCurrentPersonUrn(client);
         }
-        authorUrn = orgUrn;
-      } else {
-        authorUrn = await getCurrentPersonUrn(client);
-      }
 
-      // Handle file-based uploads if no URN-based content was resolved
-      if (postContent === undefined) {
-        if (args.image_file !== undefined) {
-          const ext = extname(args.image_file).toLowerCase();
-          const contentType = SUPPORTED_IMAGE_TYPES.get(ext);
-          if (contentType === undefined) {
-            const supported = [...SUPPORTED_IMAGE_TYPES.keys()].join(", ");
-            return {
-              content: [
-                {
-                  type: "text" as const,
-                  text: `Unsupported image format "${ext}". Supported formats: ${supported}`,
-                },
-              ],
-              isError: true,
-            };
-          }
-          const data = new Uint8Array(await readFile(args.image_file));
-          const urn = await uploadImage(client, { owner: authorUrn, data, contentType });
-          postContent = { media: { id: urn } };
-        } else if (args.video_file !== undefined) {
-          const fileStat = await stat(args.video_file);
-          if (!fileStat.isFile()) {
-            return {
-              content: [{ type: "text" as const, text: `Not a file: ${args.video_file}` }],
-              isError: true,
-            };
-          }
-          const data = await readFile(args.video_file);
-          const urn = await uploadVideo(client, { owner: authorUrn, data });
-          postContent = { media: { id: urn } };
-        } else if (args.document_file !== undefined) {
-          const ext = extname(args.document_file).toLowerCase();
-          if (!DOCUMENT_EXTENSIONS.includes(ext as (typeof DOCUMENT_EXTENSIONS)[number])) {
-            return {
-              content: [
-                {
-                  type: "text" as const,
-                  text: `Unsupported file type "${ext}". Supported types: ${DOCUMENT_EXTENSIONS.join(", ")}`,
-                },
-              ],
-              isError: true,
-            };
-          }
-          const fileStat = await stat(args.document_file);
-          if (fileStat.size > DOCUMENT_MAX_SIZE_BYTES) {
-            const sizeMB = Math.round(fileStat.size / (1024 * 1024));
-            return {
-              content: [{ type: "text" as const, text: `File is ${sizeMB} MB, which exceeds the 100 MB limit.` }],
-              isError: true,
-            };
-          }
-          const data = new Uint8Array(await readFile(args.document_file));
-          const urn = await uploadDocument(client, { owner: authorUrn, data });
-          postContent = { media: { id: urn } };
-        } else if (args.image_files !== undefined) {
-          if (args.image_files.length < 2) {
-            return {
-              content: [{ type: "text" as const, text: "Multi-image file posts require at least 2 image file paths" }],
-              isError: true,
-            };
-          }
-          const urns: string[] = [];
-          for (const filePath of args.image_files) {
-            const ext = extname(filePath).toLowerCase();
+        // Handle file-based uploads if no URN-based content was resolved
+        if (postContent === undefined) {
+          if (args.image_file !== undefined) {
+            const ext = extname(args.image_file).toLowerCase();
             const contentType = SUPPORTED_IMAGE_TYPES.get(ext);
             if (contentType === undefined) {
               const supported = [...SUPPORTED_IMAGE_TYPES.keys()].join(", ");
@@ -236,34 +167,98 @@ export function registerPostTools(server: McpServer): void {
                 content: [
                   {
                     type: "text" as const,
-                    text: `Unsupported image format "${ext}" for file "${filePath}". Supported formats: ${supported}`,
+                    text: `Unsupported image format "${ext}". Supported formats: ${supported}`,
                   },
                 ],
                 isError: true,
               };
             }
-            const data = new Uint8Array(await readFile(filePath));
+            const data = new Uint8Array(await readFile(args.image_file));
             const urn = await uploadImage(client, { owner: authorUrn, data, contentType });
-            urns.push(urn);
+            postContent = { media: { id: urn } };
+          } else if (args.video_file !== undefined) {
+            const fileStat = await stat(args.video_file);
+            if (!fileStat.isFile()) {
+              return {
+                content: [{ type: "text" as const, text: `Not a file: ${args.video_file}` }],
+                isError: true,
+              };
+            }
+            const data = await readFile(args.video_file);
+            const urn = await uploadVideo(client, { owner: authorUrn, data });
+            postContent = { media: { id: urn } };
+          } else if (args.document_file !== undefined) {
+            const ext = extname(args.document_file).toLowerCase();
+            if (!DOCUMENT_EXTENSIONS.includes(ext as (typeof DOCUMENT_EXTENSIONS)[number])) {
+              return {
+                content: [
+                  {
+                    type: "text" as const,
+                    text: `Unsupported file type "${ext}". Supported types: ${DOCUMENT_EXTENSIONS.join(", ")}`,
+                  },
+                ],
+                isError: true,
+              };
+            }
+            const fileStat = await stat(args.document_file);
+            if (fileStat.size > DOCUMENT_MAX_SIZE_BYTES) {
+              const sizeMB = Math.round(fileStat.size / (1024 * 1024));
+              return {
+                content: [{ type: "text" as const, text: `File is ${sizeMB} MB, which exceeds the 100 MB limit.` }],
+                isError: true,
+              };
+            }
+            const data = new Uint8Array(await readFile(args.document_file));
+            const urn = await uploadDocument(client, { owner: authorUrn, data });
+            postContent = { media: { id: urn } };
+          } else if (args.image_files !== undefined) {
+            if (args.image_files.length < 2) {
+              return {
+                content: [
+                  { type: "text" as const, text: "Multi-image file posts require at least 2 image file paths" },
+                ],
+                isError: true,
+              };
+            }
+            const urns: string[] = [];
+            for (const filePath of args.image_files) {
+              const ext = extname(filePath).toLowerCase();
+              const contentType = SUPPORTED_IMAGE_TYPES.get(ext);
+              if (contentType === undefined) {
+                const supported = [...SUPPORTED_IMAGE_TYPES.keys()].join(", ");
+                return {
+                  content: [
+                    {
+                      type: "text" as const,
+                      text: `Unsupported image format "${ext}" for file "${filePath}". Supported formats: ${supported}`,
+                    },
+                  ],
+                  isError: true,
+                };
+              }
+              const data = new Uint8Array(await readFile(filePath));
+              const urn = await uploadImage(client, { owner: authorUrn, data, contentType });
+              urns.push(urn);
+            }
+            postContent = { multiImage: { images: urns.map((id) => ({ id })) } };
           }
-          postContent = { multiImage: { images: urns.map((id) => ({ id })) } };
         }
-      }
 
-      const visibility = args.visibility ?? "PUBLIC";
-      const lifecycleState: PostLifecycleState = args.draft === true ? "DRAFT" : "PUBLISHED";
+        const visibility = args.visibility ?? "PUBLIC";
+        const lifecycleState: PostLifecycleState = args.draft === true ? "DRAFT" : "PUBLISHED";
 
-      const postUrn = await createPost(client, {
-        author: authorUrn,
-        text: args.text,
-        visibility,
-        content: postContent,
-        lifecycleState,
+        const postUrn = await createPost(client, {
+          author: authorUrn,
+          text: args.text,
+          visibility,
+          content: postContent,
+          lifecycleState,
+        });
+
+        return {
+          content: [{ type: "text" as const, text: `Post created: ${postUrn}` }],
+        };
       });
-
-      return {
-        content: [{ type: "text" as const, text: `Post created: ${postUrn}` }],
-      };
     },
   );
 
@@ -278,19 +273,19 @@ export function registerPostTools(server: McpServer): void {
       },
     },
     async (args) => {
-      const { config } = await resolveConfig({
-        profile: args.profile,
-        requiredScopes: ["openid", "profile", "email", "w_member_social"],
-      });
-      const accessToken = config.oauth?.accessToken ?? "";
-      const apiVersion = config.apiVersion ?? "";
-      const client = new LinkedInClient({ accessToken, apiVersion });
+      return withClient(
+        {
+          profile: args.profile,
+          requiredScopes: ["openid", "profile", "email", "w_member_social"],
+        },
+        async (client) => {
+          const post = await getPost(client, args.urn);
 
-      const post = await getPost(client, args.urn);
-
-      return {
-        content: [{ type: "text" as const, text: JSON.stringify(post, null, 2) }],
-      };
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(post, null, 2) }],
+          };
+        },
+      );
     },
   );
 
@@ -317,44 +312,38 @@ export function registerPostTools(server: McpServer): void {
         requiredScopes.push("r_organization_social");
       }
 
-      const { config } = await resolveConfig({
-        profile: args.profile,
-        requiredScopes,
-      });
-      const accessToken = config.oauth?.accessToken ?? "";
-      const apiVersion = config.apiVersion ?? "";
-      const client = new LinkedInClient({ accessToken, apiVersion });
-
-      let authorUrn: string;
-      if (args.as_org !== undefined) {
-        const orgUrn = `urn:li:organization:${args.as_org}`;
-        const orgResponse = await listOrganizations(client, { count: 100 });
-        const isAdmin = orgResponse.elements.some((acl) => acl.organization === orgUrn);
-        if (!isAdmin) {
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: `You are not an administrator of organization ${args.as_org}`,
-              },
-            ],
-            isError: true,
-          };
+      return withClient({ profile: args.profile, requiredScopes }, async (client) => {
+        let authorUrn: string;
+        if (args.as_org !== undefined) {
+          const orgUrn = `urn:li:organization:${args.as_org}`;
+          const orgResponse = await listOrganizations(client, { count: 100 });
+          const isAdmin = orgResponse.elements.some((acl) => acl.organization === orgUrn);
+          if (!isAdmin) {
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: `You are not an administrator of organization ${args.as_org}`,
+                },
+              ],
+              isError: true,
+            };
+          }
+          authorUrn = orgUrn;
+        } else {
+          authorUrn = await getCurrentPersonUrn(client);
         }
-        authorUrn = orgUrn;
-      } else {
-        authorUrn = await getCurrentPersonUrn(client);
-      }
 
-      const response = await listPosts(client, {
-        author: authorUrn,
-        count: args.count,
-        start: args.start,
+        const response = await listPosts(client, {
+          author: authorUrn,
+          count: args.count,
+          start: args.start,
+        });
+
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(response, null, 2) }],
+        };
       });
-
-      return {
-        content: [{ type: "text" as const, text: JSON.stringify(response, null, 2) }],
-      };
     },
   );
 
@@ -370,19 +359,19 @@ export function registerPostTools(server: McpServer): void {
       },
     },
     async (args) => {
-      const { config } = await resolveConfig({
-        profile: args.profile,
-        requiredScopes: ["openid", "profile", "email", "w_member_social"],
-      });
-      const accessToken = config.oauth?.accessToken ?? "";
-      const apiVersion = config.apiVersion ?? "";
-      const client = new LinkedInClient({ accessToken, apiVersion });
+      return withClient(
+        {
+          profile: args.profile,
+          requiredScopes: ["openid", "profile", "email", "w_member_social"],
+        },
+        async (client) => {
+          await updatePost(client, args.urn, { text: args.text });
 
-      await updatePost(client, args.urn, { text: args.text });
-
-      return {
-        content: [{ type: "text" as const, text: `Post updated: ${args.urn}` }],
-      };
+          return {
+            content: [{ type: "text" as const, text: `Post updated: ${args.urn}` }],
+          };
+        },
+      );
     },
   );
 
@@ -397,19 +386,19 @@ export function registerPostTools(server: McpServer): void {
       },
     },
     async (args) => {
-      const { config } = await resolveConfig({
-        profile: args.profile,
-        requiredScopes: ["openid", "profile", "email", "w_member_social"],
-      });
-      const accessToken = config.oauth?.accessToken ?? "";
-      const apiVersion = config.apiVersion ?? "";
-      const client = new LinkedInClient({ accessToken, apiVersion });
+      return withClient(
+        {
+          profile: args.profile,
+          requiredScopes: ["openid", "profile", "email", "w_member_social"],
+        },
+        async (client) => {
+          await deletePost(client, args.urn);
 
-      await deletePost(client, args.urn);
-
-      return {
-        content: [{ type: "text" as const, text: `Post deleted: ${args.urn}` }],
-      };
+          return {
+            content: [{ type: "text" as const, text: `Post deleted: ${args.urn}` }],
+          };
+        },
+      );
     },
   );
 }

--- a/packages/mcp/src/tools/reactions.ts
+++ b/packages/mcp/src/tools/reactions.ts
@@ -4,17 +4,10 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import {
-  resolveConfig,
-  LinkedInClient,
-  LinkedInAuthError,
-  getCurrentPersonUrn,
-  createReaction,
-  listReactions,
-  deleteReaction,
-  REACTION_TYPES,
-} from "@linkedctl/core";
+import { getCurrentPersonUrn, createReaction, listReactions, deleteReaction, REACTION_TYPES } from "@linkedctl/core";
 import type { ReactionType } from "@linkedctl/core";
+
+import { withClient } from "./with-client.js";
 
 export function registerReactionTools(server: McpServer): void {
   server.registerTool(
@@ -34,39 +27,24 @@ export function registerReactionTools(server: McpServer): void {
       },
     },
     async (args) => {
-      const { config } = await resolveConfig({
-        profile: args.profile,
-        requiredScopes: ["openid", "profile", "email", "w_member_social"],
-      });
-      const accessToken = config.oauth?.accessToken ?? "";
-      const apiVersion = config.apiVersion ?? "";
-      const client = new LinkedInClient({ accessToken, apiVersion });
+      return withClient(
+        {
+          profile: args.profile,
+          requiredScopes: ["openid", "profile", "email", "w_member_social"],
+        },
+        async (client) => {
+          const actor = args.as_org !== undefined ? `urn:li:organization:${args.as_org}` : undefined;
+          const reactionUrn = await createReaction(client, {
+            entity: args.entity_urn,
+            reactionType: (args.reaction_type as ReactionType | undefined) ?? "LIKE",
+            actor,
+          });
 
-      try {
-        const actor = args.as_org !== undefined ? `urn:li:organization:${args.as_org}` : undefined;
-        const reactionUrn = await createReaction(client, {
-          entity: args.entity_urn,
-          reactionType: (args.reaction_type as ReactionType | undefined) ?? "LIKE",
-          actor,
-        });
-
-        return {
-          content: [{ type: "text" as const, text: `Reaction created: ${reactionUrn}` }],
-        };
-      } catch (error: unknown) {
-        if (error instanceof LinkedInAuthError) {
           return {
-            content: [
-              {
-                type: "text" as const,
-                text: `Authentication failed: ${error.message}\nRun "linkedctl auth login" to re-authenticate.`,
-              },
-            ],
-            isError: true,
+            content: [{ type: "text" as const, text: `Reaction created: ${reactionUrn}` }],
           };
-        }
-        throw error;
-      }
+        },
+      );
     },
   );
 
@@ -81,41 +59,28 @@ export function registerReactionTools(server: McpServer): void {
       },
     },
     async (args) => {
-      const { config } = await resolveConfig({
-        profile: args.profile,
-        requiredScopes: ["openid", "profile", "email", "w_member_social"],
-      });
-      const accessToken = config.oauth?.accessToken ?? "";
-      const apiVersion = config.apiVersion ?? "";
-      const client = new LinkedInClient({ accessToken, apiVersion });
+      return withClient(
+        {
+          profile: args.profile,
+          requiredScopes: ["openid", "profile", "email", "w_member_social"],
+        },
+        async (client) => {
+          const reactions = await listReactions(client, { entity: args.entity_urn });
 
-      try {
-        const reactions = await listReactions(client, { entity: args.entity_urn });
+          if (reactions.length === 0) {
+            return {
+              content: [{ type: "text" as const, text: "No reactions found" }],
+            };
+          }
 
-        if (reactions.length === 0) {
+          const lines = reactions.map(
+            (r) => `${r.reactionType} by ${r.actor} at ${new Date(r.createdAt).toISOString()}`,
+          );
           return {
-            content: [{ type: "text" as const, text: "No reactions found" }],
+            content: [{ type: "text" as const, text: lines.join("\n") }],
           };
-        }
-
-        const lines = reactions.map((r) => `${r.reactionType} by ${r.actor} at ${new Date(r.createdAt).toISOString()}`);
-        return {
-          content: [{ type: "text" as const, text: lines.join("\n") }],
-        };
-      } catch (error: unknown) {
-        if (error instanceof LinkedInAuthError) {
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: `Authentication failed: ${error.message}\nRun "linkedctl auth login" to re-authenticate.`,
-              },
-            ],
-            isError: true,
-          };
-        }
-        throw error;
-      }
+        },
+      );
     },
   );
 
@@ -131,37 +96,22 @@ export function registerReactionTools(server: McpServer): void {
       },
     },
     async (args) => {
-      const { config } = await resolveConfig({
-        profile: args.profile,
-        requiredScopes: ["openid", "profile", "email", "w_member_social"],
-      });
-      const accessToken = config.oauth?.accessToken ?? "";
-      const apiVersion = config.apiVersion ?? "";
-      const client = new LinkedInClient({ accessToken, apiVersion });
+      return withClient(
+        {
+          profile: args.profile,
+          requiredScopes: ["openid", "profile", "email", "w_member_social"],
+        },
+        async (client) => {
+          const actorUrn =
+            args.as_org !== undefined ? `urn:li:organization:${args.as_org}` : await getCurrentPersonUrn(client);
 
-      const actorUrn =
-        args.as_org !== undefined ? `urn:li:organization:${args.as_org}` : await getCurrentPersonUrn(client);
+          await deleteReaction(client, { entity: args.entity_urn, actor: actorUrn });
 
-      try {
-        await deleteReaction(client, { entity: args.entity_urn, actor: actorUrn });
-
-        return {
-          content: [{ type: "text" as const, text: "Reaction deleted" }],
-        };
-      } catch (error: unknown) {
-        if (error instanceof LinkedInAuthError) {
           return {
-            content: [
-              {
-                type: "text" as const,
-                text: `Authentication failed: ${error.message}\nRun "linkedctl auth login" to re-authenticate.`,
-              },
-            ],
-            isError: true,
+            content: [{ type: "text" as const, text: "Reaction deleted" }],
           };
-        }
-        throw error;
-      }
+        },
+      );
     },
   );
 }

--- a/packages/mcp/src/tools/stats.test.ts
+++ b/packages/mcp/src/tools/stats.test.ts
@@ -59,7 +59,14 @@ vi.mock("@linkedctl/core", () => ({
   revokeAccessToken: vi.fn(),
 }));
 
-import { resolveConfig, getPostAnalytics, getMemberAnalytics, getOrgStats } from "@linkedctl/core";
+import {
+  resolveConfig,
+  LinkedInClient,
+  LinkedInAuthError,
+  getPostAnalytics,
+  getMemberAnalytics,
+  getOrgStats,
+} from "@linkedctl/core";
 
 describe("stats tools", () => {
   const { getClient } = setupMcpTestClient();
@@ -212,6 +219,57 @@ describe("stats tools", () => {
         aggregation: undefined,
         dateRange: { end: { year: 2025, month: 12, day: 31 } },
       });
+    });
+  });
+
+  describe("stats_post auth error", () => {
+    it("returns error with re-auth guidance for expired token", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "expired-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      } as never);
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getPostAnalytics).mockRejectedValue(new LinkedInAuthError("HTTP 401: Unauthorized"));
+
+      const result = await getClient().callTool({
+        name: "stats_post",
+        arguments: { post_urn: "urn:li:share:123" },
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: expect.stringContaining('Run "linkedctl auth login" to re-authenticate'),
+        },
+      ]);
+      expect(result.isError).toBe(true);
+    });
+
+    it("re-throws non-auth errors", async () => {
+      vi.mocked(resolveConfig).mockResolvedValue({
+        config: {
+          oauth: { accessToken: "test-token" },
+          apiVersion: "202401",
+        },
+        warnings: [],
+      } as never);
+      vi.mocked(LinkedInClient).mockImplementation(function () {
+        return Object.create(null);
+      } as unknown as typeof LinkedInClient);
+      vi.mocked(getPostAnalytics).mockRejectedValue(new Error("Server error"));
+
+      const result = await getClient().callTool({
+        name: "stats_post",
+        arguments: { post_urn: "urn:li:share:123" },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual([{ type: "text", text: "Server error" }]);
     });
   });
 

--- a/packages/mcp/src/tools/stats.ts
+++ b/packages/mcp/src/tools/stats.ts
@@ -4,8 +4,10 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import { resolveConfig, LinkedInClient, getPostAnalytics, getMemberAnalytics, getOrgStats } from "@linkedctl/core";
+import { getPostAnalytics, getMemberAnalytics, getOrgStats } from "@linkedctl/core";
 import type { AnalyticsDateRange } from "@linkedctl/core";
+
+import { withClient } from "./with-client.js";
 
 /**
  * Parse optional from/to date strings (YYYY-MM-DD) into an AnalyticsDateRange.
@@ -49,24 +51,24 @@ export function registerStatsTools(server: McpServer): void {
       },
     },
     async (args) => {
-      const { config } = await resolveConfig({
-        profile: args.profile,
-        requiredScopes: ["openid", "profile", "email", "r_member_postAnalytics"],
-      });
-      const accessToken = config.oauth?.accessToken ?? "";
-      const apiVersion = config.apiVersion ?? "";
-      const client = new LinkedInClient({ accessToken, apiVersion });
+      return withClient(
+        {
+          profile: args.profile,
+          requiredScopes: ["openid", "profile", "email", "r_member_postAnalytics"],
+        },
+        async (client) => {
+          const dateRange = parseDateRange(args.from, args.to);
+          const analytics = await getPostAnalytics(client, {
+            postUrn: args.post_urn,
+            aggregation: args.aggregation,
+            dateRange,
+          });
 
-      const dateRange = parseDateRange(args.from, args.to);
-      const analytics = await getPostAnalytics(client, {
-        postUrn: args.post_urn,
-        aggregation: args.aggregation,
-        dateRange,
-      });
-
-      return {
-        content: [{ type: "text" as const, text: JSON.stringify(analytics, null, 2) }],
-      };
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(analytics, null, 2) }],
+          };
+        },
+      );
     },
   );
 
@@ -93,23 +95,23 @@ export function registerStatsTools(server: McpServer): void {
       },
     },
     async (args) => {
-      const { config } = await resolveConfig({
-        profile: args.profile,
-        requiredScopes: ["openid", "profile", "email", "r_member_postAnalytics"],
-      });
-      const accessToken = config.oauth?.accessToken ?? "";
-      const apiVersion = config.apiVersion ?? "";
-      const client = new LinkedInClient({ accessToken, apiVersion });
+      return withClient(
+        {
+          profile: args.profile,
+          requiredScopes: ["openid", "profile", "email", "r_member_postAnalytics"],
+        },
+        async (client) => {
+          const dateRange = parseDateRange(args.from, args.to);
+          const analytics = await getMemberAnalytics(client, {
+            aggregation: args.aggregation,
+            dateRange,
+          });
 
-      const dateRange = parseDateRange(args.from, args.to);
-      const analytics = await getMemberAnalytics(client, {
-        aggregation: args.aggregation,
-        dateRange,
-      });
-
-      return {
-        content: [{ type: "text" as const, text: JSON.stringify(analytics, null, 2) }],
-      };
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(analytics, null, 2) }],
+          };
+        },
+      );
     },
   );
 
@@ -155,40 +157,40 @@ export function registerStatsTools(server: McpServer): void {
         };
       }
 
-      const { config } = await resolveConfig({
-        profile: args.profile,
-        requiredScopes: ["rw_organization_admin"],
-      });
-      const accessToken = config.oauth?.accessToken ?? "";
-      const apiVersion = config.apiVersion ?? "";
-      const client = new LinkedInClient({ accessToken, apiVersion });
+      return withClient(
+        {
+          profile: args.profile,
+          requiredScopes: ["rw_organization_admin"],
+        },
+        async (client) => {
+          const organizationUrn = `urn:li:organization:${args.id}`;
 
-      const organizationUrn = `urn:li:organization:${args.id}`;
+          const timeGranularity = args.time_granularity;
+          const timeRange =
+            args.start !== undefined && args.end !== undefined
+              ? { start: new Date(args.start).getTime(), end: new Date(args.end).getTime() }
+              : undefined;
 
-      const timeGranularity = args.time_granularity;
-      const timeRange =
-        args.start !== undefined && args.end !== undefined
-          ? { start: new Date(args.start).getTime(), end: new Date(args.end).getTime() }
-          : undefined;
+          const shares =
+            args.shares !== undefined
+              ? args.shares
+                  .split(",")
+                  .map((s) => s.trim())
+                  .filter((s) => s.length > 0)
+              : undefined;
 
-      const shares =
-        args.shares !== undefined
-          ? args.shares
-              .split(",")
-              .map((s) => s.trim())
-              .filter((s) => s.length > 0)
-          : undefined;
+          const response = await getOrgStats(client, {
+            organizationUrn,
+            timeGranularity,
+            timeRange,
+            shares,
+          });
 
-      const response = await getOrgStats(client, {
-        organizationUrn,
-        timeGranularity,
-        timeRange,
-        shares,
-      });
-
-      return {
-        content: [{ type: "text" as const, text: JSON.stringify(response, null, 2) }],
-      };
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify(response, null, 2) }],
+          };
+        },
+      );
     },
   );
 }

--- a/packages/mcp/src/tools/with-client.test.ts
+++ b/packages/mcp/src/tools/with-client.test.ts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@linkedctl/core", () => ({
+  resolveConfig: vi.fn(),
+  LinkedInClient: vi.fn(),
+  LinkedInAuthError: class LinkedInAuthError extends Error {
+    public readonly status = 401;
+    constructor(message: string) {
+      super(message);
+      this.name = "LinkedInAuthError";
+    }
+  },
+}));
+
+import { resolveConfig, LinkedInClient, LinkedInAuthError } from "@linkedctl/core";
+import { withClient } from "./with-client.js";
+
+describe("withClient", () => {
+  it("resolves config and passes client to callback", async () => {
+    vi.mocked(resolveConfig).mockResolvedValue({
+      config: {
+        oauth: { accessToken: "test-token" },
+        apiVersion: "202401",
+      },
+      warnings: [],
+    });
+    vi.mocked(LinkedInClient).mockImplementation(function () {
+      return Object.create(null);
+    } as unknown as typeof LinkedInClient);
+
+    const result = await withClient({ profile: "work", requiredScopes: ["openid", "profile"] }, async () => ({
+      content: [{ type: "text" as const, text: "ok" }],
+    }));
+
+    expect(resolveConfig).toHaveBeenCalledWith({
+      profile: "work",
+      requiredScopes: ["openid", "profile"],
+    });
+    expect(LinkedInClient).toHaveBeenCalledWith({
+      accessToken: "test-token",
+      apiVersion: "202401",
+    });
+    expect(result).toEqual({
+      content: [{ type: "text", text: "ok" }],
+    });
+  });
+
+  it("catches LinkedInAuthError and returns error with re-auth guidance", async () => {
+    vi.mocked(resolveConfig).mockResolvedValue({
+      config: {
+        oauth: { accessToken: "expired-token" },
+        apiVersion: "202401",
+      },
+      warnings: [],
+    });
+    vi.mocked(LinkedInClient).mockImplementation(function () {
+      return Object.create(null);
+    } as unknown as typeof LinkedInClient);
+
+    const result = await withClient({ requiredScopes: ["openid"] }, async () => {
+      throw new LinkedInAuthError("HTTP 401: Unauthorized");
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: expect.stringContaining('Run "linkedctl auth login" to re-authenticate'),
+      },
+    ]);
+    expect(result.content[0]?.text).toContain("Authentication failed: HTTP 401: Unauthorized");
+  });
+
+  it("re-throws non-auth errors", async () => {
+    vi.mocked(resolveConfig).mockResolvedValue({
+      config: {
+        oauth: { accessToken: "test-token" },
+        apiVersion: "202401",
+      },
+      warnings: [],
+    });
+    vi.mocked(LinkedInClient).mockImplementation(function () {
+      return Object.create(null);
+    } as unknown as typeof LinkedInClient);
+
+    await expect(
+      withClient({ requiredScopes: ["openid"] }, async () => {
+        throw new Error("Network failure");
+      }),
+    ).rejects.toThrow("Network failure");
+  });
+
+  it("handles undefined profile with exactOptionalPropertyTypes", async () => {
+    vi.mocked(resolveConfig).mockResolvedValue({
+      config: {
+        oauth: { accessToken: "test-token" },
+        apiVersion: "202401",
+      },
+      warnings: [],
+    });
+    vi.mocked(LinkedInClient).mockImplementation(function () {
+      return Object.create(null);
+    } as unknown as typeof LinkedInClient);
+
+    const result = await withClient({ profile: undefined, requiredScopes: ["openid"] }, async () => ({
+      content: [{ type: "text" as const, text: "ok" }],
+    }));
+
+    expect(resolveConfig).toHaveBeenCalledWith({
+      profile: undefined,
+      requiredScopes: ["openid"],
+    });
+    expect(result.content).toEqual([{ type: "text", text: "ok" }]);
+  });
+});

--- a/packages/mcp/src/tools/with-client.ts
+++ b/packages/mcp/src/tools/with-client.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { resolveConfig, LinkedInClient, LinkedInAuthError } from "@linkedctl/core";
+
+export async function withClient(
+  options: { profile?: string | undefined; requiredScopes: string[] },
+  fn: (client: LinkedInClient) => Promise<{ content: { type: "text"; text: string }[]; isError?: boolean }>,
+): Promise<{ content: { type: "text"; text: string }[]; isError?: boolean }> {
+  const { config } = await resolveConfig({
+    profile: options.profile,
+    requiredScopes: options.requiredScopes,
+  });
+  const accessToken = config.oauth?.accessToken ?? "";
+  const apiVersion = config.apiVersion ?? "";
+  const client = new LinkedInClient({ accessToken, apiVersion });
+
+  try {
+    return await fn(client);
+  } catch (error: unknown) {
+    if (error instanceof LinkedInAuthError) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Authentication failed: ${error.message}\nRun "linkedctl auth login" to re-authenticate.`,
+          },
+        ],
+        isError: true,
+      };
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary

- Extract `withClient()` helper (`packages/mcp/src/tools/with-client.ts`) that resolves config, creates the LinkedIn API client, and catches `LinkedInAuthError` with actionable re-auth guidance
- Refactor all 7 tool modules (auth, posts, comments, reactions, orgs, stats, media) to use `withClient()`, eliminating ~20x duplicated client construction boilerplate
- All 22 MCP tools now consistently return `{ isError: true }` with "Run `linkedctl auth login` to re-authenticate" when auth fails, instead of throwing unhandled exceptions
- Add auth error tests (`LinkedInAuthError` + non-auth error re-throw) to all 6 tool test files that were missing them, plus dedicated `with-client.test.ts`

Closes #164

## Test plan

- [x] `pnpm test` — all unit tests pass (including new auth error tests in posts, comments, orgs, stats, media, with-client)
- [x] `pnpm typecheck` — passes with `exactOptionalPropertyTypes`
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)